### PR TITLE
undo nightly rustfmt formatting on generated proto files

### DIFF
--- a/apps/src/lib/proto/generated/services.rs
+++ b/apps/src/lib/proto/generated/services.rs
@@ -32,7 +32,7 @@ pub struct RpcResponse {
     #[prost(string, tag = "1")]
     pub result: ::prost::alloc::string::String,
 }
-/// Generated client implementations.
+#[doc = r" Generated client implementations."]
 pub mod rpc_service_client {
     #![allow(unused_variables, dead_code, missing_docs)]
     use tonic::codegen::*;
@@ -40,7 +40,7 @@ pub mod rpc_service_client {
         inner: tonic::client::Grpc<T>,
     }
     impl RpcServiceClient<tonic::transport::Channel> {
-        /// Attempt to create a new client by connecting to a given endpoint.
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
             D: std::convert::TryInto<tonic::transport::Endpoint>,
@@ -61,7 +61,6 @@ pub mod rpc_service_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
-
         pub fn with_interceptor(
             inner: T,
             interceptor: impl Into<tonic::Interceptor>,
@@ -70,7 +69,6 @@ pub mod rpc_service_client {
                 tonic::client::Grpc::with_interceptor(inner, interceptor);
             Self { inner }
         }
-
         pub async fn send_message(
             &mut self,
             request: impl tonic::IntoRequest<super::RpcMessage>,
@@ -102,12 +100,11 @@ pub mod rpc_service_client {
         }
     }
 }
-/// Generated server implementations.
+#[doc = r" Generated server implementations."]
 pub mod rpc_service_server {
     #![allow(unused_variables, dead_code, missing_docs)]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for
-    /// use with RpcServiceServer.
+    #[doc = "Generated trait containing gRPC methods that should be implemented for use with RpcServiceServer."]
     #[async_trait]
     pub trait RpcService: Send + Sync + 'static {
         async fn send_message(
@@ -126,7 +123,6 @@ pub mod rpc_service_server {
             let inner = _Inner(inner, None);
             Self { inner }
         }
-
         pub fn with_interceptor(
             inner: T,
             interceptor: impl Into<tonic::Interceptor>,
@@ -142,17 +138,15 @@ pub mod rpc_service_server {
         B: HttpBody + Send + Sync + 'static,
         B::Error: Into<StdError> + Send + 'static,
     {
+        type Response = http::Response<tonic::body::BoxBody>;
         type Error = Never;
         type Future = BoxFuture<Self::Response, Self::Error>;
-        type Response = http::Response<tonic::body::BoxBody>;
-
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
         ) -> Poll<Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
-
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             let inner = self.inner.clone();
             match req.uri().path() {
@@ -163,12 +157,11 @@ pub mod rpc_service_server {
                         tonic::server::UnaryService<super::RpcMessage>
                         for SendMessageSvc<T>
                     {
+                        type Response = super::RpcResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
                         >;
-                        type Response = super::RpcResponse;
-
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RpcMessage>,


### PR DESCRIPTION
a quick follow-up on #199, I forgot to check in the stable rustfmt version of the generated files