### PR TITLE
Add a key comparator and load data at the height

### DIFF
--- a/ledger/Cargo.lock
+++ b/ledger/Cargo.lock
@@ -23,7 +23,6 @@ dependencies = [
  "prost",
  "rand 0.7.3",
  "rand_core 0.5.1",
- "regex",
  "rocksdb",
  "serde",
  "serde_bytes",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -53,7 +53,6 @@ prost = "0.7.0"
 rand = {version = "0.7", default-features = false}
 rand_core = {version = "0.5", default-features = false}
 rocksdb = "0.15"
-regex = "1.4.5"
 serde = "1.0.123"
 serde_bytes = "0.11.5"
 serde_json = "1.0.62"


### PR DESCRIPTION
#6 DB keys schema

- Add a key comparator to sort keys by the height
  - In lexicographical order, the height aren't ordered. For example, "11" is before "2"
- Load the previous state from RocksDB

NOTE: For the testing, WAL is enabled to sync data to the disk now. We will disable WAL after we implement a shutdown with flush.