### PR TITLE
set stable toolchain version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,6 @@ dependencies = [
  "rayon",
  "regex",
  "rocksdb",
- "rustc_version",
  "serde 1.0.125",
  "serde_bytes",
  "serde_json",

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -91,5 +91,4 @@ tempdir = "0.3.7"
 wasmer-vm = "1.0.2"
 
 [build-dependencies]
-rustc_version = "0.3.3"
 tonic-build = "0.4.0"

--- a/apps/build.rs
+++ b/apps/build.rs
@@ -1,26 +1,12 @@
-use std::process::{exit, Command};
+use std::process::Command;
 use std::{env, str};
-
-use rustc_version::{version, Version};
 
 /// Path to the .proto source files, relative to `apps` directory
 const PROTO_SRC: &str = "../proto";
 /// The version should match the one we use in the `Makefile`
 const RUSTFMT_TOOLCHAIN: &str = "nightly-2021-03-09";
-/// The minimum required rustc version
-const RUSTC_MIN_VERSION: &str = "1.51.0";
 
 fn main() {
-    // Check the rustc version
-    // TODO Replace with https://github.com/rust-lang/rust/issues/65262 once stabilized.
-    if version().unwrap() < Version::parse(RUSTC_MIN_VERSION).unwrap() {
-        eprintln!(
-            "This crate requires rustc version >= {}.",
-            RUSTC_MIN_VERSION
-        );
-        exit(1);
-    }
-
     // Tell Cargo that if the given file changes, to rerun this build script.
     println!("cargo:rerun-if-changed={}", PROTO_SRC);
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,4 @@
 [toolchain]
 channel = "stable"
+date = "2021-05-18"
+components = ["rustc", "cargo", "rust-std", "rust-docs", "rls", "rust-src", "rust-analysis"]


### PR DESCRIPTION
Because libp2p requires rustc version > 1.51, the build currently fails with older versions. Unfortunately, the build.rs didn't work for this use case, because the dependencies are compiled before build.rs runs. This sets the toolchain version in `rust-toolchain` to a specific stable release instead