### PR TITLE
store predecessor epochs

### DIFF
--- a/apps/src/lib/node/ledger/storage/mod.rs
+++ b/apps/src/lib/node/ledger/storage/mod.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use anoma::ledger::storage::types::MerkleTree;
 use anoma::ledger::storage::{types, BlockStorage, Storage, StorageHasher};
 use anoma::types::address::EstablishedAddressGen;
-use anoma::types::storage::{BlockHash, BlockHeight, Epoch, Key};
+use anoma::types::storage::{BlockHash, BlockHeight, Epoch, Epochs, Key};
 use anoma::types::time::DateTimeUtc;
 use blake2b_rs::{Blake2b, Blake2bBuilder};
 use sparse_merkle_tree::blake2b::Blake2bHasher;
@@ -29,6 +29,7 @@ pub fn open(db_path: impl AsRef<Path>, chain_id: String) -> PersistentStorage {
         hash: BlockHash::default(),
         height: BlockHeight::default(),
         epoch: Epoch::default(),
+        pred_epochs: Epochs::default(),
         subspaces: HashMap::default(),
     };
     PersistentStorage {

--- a/docs/src/explore/design/ledger/epochs.md
+++ b/docs/src/explore/design/ledger/epochs.md
@@ -7,3 +7,9 @@ We store the current epoch in global storage and the epoch of each block in the 
 The first epoch (ID 0) starts on the genesis block. The next epoch minimum start time is set to the genesis time configured for the chain + minimum duration and the next epoch minimum height is set to the height of the genesis block (typically 1) + minimum number of blocks.
 
 On each block `BeginBlock` Tendermint call, we check if the current epoch is finished, in which case we move on to the next epoch. An epoch is finished when both the minimum number of blocks and minimum duration of an epoch have been created from the first block of a current epoch. When a new epoch starts, the next epoch minimum height is set to the block's height + minimum number of blocks and minimum start time time is set to block's time from the block header + minimum duration.
+
+## Predecessor blocks epochs
+
+We store the epoch ranges of predecessor blocks. This is used for example for to look-up the epoch from an evidence of validators that acted maliciously (which includes block height and block time) for PoS system. For the PoS system, in block at height `h`, we only need to know values from Tendermint `max(h - consensus_params.evidence.max_age_num_blocks, 0)`, which is set to `100000` by default.
+
+The predecessor epochs are stored in the block storage.  We update this structure on every new epoch and trim any epochs that ended more than `max_age_num_blocks` ago.

--- a/shared/src/ledger/storage/mod.rs
+++ b/shared/src/ledger/storage/mod.rs
@@ -20,7 +20,7 @@ use crate::ledger::gas::MIN_STORAGE_GAS;
 use crate::ledger::parameters::{self, EpochDuration};
 use crate::types::address::{Address, EstablishedAddressGen};
 use crate::types::storage::{
-    BlockHash, BlockHeight, DbKeySeg, Epoch, Key, BLOCK_HASH_LENGTH,
+    BlockHash, BlockHeight, DbKeySeg, Epoch, Epochs, Key, BLOCK_HASH_LENGTH,
     CHAIN_ID_LENGTH,
 };
 use crate::types::time::DateTimeUtc;
@@ -66,6 +66,8 @@ pub struct BlockStorage<H: StorageHasher> {
     pub height: BlockHeight,
     /// Epoch of the block
     pub epoch: Epoch,
+    /// Predecessor block epochs
+    pub pred_epochs: Epochs,
     /// Accounts' subspaces storage for arbitrary key-values
     pub subspaces: HashMap<Key, Vec<u8>>,
 }
@@ -99,6 +101,8 @@ pub struct BlockState {
     pub height: BlockHeight,
     /// Epoch of the block
     pub epoch: Epoch,
+    /// Predecessor block epochs
+    pub pred_epochs: Epochs,
     /// Minimum block height at which the next epoch may start
     pub next_epoch_min_start_height: BlockHeight,
     /// Minimum block time at which the next epoch may start
@@ -160,6 +164,7 @@ where
             hash,
             height,
             epoch,
+            pred_epochs,
             next_epoch_min_start_height,
             next_epoch_min_start_time,
             subspaces,
@@ -170,6 +175,7 @@ where
             self.block.hash = hash;
             self.block.height = height;
             self.block.epoch = epoch;
+            self.block.pred_epochs = pred_epochs;
             self.block.subspaces = subspaces;
             self.last_height = height;
             self.current_epoch = epoch;
@@ -204,6 +210,7 @@ where
             hash: self.block.hash.clone(),
             height: self.block.height,
             epoch: self.block.epoch,
+            pred_epochs: self.block.pred_epochs.clone(),
             next_epoch_min_start_height: self.next_epoch_min_start_height,
             next_epoch_min_start_time: self.next_epoch_min_start_time,
             subspaces: self.block.subspaces.clone(),
@@ -535,6 +542,7 @@ pub mod testing {
                 hash: BlockHash::default(),
                 height: BlockHeight::default(),
                 epoch: Epoch::default(),
+                pred_epochs: Epochs::default(),
                 subspaces,
             };
             Self {

--- a/shared/src/ledger/storage/mod.rs
+++ b/shared/src/ledger/storage/mod.rs
@@ -432,6 +432,12 @@ where
             } = parameters.epoch_duration;
             self.next_epoch_min_start_height = height + min_num_of_blocks;
             self.next_epoch_min_start_time = time + min_duration;
+            // TODO put this into PoS parameters and pass it to tendermint
+            // `consensus_params` on `InitChain` and `EndBlock`
+            let evidence_max_age_num_blocks: u64 = 100000;
+            self.block
+                .pred_epochs
+                .new_epoch(height, evidence_max_age_num_blocks);
             tracing::info!("Began a new epoch {}", self.block.epoch);
         }
         self.update_epoch_in_merkle_tree()
@@ -654,9 +660,11 @@ mod tests {
                     block_height + epoch_duration.min_num_of_blocks);
                 assert_eq!(storage.next_epoch_min_start_time,
                     block_time + epoch_duration.min_duration);
+                assert_eq!(storage.block.pred_epochs.get_epoch(block_height), Some(epoch_before.next()));
             } else {
                 assert_eq!(storage.block.epoch, epoch_before);
                 assert_eq!(storage.current_epoch, epoch_before);
+                assert_eq!(storage.block.pred_epochs.get_epoch(block_height), Some(epoch_before));
             }
 
             // Update the epoch duration parameters


### PR DESCRIPTION
For the PoS slashing, we need to be able to look-up epoch by a block height for byzantine validators evidence given by Tendermint ABCI (we cannot query the RPC at an older height, as this happens within a block application - ABCI `BeginBlock`). This PR adds the historical values to the storage to be used in the PoS integration.