### PR TITLE
1/4 PoS: initial version of the PoS crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ dependencies = [
  "loupe",
  "parity-wasm",
  "pretty_assertions",
- "proptest",
+ "proptest 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.8.0",
  "prost-types 0.8.0",
  "pwasm-utils",
@@ -143,7 +143,7 @@ dependencies = [
  "jsonpath_lib",
  "libc",
  "libp2p",
- "proptest",
+ "proptest 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.8.0",
  "prost-types 0.8.0",
  "rand 0.7.3",
@@ -174,6 +174,15 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "websocket",
+]
+
+[[package]]
+name = "anoma_proof_of_stake"
+version = "0.1.0"
+dependencies = [
+ "borsh",
+ "proptest 1.0.0 (git+https://github.com/heliaxdev/proptest?branch=tomas/state-machine)",
+ "thiserror",
 ]
 
 [[package]]
@@ -3965,6 +3974,25 @@ name = "proptest"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static 1.4.0",
+ "num-traits 0.2.14",
+ "quick-error 2.0.1",
+ "rand 0.8.4",
+ "rand_chacha 0.3.1",
+ "rand_xorshift 0.3.0",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+]
+
+[[package]]
+name = "proptest"
+version = "1.0.0"
+source = "git+https://github.com/heliaxdev/proptest?branch=tomas/state-machine#121b0544cc0b4f01132965adc3db2f538498c4cb"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "vm_env",
   "vm_macro",
   "tests",
+  "proof_of_stake",
 ]
 
 # wasm packages have to be built separately
@@ -18,3 +19,8 @@ exclude = [
 [patch.crates-io]
 tracing = {git = "https://github.com/tokio-rs/tracing/", branch = "v0.1.x"}
 tracing-core = {git = "https://github.com/tokio-rs/tracing/", branch = "v0.1.x"}
+
+[profile.release]
+lto = true
+opt-level = 3
+panic = "unwind"

--- a/proof_of_stake/Cargo.toml
+++ b/proof_of_stake/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+authors = ["Heliax AG <hello@heliax.dev>"]
+description = "Anoma Proof of Stake system"
+edition = "2018"
+license = "GPL-3.0"
+name = "anoma_proof_of_stake"
+readme = "../README.md"
+resolver = "2"
+version = "0.1.0"
+
+[dependencies]
+borsh = "0.9.1"
+thiserror = "1.0.26"
+
+[dev-dependencies]
+proptest = {git = "https://github.com/heliaxdev/proptest", branch = "tomas/state-machine"}
+# proptest = {path = "../../proptest/proptest"}

--- a/proof_of_stake/src/btree_set.rs
+++ b/proof_of_stake/src/btree_set.rs
@@ -35,8 +35,8 @@ impl<T: Ord + Clone> BTreeSetShims<T> for BTreeSet<T> {
     }
 
     fn pop_first_shim(&mut self) -> Option<T> {
-        let iter = self.iter();
-        let first = iter.last().cloned();
+        let mut iter = self.iter();
+        let first = iter.next().cloned();
         if let Some(first) = first {
             return self.take(&first);
         }

--- a/proof_of_stake/src/btree_set.rs
+++ b/proof_of_stake/src/btree_set.rs
@@ -1,0 +1,54 @@
+//!  This module adds shims for BTreeSet methods that not yet stable.
+
+use std::collections::BTreeSet;
+
+/// This trait adds shims for BTreeSet methods that not yet stable. They have
+/// the same behavior as their nightly counterparts, but additionally require
+/// `Clone` bound on the element type (for `pop_first` and `pop_last`).
+pub trait BTreeSetShims<T> {
+    /// Returns a reference to the first value in the set, if any. This value is
+    /// always the minimum of all values in the set.
+    fn first_shim(&self) -> Option<&T>;
+
+    /// Returns a reference to the last value in the set, if any. This value is
+    /// always the maximum of all values in the set.
+    fn last_shim(&self) -> Option<&T>;
+
+    /// Removes the first value from the set and returns it, if any. The first
+    /// value is always the minimum value in the set.
+    fn pop_first_shim(&mut self) -> Option<T>;
+
+    /// Removes the last value from the set and returns it, if any. The last
+    /// value is always the maximum value in the set.
+    fn pop_last_shim(&mut self) -> Option<T>;
+}
+
+impl<T: Ord + Clone> BTreeSetShims<T> for BTreeSet<T> {
+    fn first_shim(&self) -> Option<&T> {
+        let mut iter = self.iter();
+        iter.next()
+    }
+
+    fn last_shim(&self) -> Option<&T> {
+        let iter = self.iter();
+        iter.last()
+    }
+
+    fn pop_first_shim(&mut self) -> Option<T> {
+        let iter = self.iter();
+        let first = iter.last().cloned();
+        if let Some(first) = first {
+            return self.take(&first);
+        }
+        None
+    }
+
+    fn pop_last_shim(&mut self) -> Option<T> {
+        let iter = self.iter();
+        let last = iter.last().cloned();
+        if let Some(last) = last {
+            return self.take(&last);
+        }
+        None
+    }
+}

--- a/proof_of_stake/src/epoched.rs
+++ b/proof_of_stake/src/epoched.rs
@@ -1,0 +1,1270 @@
+//! [`Epoched`] and [`EpochedDelta`] are structures for data that is set for
+//! future epochs at a given [`EpochOffset`].
+
+use core::marker::PhantomData;
+use core::{cmp, fmt, ops};
+
+use borsh::{BorshDeserialize, BorshSerialize};
+
+use crate::types::Epoch;
+use crate::PosParams;
+
+/// Data that may have values set for future epochs, up to an epoch at offset as
+/// set via the `Offset` type parameter.
+#[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
+pub struct Epoched<Data, Offset>
+where
+    Data: Clone + BorshDeserialize + BorshSerialize,
+    Offset: EpochOffset,
+{
+    /// The epoch in which this data was last updated
+    last_update: Epoch,
+    data: Vec<Option<Data>>,
+    offset: PhantomData<Offset>,
+}
+
+/// Data that may have delta values (a difference from the predecessor epoch)
+/// set for future epochs, up to an epoch at offset as set via the `Offset` type
+/// parameter.
+#[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
+pub struct EpochedDelta<Data, Offset>
+where
+    Data: Clone + ops::Add<Output = Data> + BorshDeserialize + BorshSerialize,
+    Offset: EpochOffset,
+{
+    /// The epoch in which this data was last updated
+    last_update: Epoch,
+    data: Vec<Option<Data>>,
+    offset: PhantomData<Offset>,
+}
+
+/// Which offset should be used to set data. The value is read from
+/// [`PosParams`].
+pub trait EpochOffset:
+    fmt::Debug + Clone + BorshDeserialize + BorshSerialize
+{
+    /// Find the value of a given offset from PoS parameters.
+    fn value(params: &PosParams) -> u64;
+    /// Convert to [`DynEpochOffset`]
+    fn dyn_offset() -> DynEpochOffset;
+}
+
+/// Offset at pipeline length.
+#[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
+pub struct OffsetPipelineLen;
+impl EpochOffset for OffsetPipelineLen {
+    fn value(params: &PosParams) -> u64 {
+        params.pipeline_len
+    }
+
+    fn dyn_offset() -> DynEpochOffset {
+        DynEpochOffset::PipelineLen
+    }
+}
+
+/// Offset at unbonding length.
+#[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
+pub struct OffsetUnboundingLen;
+impl EpochOffset for OffsetUnboundingLen {
+    fn value(params: &PosParams) -> u64 {
+        params.unbonding_len
+    }
+
+    fn dyn_offset() -> DynEpochOffset {
+        DynEpochOffset::UnbondingLen
+    }
+}
+
+/// Offset length dynamic choice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DynEpochOffset {
+    /// Offset at pipeline length.
+    PipelineLen,
+    /// Offset at unbonding length.
+    UnbondingLen,
+}
+impl DynEpochOffset {
+    /// Find the value of a given offset from PoS parameters.
+    pub fn value(&self, params: &PosParams) -> u64 {
+        match self {
+            DynEpochOffset::PipelineLen => params.pipeline_len,
+            DynEpochOffset::UnbondingLen => params.unbonding_len,
+        }
+    }
+}
+
+impl<Data, Offset> Epoched<Data, Offset>
+where
+    Data: fmt::Debug + Clone + BorshDeserialize + BorshSerialize,
+    Offset: EpochOffset,
+{
+    /// Initialize new epoched data. Sets the head to the given value.
+    /// This should only be used at genesis.
+    pub fn init_at_genesis(
+        value: Data,
+        current_epoch: impl Into<Epoch>,
+    ) -> Self {
+        Self {
+            last_update: current_epoch.into(),
+            data: vec![Some(value)],
+            offset: PhantomData,
+        }
+    }
+
+    /// Initialize new data at the data's epoch offset.
+    pub fn init(
+        value: Data,
+        current_epoch: impl Into<Epoch>,
+        params: &PosParams,
+    ) -> Self {
+        let offset = Offset::value(params);
+        let mut data = vec![];
+        for _ in 0..offset {
+            data.push(None);
+        }
+        data.push(Some(value));
+        Self {
+            last_update: current_epoch.into(),
+            data,
+            offset: PhantomData,
+        }
+    }
+
+    /// Find the value for the given epoch or a nearest epoch before it.
+    pub fn get(&self, epoch: impl Into<Epoch>) -> Option<&Data> {
+        let epoch = epoch.into();
+        let index: usize = (epoch.sub_or_default(self.last_update)).into();
+        self.get_at_index(index)
+    }
+
+    /// Find the value at the offset from the given epoch or a nearest epoch
+    /// before it.
+    pub fn get_at_offset(
+        &self,
+        epoch: impl Into<Epoch>,
+        offset: DynEpochOffset,
+        params: &PosParams,
+    ) -> Option<&Data> {
+        let offset = offset.value(params);
+        let epoch_at_offset = epoch.into() + offset;
+        let index: usize =
+            (epoch_at_offset.sub_or_default(self.last_update)).into();
+        self.get_at_index(index)
+    }
+
+    /// Find the delta value at or before the given index.
+    fn get_at_index(&self, offset: usize) -> Option<&Data> {
+        let mut index = cmp::min(offset, self.data.len());
+        loop {
+            if let Some(result @ Some(_)) = self.data.get(index) {
+                return result.as_ref();
+            }
+            if index == 0 {
+                return None;
+            } else {
+                index -= 1;
+            }
+        }
+    }
+
+    /// Find the value for the given epoch, if any. Returns `None` when the
+    /// given epoch is lower than `self.last_update`.
+    pub(crate) fn get_at_epoch(
+        &self,
+        epoch: impl Into<Epoch>,
+    ) -> Option<&Data> {
+        let epoch = epoch.into();
+        let index: usize = (epoch.sub_or_default(self.last_update)).into();
+        match self.data.get(index) {
+            Some(result) => result.as_ref(),
+            None => None,
+        }
+    }
+
+    /// Update the data associated with epochs, if needed. The head element is
+    /// set to the latest value and any value before the current epoch is
+    /// dropped.
+    fn update_data(
+        &mut self,
+        current_epoch: impl Into<Epoch>,
+        params: &PosParams,
+    ) {
+        let epoch = current_epoch.into();
+        debug_assert!(
+            epoch >= self.last_update,
+            "The current epoch must be greater than or equal to the last \
+             update"
+        );
+        let offset = Offset::value(params) as usize;
+        let last_update = self.last_update;
+        let shift: usize =
+            cmp::min((epoch.sub_or_default(last_update)).into(), offset);
+
+        // Resize the data if needed
+        if self.data.len() < offset + 1 {
+            self.data.resize_with(offset + 1, Default::default);
+        }
+
+        if shift != 0 {
+            let mid_point = cmp::min(shift, self.data.len());
+            let mut latest_value: Option<Data> = None;
+            // Find the latest value in elements before the mid-point and clear
+            // them
+            for i in 0..mid_point {
+                if let Some(Some(data)) = self.data.get(i) {
+                    latest_value = Some(data.clone());
+                }
+                self.data[i] = None;
+            }
+            // Rotate left on the mid-point
+            self.data.rotate_left(mid_point);
+            // Update the head with the latest value, if it's not already set
+            let current = self.data.get_mut(0).unwrap();
+            if current.is_none() {
+                *current = latest_value;
+            }
+        }
+
+        self.last_update = epoch;
+    }
+
+    /// Set the value at the data's epoch offset.
+    pub fn set(
+        &mut self,
+        value: Data,
+        current_epoch: impl Into<Epoch>,
+        params: &PosParams,
+    ) {
+        self.update_data(current_epoch, params);
+
+        let offset = Offset::value(params) as usize;
+        self.data[offset] = Some(value);
+    }
+
+    /// Update the values starting from the given epoch offset (which must not
+    /// be greater than the `Offset` type parameter of self) with the given
+    /// function.
+    pub fn update_from_offset(
+        &mut self,
+        update_value: impl Fn(&mut Data, Epoch),
+        current_epoch: impl Into<Epoch>,
+        offset: DynEpochOffset,
+        params: &PosParams,
+    ) {
+        let offset = offset.value(params) as usize;
+        debug_assert!(offset <= Offset::value(params) as usize);
+        let epoch = current_epoch.into();
+        self.update_data(epoch, params);
+
+        if let Some(data) = self.data.get_mut(offset).unwrap() {
+            // If there's a value at `offset`, update it
+            update_value(data, self.last_update + offset)
+        } else {
+            // Try to find if there's any value before `offset`
+            let mut latest_value: Option<Data> = None;
+            for i in (0..offset).rev() {
+                if let Some(Some(data)) = self.data.get(i) {
+                    latest_value = Some(data.clone());
+                    break;
+                }
+            }
+            // If there's a value before `offset`, update it and use it as the
+            // current value
+            if let Some(mut latest_value) = latest_value {
+                let val_at_offset = self.data.get_mut(offset).unwrap();
+                update_value(&mut latest_value, self.last_update + offset);
+                *val_at_offset = Some(latest_value);
+            }
+        }
+        // Update any data after `offset`
+        for i in offset + 1..self.data.len() {
+            if let Some(Some(data)) = self.data.get_mut(i) {
+                update_value(data, self.last_update + i)
+            }
+        }
+    }
+
+    /// Get the epoch of the last update
+    pub fn last_update(&self) -> Epoch {
+        self.last_update
+    }
+}
+
+impl<Data, Offset> EpochedDelta<Data, Offset>
+where
+    Data: fmt::Debug
+        + Clone
+        + ops::Add<Output = Data>
+        + BorshDeserialize
+        + BorshSerialize,
+    Offset: EpochOffset,
+{
+    /// Initialize new epoched delta data. Sets the head to the given value.
+    /// This should only be used at genesis.
+    pub fn init_at_genesis(
+        value: Data,
+        current_epoch: impl Into<Epoch>,
+    ) -> Self {
+        Self::init_at_index(value, current_epoch, 0)
+    }
+
+    /// Initialize new data at the data's epoch offset.
+    pub fn init(
+        value: Data,
+        current_epoch: impl Into<Epoch>,
+        params: &PosParams,
+    ) -> Self {
+        let index = Offset::value(params) as usize;
+        Self::init_at_index(value, current_epoch, index)
+    }
+
+    /// Initialize new data at the given epoch offset (which must not be greater
+    /// than the `Offset` type parameter of self).
+    pub fn init_at_offset(
+        value: Data,
+        current_epoch: impl Into<Epoch>,
+        offset: DynEpochOffset,
+        params: &PosParams,
+    ) -> Self {
+        let index = offset.value(params) as usize;
+        Self::init_at_index(value, current_epoch, index)
+    }
+
+    /// Initialize new data at the given index.
+    fn init_at_index(
+        value: Data,
+        current_epoch: impl Into<Epoch>,
+        offset: usize,
+    ) -> Self {
+        let mut data = vec![];
+        for _ in 0..offset {
+            data.push(None);
+        }
+        data.push(Some(value));
+        Self {
+            last_update: current_epoch.into(),
+            data,
+            offset: PhantomData,
+        }
+    }
+
+    /// Find the current value for the given epoch as the sum of delta values at
+    /// and before the current epoch.
+    pub fn get(&self, epoch: impl Into<Epoch>) -> Option<Data> {
+        let epoch = epoch.into();
+        let index: usize = (epoch.sub_or_default(self.last_update)).into();
+        self.get_at_index(index)
+    }
+
+    /// Find the value at the offset from the given epoch as the sum of delta
+    /// values at and before the epoch offset.
+    pub fn get_at_offset(
+        &self,
+        epoch: impl Into<Epoch>,
+        offset: DynEpochOffset,
+        params: &PosParams,
+    ) -> Option<Data> {
+        let offset = offset.value(params);
+        let epoch_at_offset = epoch.into() + offset;
+        let index: usize =
+            (epoch_at_offset.sub_or_default(self.last_update)).into();
+        self.get_at_index(index)
+    }
+
+    /// Iterate the delta values set in the data.
+    pub fn iter(&self) -> impl Iterator<Item = &Data> {
+        self.data.iter().filter_map(|value| value.as_ref())
+    }
+
+    /// Iterate the delta values set in the data together with their epoch.
+    pub fn iter_with_epochs(&self) -> impl Iterator<Item = (&Data, Epoch)> {
+        let last_update = self.last_update;
+        self.data
+            .iter()
+            .enumerate()
+            .filter_map(move |(index, value)| {
+                value.as_ref().map(|value| (value, last_update + index))
+            })
+    }
+
+    /// Find the value at the given index as the sum of delta values at and
+    /// before the index.
+    fn get_at_index(&self, offset: usize) -> Option<Data> {
+        let index = cmp::min(offset, self.data.len());
+        let mut sum: Option<Data> = None;
+        for i in 0..index + 1 {
+            if let Some(next) = self.data.get(i) {
+                // Add current to the sum, if any
+                match (&sum, next) {
+                    (Some(current_sum), Some(next)) => {
+                        sum = Some(current_sum.clone() + next.clone())
+                    }
+                    (None, Some(next)) => sum = Some(next.clone()),
+                    _ => {}
+                };
+            }
+        }
+        sum
+    }
+
+    /// Find the delta value for the given epoch, if any. Returns `None` when
+    /// the given epoch is lower than `self.last_update`.
+    pub(crate) fn get_delta_at_epoch(
+        &self,
+        epoch: impl Into<Epoch>,
+    ) -> Option<&Data> {
+        let epoch = epoch.into();
+        match epoch.checked_sub(self.last_update) {
+            Some(index) => {
+                let index: usize = index.into();
+                match self.data.get(index) {
+                    Some(result) => result.as_ref(),
+                    None => None,
+                }
+            }
+            None => None,
+        }
+    }
+
+    /// Update the data associated with epochs, if needed. Any value before the
+    /// current epoch is added to the head element before being dropped.
+    fn update_data(
+        &mut self,
+        current_epoch: impl Into<Epoch>,
+        params: &PosParams,
+    ) {
+        let epoch = current_epoch.into();
+        debug_assert!(
+            epoch >= self.last_update,
+            "The current epoch must be greater than or equal to the last \
+             update"
+        );
+        let offset = Offset::value(params) as usize;
+        let last_update = self.last_update;
+        let shift: usize =
+            cmp::min((epoch.sub_or_default(last_update)).into(), offset);
+
+        // Resize the data if needed
+        if self.data.len() < offset + 1 {
+            self.data.resize_with(offset + 1, Default::default);
+        }
+
+        if shift != 0 {
+            let mid_point = cmp::min(shift, self.data.len());
+            let mut sum: Option<Data> = None;
+            // Sum and clear all the elements before the mid-point
+            for i in 0..mid_point {
+                if let Some(next) = self.data.get(i) {
+                    // Add current to the sum, if any
+                    match (&sum, next) {
+                        (Some(current_sum), Some(next)) => {
+                            sum = Some(current_sum.clone() + next.clone())
+                        }
+                        (Some(current_sum), None) => {
+                            sum = Some(current_sum.clone())
+                        }
+                        (None, Some(next)) => sum = Some(next.clone()),
+                        _ => {}
+                    };
+                    // Clear the field
+                    self.data[i] = None;
+                }
+            }
+            // Rotate left on the mid-point
+            self.data.rotate_left(mid_point);
+            // Add the sum to the head
+            let mut current = self.data.get_mut(0).unwrap();
+            match (&sum, &mut current) {
+                (Some(sum), Some(current)) => {
+                    *current = current.clone() + sum.clone()
+                }
+                (Some(_), None) => *current = sum,
+                _ => {}
+            }
+        }
+
+        self.last_update = epoch;
+    }
+
+    /// Add or set the delta value at the data's epoch offset. If there's an
+    /// existing value, it will be added to the new value.
+    pub fn add(
+        &mut self,
+        value: Data,
+        current_epoch: impl Into<Epoch>,
+        params: &PosParams,
+    ) {
+        self.update_data(current_epoch, params);
+
+        let offset = Offset::value(params) as usize;
+        self.data[offset] = self.data[offset].as_ref().map_or_else(
+            || Some(value.clone()),
+            |last_delta| Some(last_delta.clone() + value.clone()),
+        );
+    }
+
+    /// Delete the current delta value (the data's head element).
+    pub fn delete_current(
+        &mut self,
+        current_epoch: impl Into<Epoch>,
+        params: &PosParams,
+    ) {
+        self.update_data(current_epoch, params);
+        self.data[0] = None;
+    }
+
+    /// Add or set the delta value at the given epoch offset (which must not
+    /// be greater than the `Offset` type parameter of self).
+    pub fn add_at_offset(
+        &mut self,
+        value: Data,
+        current_epoch: impl Into<Epoch>,
+        offset: DynEpochOffset,
+        params: &PosParams,
+    ) {
+        let offset = offset.value(params) as usize;
+        debug_assert!(offset <= Offset::value(params) as usize);
+        let epoch = current_epoch.into();
+        self.update_data(epoch, params);
+
+        self.data[offset] = self.data[offset].as_ref().map_or_else(
+            || Some(value.clone()),
+            |last_delta| Some(last_delta.clone() + value.clone()),
+        );
+    }
+
+    /// Add or set the delta value at the given epoch (which must not at an
+    /// offset that is greater than the `Offset` type parameter of self).
+    pub fn add_at_epoch(
+        &mut self,
+        value: Data,
+        current_epoch: impl Into<Epoch>,
+        update_epoch: impl Into<Epoch>,
+        params: &PosParams,
+    ) {
+        let current_epoch = current_epoch.into();
+        let update_epoch = update_epoch.into();
+        self.update_data(current_epoch, params);
+        let offset =
+            (u64::from(update_epoch) - u64::from(current_epoch)) as usize;
+        debug_assert!(offset <= Offset::value(params) as usize);
+
+        self.data[offset] = self.data[offset].as_ref().map_or_else(
+            || Some(value.clone()),
+            |last_delta| Some(last_delta.clone() + value.clone()),
+        );
+    }
+
+    /// Update the delta values in reverse order (starting from the future-most
+    /// epoch) while the update function returns `true`.
+    pub fn rev_update_while(
+        &mut self,
+        mut update_value: impl FnMut(&mut Data, Epoch) -> bool,
+        current_epoch: impl Into<Epoch>,
+        params: &PosParams,
+    ) {
+        let epoch = current_epoch.into();
+        self.update_data(epoch, params);
+
+        let offset = Offset::value(params) as usize;
+        for ix in (0..offset + 1).rev() {
+            if let Some(Some(current)) = self.data.get_mut(ix) {
+                let keep_going = update_value(current, epoch + ix);
+                if !keep_going {
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Get the epoch of the last update
+    pub fn last_update(&self) -> Epoch {
+        self.last_update
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::rc::Rc;
+
+    use proptest::prelude::*;
+    use proptest::prop_state_machine;
+    use proptest::state_machine::{AbstractStateMachine, StateMachineTest};
+
+    use super::*;
+    use crate::types::tests::arb_epoch;
+    use crate::types::BasisPoints;
+
+    prop_state_machine! {
+        #[test]
+        fn epoched_state_machine_with_pipeline_offset(
+            sequential 1..20 => EpochedAbstractStateMachine<OffsetPipelineLen>);
+
+        #[test]
+        fn epoched_state_machine_with_unbounding_offset(
+            sequential 1..20 => EpochedAbstractStateMachine<OffsetUnboundingLen>);
+
+        #[test]
+        fn epoched_delta_state_machine_with_pipeline_offset(
+            sequential 1..20 => EpochedDeltaAbstractStateMachine<OffsetPipelineLen>);
+
+        #[test]
+        fn epoched_delta_state_machine_with_unbounding_offset(
+            sequential 1..20 => EpochedDeltaAbstractStateMachine<OffsetUnboundingLen>);
+    }
+
+    /// Abstract representation of [`Epoched`].
+    #[derive(Clone, Debug)]
+    struct EpochedState<Data> {
+        init_at_genesis: bool,
+        params: PosParams,
+        last_update: Epoch,
+        data: HashMap<Epoch, Data>,
+    }
+
+    #[derive(Clone, Debug)]
+    enum EpochedTransition<Data> {
+        Get(Epoch),
+        Set { value: Data, epoch: Epoch },
+        UpdateFromOffset(UpdateFromOffset<Data>),
+    }
+    /// These are the arguments of one of the constructors in
+    /// [`EpochedTransition`]. It's not inlined because we need to manually
+    /// implement `Debug`.
+    struct UpdateFromOffset<Data> {
+        update_value: Rc<dyn Fn(&mut Data, Epoch)>,
+        epoch: Epoch,
+        offset: DynEpochOffset,
+    }
+    impl<Data> Clone for UpdateFromOffset<Data> {
+        fn clone(&self) -> Self {
+            Self {
+                update_value: self.update_value.clone(),
+                epoch: self.epoch,
+                offset: self.offset,
+            }
+        }
+    }
+    impl<Data> fmt::Debug for UpdateFromOffset<Data> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("UpdateFromOffset")
+                .field("update_value", &"Rc<dyn Fn(&mut Data, Epoch)>")
+                .field("epoch", &self.epoch)
+                .field("offset", &self.offset)
+                .finish()
+        }
+    }
+
+    /// Abstract state machine implementation for [`Epoched`].
+    struct EpochedAbstractStateMachine<Offset: EpochOffset> {
+        phantom: PhantomData<Offset>,
+    }
+    impl<Offset> AbstractStateMachine for EpochedAbstractStateMachine<Offset>
+    where
+        Offset: EpochOffset,
+    {
+        type State = EpochedState<u64>;
+        type Transition = EpochedTransition<u64>;
+
+        fn init_state() -> BoxedStrategy<Self::State> {
+            prop_oneof![
+                // Initialized at genesis
+                (arb_pos_params(), 0_u64..1_000_000, any::<u64>()).prop_map(
+                    |(params, epoch, initial)| {
+                        let mut data = HashMap::default();
+                        data.insert(epoch.into(), initial);
+                        EpochedState {
+                            init_at_genesis: true,
+                            params,
+                            last_update: epoch.into(),
+                            data,
+                        }
+                    }
+                ),
+                // Initialized after genesis
+                (arb_pos_params(), 0_u64..1_000_000, any::<u64>()).prop_map(
+                    |(params, epoch, initial)| {
+                        let offset = Offset::value(&params);
+                        let mut data = HashMap::default();
+                        data.insert((epoch + offset).into(), initial);
+                        EpochedState {
+                            init_at_genesis: false,
+                            params,
+                            last_update: epoch.into(),
+                            data,
+                        }
+                    }
+                ),
+            ]
+            .boxed()
+        }
+
+        fn transitions(state: &Self::State) -> BoxedStrategy<Self::Transition> {
+            let offset = Offset::value(&state.params);
+            let dyn_offset = Offset::dyn_offset();
+            let last_update: u64 = state.last_update.into();
+            prop_oneof![
+                arb_epoch(
+                    last_update.checked_sub(4 * offset).unwrap_or_default()
+                        ..last_update + 4 * offset
+                )
+                .prop_map(EpochedTransition::Get),
+                (
+                    any::<u64>(),
+                    // Update's epoch may not be lower than the last_update
+                    arb_epoch(last_update..last_update + 10),
+                )
+                    .prop_map(|(value, epoch)| {
+                        EpochedTransition::Set { value, epoch }
+                    }),
+                (
+                    any::<u64>(),
+                    arb_epoch(last_update..last_update + 4 * offset),
+                    arb_offset(Some(dyn_offset))
+                )
+                    .prop_map(|(new_value, epoch, offset)| {
+                        EpochedTransition::UpdateFromOffset(UpdateFromOffset {
+                            update_value: Rc::new(
+                                move |current: &mut u64, _epoch| {
+                                    let value = new_value;
+                                    *current = value
+                                },
+                            ),
+                            epoch,
+                            offset,
+                        })
+                    }),
+            ]
+            .boxed()
+        }
+
+        fn apply_abstract(
+            mut state: Self::State,
+            transition: &Self::Transition,
+        ) -> Self::State {
+            match transition {
+                EpochedTransition::Get(_epoch) => {
+                    // no side effects
+                }
+                EpochedTransition::Set { value, epoch } => {
+                    let offset = Offset::value(&state.params);
+                    state.last_update = *epoch;
+                    state.data.insert(*epoch + offset, *value);
+                }
+                EpochedTransition::UpdateFromOffset(UpdateFromOffset {
+                    update_value,
+                    epoch,
+                    offset,
+                }) => {
+                    state.last_update = *epoch;
+                    let offset = *epoch + offset.value(&state.params);
+                    if !state.data.contains_key(epoch) {
+                        let mut latest_key = Epoch::default();
+                        let mut latest = None;
+                        for (key, value) in state.data.iter() {
+                            if key > &latest_key && key < &offset {
+                                latest_key = *key;
+                                latest = Some(*value)
+                            }
+                        }
+                        if let Some(latest) = latest {
+                            state.data.insert(*epoch, latest);
+                        }
+                    }
+                    for (key, value) in state.data.iter_mut() {
+                        if key >= &offset {
+                            update_value(value, *key)
+                        }
+                    }
+                }
+            }
+            state
+        }
+    }
+
+    impl<Offset> StateMachineTest for EpochedAbstractStateMachine<Offset>
+    where
+        Offset: EpochOffset,
+    {
+        type Abstract = Self;
+        type ConcreteState = (PosParams, Epoched<u64, Offset>);
+
+        fn init_test(
+            initial_state: <Self::Abstract as AbstractStateMachine>::State,
+        ) -> Self::ConcreteState {
+            assert!(initial_state.data.len() == 1);
+            let data = if initial_state.init_at_genesis {
+                let genesis_epoch = initial_state.last_update;
+                let value = initial_state.data.get(&genesis_epoch).unwrap();
+                Epoched::init_at_genesis(*value, genesis_epoch)
+            } else {
+                let (key, value) = initial_state.data.iter().next().unwrap();
+                let data = Epoched::init(
+                    *value,
+                    initial_state.last_update,
+                    &initial_state.params,
+                );
+                assert_eq!(
+                    Some(*value),
+                    data.data[usize::from(*key - initial_state.last_update)]
+                );
+                data
+            };
+            (initial_state.params, data)
+        }
+
+        fn apply_concrete(
+            (params, mut data): Self::ConcreteState,
+            transition: &<Self::Abstract as AbstractStateMachine>::Transition,
+        ) -> Self::ConcreteState {
+            let offset = Offset::value(&params) as usize;
+            match transition {
+                EpochedTransition::Get(epoch) => {
+                    let epoch = *epoch;
+                    let value = data.get(epoch);
+                    // Post-conditions
+                    let last_update = data.last_update;
+                    match value {
+                        Some(val) => {
+                            // When a value found, it should be the last value
+                            // before or on the upper bound
+                            let upper_bound = cmp::min(
+                                cmp::min(
+                                    (epoch.sub_or_default(last_update)).into(),
+                                    offset,
+                                ) + 1,
+                                data.data.len(),
+                            );
+                            for i in (0..upper_bound).rev() {
+                                match data.data[i] {
+                                    Some(ref stored_val) => {
+                                        assert_eq!(val, stored_val);
+                                        break;
+                                    }
+                                    None => {
+                                        // The value must be found on or after 0
+                                        // index
+                                        assert_ne!(i, 0);
+                                    }
+                                }
+                            }
+                        }
+                        None => {
+                            // When no value found, there should be no values
+                            // before the upper bound
+                            let upper_bound = cmp::min(
+                                cmp::min(
+                                    (epoch.sub_or_default(last_update)).into(),
+                                    offset,
+                                ) + 1,
+                                data.data.len(),
+                            );
+                            for i in 0..upper_bound {
+                                assert_eq!(None, data.data[i]);
+                            }
+                        }
+                    }
+                }
+                EpochedTransition::Set { value, epoch } => {
+                    let current_before_update = data.get(*epoch).copied();
+                    let epochs_up_to_offset =
+                        (*epoch + 1_u64).iter_range(offset as u64 - 1);
+                    // Find the values in epochs up to the offset
+                    let range_before_update: Vec<_> = epochs_up_to_offset
+                        .clone()
+                        .map(|epoch| data.get(epoch).copied())
+                        .collect();
+
+                    data.set(*value, *epoch, &params);
+
+                    // Post-conditions
+                    assert_eq!(data.last_update, *epoch);
+                    assert_eq!(
+                        data.data[offset as usize],
+                        Some(*value),
+                        "The value at offset must be updated"
+                    );
+                    assert!(
+                        data.data.len() > offset as usize,
+                        "The length of the data must be greater than the \
+                         offset"
+                    );
+                    assert_eq!(
+                        data.get(*epoch),
+                        current_before_update.as_ref(),
+                        "The current value must not change"
+                    );
+                    let range_after_update: Vec<_> = epochs_up_to_offset
+                        .map(|epoch| data.get(epoch).copied())
+                        .collect();
+                    assert_eq!(
+                        range_before_update, range_after_update,
+                        "The values in epochs before the offset must not \
+                         change"
+                    );
+                }
+                EpochedTransition::UpdateFromOffset(UpdateFromOffset {
+                    update_value,
+                    epoch,
+                    offset: update_offset,
+                }) => {
+                    let update_offset_val = update_offset.value(&params);
+                    let current_before_update = data.get(*epoch).copied();
+                    let next_epoch: u64 = (*epoch + 1_u64).into();
+                    let epoch_at_update_offset: u64 =
+                        (*epoch + update_offset_val).into();
+                    // Find the values in epochs before the offset
+                    let range_up_to_offset_before_update: Vec<_> = (next_epoch
+                        ..epoch_at_update_offset)
+                        .map(|i: u64| data.get(Epoch::from(i)).copied())
+                        .collect();
+                    let epoch_after_offset: u64 = epoch_at_update_offset + 1;
+                    let epoch_at_offset: u64 = (*epoch + offset).into();
+                    // Find the values in epochs after the offset
+                    let mut range_from_offset_before_update: Vec<_> =
+                        (epoch_after_offset..epoch_at_offset)
+                            .map(|i: u64| {
+                                let epoch = Epoch::from(i);
+                                (data.get(epoch).copied(), epoch)
+                            })
+                            .collect();
+
+                    data.update_from_offset(
+                        |val, epoch| update_value(val, epoch),
+                        *epoch,
+                        *update_offset,
+                        &params,
+                    );
+
+                    // Post-conditions
+                    assert_eq!(data.last_update, *epoch);
+                    // Update all the values with the update function
+                    let range_from_offset_before_update: Vec<_> =
+                        range_from_offset_before_update
+                            .iter_mut()
+                            .map(|(val, epoch)| {
+                                if let Some(val) = val.as_mut() {
+                                    update_value(val, *epoch);
+                                }
+                                *val
+                            })
+                            .collect();
+                    let range_from_offset_after_update: Vec<_> =
+                        (epoch_after_offset..epoch_at_offset)
+                            .map(|i: u64| data.get(Epoch::from(i)).copied())
+                            .collect();
+                    assert_eq!(
+                        range_from_offset_before_update,
+                        range_from_offset_after_update,
+                        "The values in epochs from the offset must be updated"
+                    );
+                    assert_eq!(
+                        data.get(*epoch),
+                        current_before_update.as_ref(),
+                        "The current value must not change"
+                    );
+                    let range_up_to_offset_after_update: Vec<_> = (next_epoch
+                        ..epoch_at_update_offset)
+                        .map(|i: u64| data.get(Epoch::from(i)).copied())
+                        .collect();
+                    assert_eq!(
+                        range_up_to_offset_before_update,
+                        range_up_to_offset_after_update,
+                        "The values in epochs up to the offset must not change"
+                    );
+                }
+            }
+            (params, data)
+        }
+
+        fn invariants((params, data): &Self::ConcreteState) {
+            let offset = Offset::value(params);
+            assert!(data.data.len() <= (offset + 1) as usize);
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    enum EpochedDeltaTransition<Data> {
+        Get(Epoch),
+        Add { value: Data, epoch: Epoch },
+    }
+
+    /// Abstract state machine implementation for [`EpochedDelta`].
+    struct EpochedDeltaAbstractStateMachine<Offset: EpochOffset> {
+        phantom: PhantomData<Offset>,
+    }
+    impl<Offset> AbstractStateMachine for EpochedDeltaAbstractStateMachine<Offset>
+    where
+        Offset: EpochOffset,
+    {
+        type State = EpochedState<u64>;
+        type Transition = EpochedDeltaTransition<u64>;
+
+        fn init_state() -> BoxedStrategy<Self::State> {
+            prop_oneof![
+                // Initialized at genesis
+                (arb_pos_params(), arb_epoch(0..1_000_000), 1..10_000_000_u64)
+                    .prop_map(|(params, epoch, initial)| {
+                        let mut data = HashMap::default();
+                        data.insert(epoch, initial);
+                        EpochedState {
+                            init_at_genesis: true,
+                            params,
+                            last_update: epoch,
+                            data,
+                        }
+                    }),
+                // Initialized after genesis
+                (arb_pos_params(), arb_epoch(0..1_000_000), 1..10_000_000_u64)
+                    .prop_map(|(params, epoch, initial)| {
+                        let offset = Offset::value(&params);
+                        let mut data = HashMap::default();
+                        data.insert(epoch + offset, initial);
+                        EpochedState {
+                            init_at_genesis: false,
+                            params,
+                            last_update: epoch,
+                            data,
+                        }
+                    }),
+            ]
+            .boxed()
+        }
+
+        fn transitions(state: &Self::State) -> BoxedStrategy<Self::Transition> {
+            let offset = Offset::value(&state.params);
+            let last_update: u64 = state.last_update.into();
+            prop_oneof![
+                (last_update.checked_sub(4 * offset).unwrap_or_default()
+                    ..last_update + 4 * offset)
+                    .prop_map(|epoch| {
+                        EpochedDeltaTransition::Get(epoch.into())
+                    }),
+                (
+                    1..10_000_000_u64,
+                    // Update's epoch may not be lower than the last_update
+                    last_update..last_update + 10,
+                )
+                    .prop_map(|(value, epoch)| {
+                        EpochedDeltaTransition::Add {
+                            value,
+                            epoch: epoch.into(),
+                        }
+                    })
+            ]
+            .boxed()
+        }
+
+        fn apply_abstract(
+            mut state: Self::State,
+            transition: &Self::Transition,
+        ) -> Self::State {
+            match transition {
+                EpochedDeltaTransition::Get(_epoch) => {
+                    // no side effects
+                }
+                EpochedDeltaTransition::Add {
+                    value: change,
+                    epoch,
+                } => {
+                    let epoch = *epoch;
+                    let offset = Offset::value(&state.params);
+                    state.last_update = epoch;
+                    let current = state.data.entry(epoch + offset).or_insert(0);
+                    *current += *change;
+                }
+            }
+            state
+        }
+    }
+
+    impl<Offset> StateMachineTest for EpochedDeltaAbstractStateMachine<Offset>
+    where
+        Offset: EpochOffset,
+    {
+        type Abstract = Self;
+        type ConcreteState = (PosParams, EpochedDelta<u64, Offset>);
+
+        fn init_test(
+            initial_state: <Self::Abstract as AbstractStateMachine>::State,
+        ) -> Self::ConcreteState {
+            assert!(initial_state.data.len() == 1);
+            let data = if initial_state.init_at_genesis {
+                let genesis_epoch = initial_state.last_update;
+                let value = initial_state.data.get(&genesis_epoch).unwrap();
+                EpochedDelta::init_at_genesis(*value, genesis_epoch)
+            } else {
+                let (key, value) = initial_state.data.iter().next().unwrap();
+                let data = EpochedDelta::init(
+                    *value,
+                    initial_state.last_update,
+                    &initial_state.params,
+                );
+                assert_eq!(
+                    Some(*value),
+                    data.data[usize::from(*key - initial_state.last_update)]
+                );
+                data
+            };
+            (initial_state.params, data)
+        }
+
+        fn apply_concrete(
+            (params, mut data): Self::ConcreteState,
+            transition: &<Self::Abstract as AbstractStateMachine>::Transition,
+        ) -> Self::ConcreteState {
+            let offset = Offset::value(&params) as usize;
+            match transition {
+                EpochedDeltaTransition::Get(epoch) => {
+                    let epoch = *epoch;
+                    let value = data.get(epoch);
+                    // Post-conditions
+                    let last_update = data.last_update;
+                    match value {
+                        Some(val) => {
+                            // When a value found, it should be equal to the sum
+                            // of deltas before and on the upper bound
+                            let upper_bound = cmp::min(
+                                cmp::min(
+                                    (epoch.sub_or_default(last_update)).into(),
+                                    offset,
+                                ) + 1,
+                                data.data.len(),
+                            );
+                            let mut sum = 0;
+                            for i in (0..upper_bound).rev() {
+                                if let Some(stored_val) = data.data[i] {
+                                    sum += stored_val;
+                                }
+                            }
+                            assert_eq!(val, sum);
+                        }
+                        None => {
+                            // When no value found, there should be no values
+                            // before the upper bound
+                            let upper_bound = cmp::min(
+                                cmp::min(
+                                    (epoch.sub_or_default(last_update)).into(),
+                                    offset,
+                                ) + 1,
+                                data.data.len(),
+                            );
+                            for i in 0..upper_bound {
+                                assert_eq!(None, data.data[i]);
+                            }
+                        }
+                    }
+                }
+                EpochedDeltaTransition::Add {
+                    value: change,
+                    epoch,
+                } => {
+                    let current_value_before_update = data.get(*epoch);
+                    let value_at_offset_before_update =
+                        data.get(*epoch + offset);
+                    let epochs_up_to_offset =
+                        (*epoch + 1_u64).iter_range(offset as u64 - 1);
+                    // Find the values in epochs before the offset
+                    let range_before_update: Vec<_> = epochs_up_to_offset
+                        .clone()
+                        .map(|epoch| data.get(epoch))
+                        .collect();
+
+                    data.add(*change, *epoch, &params);
+
+                    // Post-conditions
+                    assert_eq!(data.last_update, *epoch);
+                    let value_at_offset_after_update =
+                        data.get(*epoch + offset);
+                    assert_eq!(
+                        value_at_offset_after_update.unwrap_or_default(),
+                        *change
+                            + value_at_offset_before_update.unwrap_or_default(),
+                        "The value at the offset must have increased by the \
+                         change"
+                    );
+                    assert!(
+                        data.data.len() > offset as usize,
+                        "The length of the data must be greater than the \
+                         offset"
+                    );
+                    assert_eq!(
+                        data.get(*epoch),
+                        current_value_before_update,
+                        "The current value must not change"
+                    );
+                    let range_after_update: Vec<_> = epochs_up_to_offset
+                        .map(|epoch| data.get(epoch))
+                        .collect();
+                    assert_eq!(
+                        range_before_update, range_after_update,
+                        "The values in epochs before the offset must not \
+                         change"
+                    );
+                }
+            }
+            (params, data)
+        }
+
+        fn invariants((params, data): &Self::ConcreteState) {
+            let offset = Offset::value(params);
+            assert!(data.data.len() <= (offset + 1) as usize);
+        }
+    }
+
+    fn arb_pos_params() -> impl Strategy<Value = PosParams> {
+        (
+            10..500_u64,
+            1..10_u64,
+            1..10_000_u64,
+            1..1_000_u64,
+            1..1_000_u64,
+            1..10_000_u64,
+            1..10_000_u64,
+        )
+            .prop_flat_map(
+                |(
+                    max_validator_slots,
+                    pipeline_len,
+                    votes_per_token,
+                    block_proposer_reward,
+                    block_vote_reward,
+                    duplicate_vote_slash_rate,
+                    light_client_attack_slash_rate,
+                )| {
+                    (pipeline_len + 1..pipeline_len + 10).prop_map(
+                        move |unbonding_len| PosParams {
+                            max_validator_slots,
+                            pipeline_len,
+                            unbonding_len,
+                            votes_per_token: BasisPoints::new(votes_per_token),
+                            block_proposer_reward,
+                            block_vote_reward,
+                            duplicate_vote_slash_rate: BasisPoints::new(
+                                duplicate_vote_slash_rate,
+                            ),
+                            light_client_attack_slash_rate: BasisPoints::new(
+                                light_client_attack_slash_rate,
+                            ),
+                        },
+                    )
+                },
+            )
+    }
+
+    fn arb_offset(
+        min: Option<DynEpochOffset>,
+    ) -> impl Strategy<Value = DynEpochOffset> {
+        match min {
+            Some(DynEpochOffset::PipelineLen) => {
+                Just(DynEpochOffset::PipelineLen).boxed()
+            }
+            Some(DynEpochOffset::UnbondingLen) | None => prop_oneof![
+                Just(DynEpochOffset::PipelineLen),
+                Just(DynEpochOffset::UnbondingLen),
+            ]
+            .boxed(),
+        }
+    }
+}

--- a/proof_of_stake/src/lib.rs
+++ b/proof_of_stake/src/lib.rs
@@ -1617,7 +1617,7 @@ fn update_validator_set<Address, TokenChange>(
                     let min_voting_power = min_active_validator
                         .map(|v| v.voting_power)
                         .unwrap_or_default();
-                    if voting_power_pre > min_voting_power {
+                    if voting_power_post > min_voting_power {
                         let deactivate_min =
                             validator_set.active.pop_first_shim();
                         let popped =
@@ -1640,7 +1640,7 @@ fn update_validator_set<Address, TokenChange>(
                     let max_voting_power = max_inactive_validator
                         .map(|v| v.voting_power)
                         .unwrap_or_default();
-                    if voting_power_pre < max_voting_power {
+                    if voting_power_post < max_voting_power {
                         let activate_max =
                             validator_set.inactive.pop_last_shim();
                         let popped =

--- a/proof_of_stake/src/lib.rs
+++ b/proof_of_stake/src/lib.rs
@@ -1,0 +1,1814 @@
+//! Proof of Stake system.
+//!
+//! TODO: We might need to storage both active and total validator set voting
+//! power. For consensus, we only consider active validator set voting power,
+//! but for other activities in which inactive validators can participate (e.g.
+//! voting on a protocol parameter changes, upgrades, default VP changes) we
+//! should use the total validator set voting power.
+
+#![warn(missing_docs)]
+#![deny(rustdoc::broken_intra_doc_links)]
+#![deny(rustdoc::private_intra_doc_links)]
+
+mod btree_set;
+pub mod epoched;
+pub mod parameters;
+pub mod types;
+pub mod validation;
+
+use core::fmt::Debug;
+use std::collections::{BTreeSet, HashMap};
+use std::convert::TryFrom;
+use std::fmt::Display;
+use std::hash::Hash;
+use std::num::TryFromIntError;
+use std::ops::{Add, AddAssign, Neg, Sub, SubAssign};
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use epoched::{
+    DynEpochOffset, EpochOffset, Epoched, EpochedDelta, OffsetPipelineLen,
+};
+use parameters::PosParams;
+use thiserror::Error;
+use types::{
+    ActiveValidator, Bonds, Epoch, GenesisValidator, Slash, SlashType, Slashes,
+    TotalVotingPowers, Unbond, Unbonds, ValidatorConsensusKeys, ValidatorSet,
+    ValidatorSetUpdate, ValidatorSets, ValidatorState, ValidatorStates,
+    ValidatorTotalDeltas, ValidatorVotingPowers, VotingPower, VotingPowerDelta,
+};
+
+use crate::btree_set::BTreeSetShims;
+use crate::types::{Bond, BondId, WeightedValidator};
+
+/// Read-only part of the PoS system
+pub trait PosReadOnly {
+    /// Address type
+    type Address: Display
+        + Debug
+        + Clone
+        + PartialEq
+        + Eq
+        + PartialOrd
+        + Ord
+        + Hash
+        + BorshDeserialize
+        + BorshSerialize;
+    /// Token amount type
+    type TokenAmount: Display
+        + Debug
+        + Default
+        + Clone
+        + Copy
+        + Add<Output = Self::TokenAmount>
+        + AddAssign
+        + Sub
+        + PartialOrd
+        + Into<u64>
+        + From<u64>
+        + Into<Self::TokenChange>
+        + SubAssign
+        + BorshDeserialize
+        + BorshSerialize;
+    /// Token change type
+    type TokenChange: Display
+        + Debug
+        + Default
+        + Clone
+        + Copy
+        + Add<Output = Self::TokenChange>
+        + Sub<Output = Self::TokenChange>
+        + From<Self::TokenAmount>
+        + Into<i128>
+        + Neg<Output = Self::TokenChange>
+        + BorshDeserialize
+        + BorshSerialize;
+    /// Cryptographic public key type
+    type PublicKey: Debug + Clone + BorshDeserialize + BorshSerialize;
+
+    /// Address of the PoS account
+    const POS_ADDRESS: Self::Address;
+    /// Address of the staking token
+    /// TODO: this should be `const`, but in the ledger `address::xan` is not a
+    /// `const fn`
+    fn staking_token_address() -> Self::Address;
+
+    /// Read PoS parameters.
+    fn read_pos_params(&self) -> PosParams;
+    /// Read PoS validator's staking reward address.
+    fn read_validator_staking_reward_address(
+        &self,
+        key: &Self::Address,
+    ) -> Option<Self::Address>;
+    /// Read PoS validator's consensus key (used for signing block votes).
+    fn read_validator_consensus_key(
+        &self,
+        key: &Self::Address,
+    ) -> Option<ValidatorConsensusKeys<Self::PublicKey>>;
+    /// Read PoS validator's state.
+    fn read_validator_state(
+        &self,
+        key: &Self::Address,
+    ) -> Option<ValidatorStates>;
+    /// Read PoS validator's total deltas of their bonds (validator self-bonds
+    /// and delegations).
+    fn read_validator_total_deltas(
+        &self,
+        key: &Self::Address,
+    ) -> Option<ValidatorTotalDeltas<Self::TokenChange>>;
+    /// Read PoS validator's voting power.
+    fn read_validator_voting_power(
+        &self,
+        key: &Self::Address,
+    ) -> Option<ValidatorVotingPowers>;
+    /// Read PoS slashes applied to a validator.
+    fn read_validator_slashes(&self, key: &Self::Address) -> Vec<Slash>;
+    /// Read PoS bond (validator self-bond or a delegation).
+    fn read_bond(
+        &self,
+        key: &BondId<Self::Address>,
+    ) -> Option<Bonds<Self::TokenAmount>>;
+    /// Read PoS unbond (unbonded tokens from validator self-bond or a
+    /// delegation).
+    fn read_unbond(
+        &self,
+        key: &BondId<Self::Address>,
+    ) -> Option<Unbonds<Self::TokenAmount>>;
+    /// Read PoS validator set (active and inactive).
+    fn read_validator_set(&self) -> ValidatorSets<Self::Address>;
+    /// Read PoS total voting power of all validators (active and inactive).
+    fn read_total_voting_power(&self) -> TotalVotingPowers;
+}
+
+/// PoS system trait to be implemented in integration that can read and write
+/// PoS data.
+pub trait PosActions: PosReadOnly {
+    /// Write PoS parameters.
+    fn write_pos_params(&mut self, params: &PosParams);
+    /// Write PoS validator's raw hash its address.
+    fn write_validator_address_raw_hash(&mut self, address: &Self::Address);
+    /// Write PoS validator's staking reward address, into which staking rewards
+    /// will be credited.
+    fn write_validator_staking_reward_address(
+        &mut self,
+        key: &Self::Address,
+        value: Self::Address,
+    );
+    /// Write PoS validator's consensus key (used for signing block votes).
+    fn write_validator_consensus_key(
+        &mut self,
+        key: &Self::Address,
+        value: ValidatorConsensusKeys<Self::PublicKey>,
+    );
+    /// Write PoS validator's state.
+    fn write_validator_state(
+        &mut self,
+        key: &Self::Address,
+        value: ValidatorStates,
+    );
+    /// Write PoS validator's total deltas of their bonds (validator self-bonds
+    /// and delegations).
+    fn write_validator_total_deltas(
+        &mut self,
+        key: &Self::Address,
+        value: ValidatorTotalDeltas<Self::TokenChange>,
+    );
+    /// Write PoS validator's voting power.
+    fn write_validator_voting_power(
+        &mut self,
+        key: &Self::Address,
+        value: ValidatorVotingPowers,
+    );
+    /// Write PoS bond (validator self-bond or a delegation).
+    fn write_bond(
+        &mut self,
+        key: &BondId<Self::Address>,
+        value: Bonds<Self::TokenAmount>,
+    );
+    /// Write PoS unbond (unbonded tokens from validator self-bond or a
+    /// delegation).
+    fn write_unbond(
+        &mut self,
+        key: &BondId<Self::Address>,
+        value: Unbonds<Self::TokenAmount>,
+    );
+    /// Write PoS validator set (active and inactive).
+    fn write_validator_set(&mut self, value: ValidatorSets<Self::Address>);
+    /// Write PoS total voting power of all validators (active and inactive).
+    fn write_total_voting_power(&mut self, value: TotalVotingPowers);
+
+    /// Delete an emptied PoS bond (validator self-bond or a delegation).
+    fn delete_bond(&mut self, key: &BondId<Self::Address>);
+    /// Delete an emptied PoS unbond (unbonded tokens from validator self-bond
+    /// or a delegation).
+    fn delete_unbond(&mut self, key: &BondId<Self::Address>);
+
+    /// Transfer tokens from the `src` to the `dest`.
+    fn transfer(
+        &mut self,
+        token: &Self::Address,
+        amount: Self::TokenAmount,
+        src: &Self::Address,
+        dest: &Self::Address,
+    );
+
+    /// Attempt to update the given account to become a validator.
+    fn become_validator(
+        &mut self,
+        address: &Self::Address,
+        staking_reward_address: &Self::Address,
+        consensus_key: &Self::PublicKey,
+        current_epoch: impl Into<Epoch>,
+    ) -> Result<(), BecomeValidatorError<Self::Address>> {
+        let current_epoch = current_epoch.into();
+        let params = self.read_pos_params();
+        let mut validator_set = self.read_validator_set();
+        if self.is_validator(address).is_some() {
+            return Err(BecomeValidatorError::AlreadyValidator(
+                address.clone(),
+            ));
+        }
+        let BecomeValidatorData {
+            consensus_key,
+            state,
+        } = become_validator(
+            &params,
+            address,
+            consensus_key,
+            &mut validator_set,
+            current_epoch,
+        );
+        self.write_validator_staking_reward_address(
+            address,
+            staking_reward_address.clone(),
+        );
+        self.write_validator_consensus_key(address, consensus_key);
+        self.write_validator_state(address, state);
+        self.write_validator_set(validator_set);
+        self.write_validator_address_raw_hash(address);
+        Ok(())
+    }
+
+    /// Check if the given address is a validator by checking that it has some
+    /// state.
+    fn is_validator(
+        &mut self,
+        address: &Self::Address,
+    ) -> Option<Epoched<ValidatorState, OffsetPipelineLen>> {
+        self.read_validator_state(address)
+    }
+
+    /// Self-bond tokens to a validator when `source` is `None` or equal to
+    /// the `validator` address, or delegate tokens from the `source` to the
+    /// `validator`.
+    fn bond_tokens(
+        &mut self,
+        source: Option<&Self::Address>,
+        validator: &Self::Address,
+        amount: Self::TokenAmount,
+        current_epoch: impl Into<Epoch>,
+    ) -> Result<(), BondError<Self::Address>> {
+        let current_epoch = current_epoch.into();
+        if let Some(source) = source {
+            if source != validator {
+                if let Some(_state) = self.is_validator(source) {
+                    return Err(BondError::SourceMustNotBeAValidator(
+                        source.clone(),
+                    ));
+                }
+            }
+        }
+        let params = self.read_pos_params();
+        let validator_state = self.is_validator(validator);
+        let source = source.unwrap_or(validator);
+        let bond_id = BondId {
+            source: source.clone(),
+            validator: validator.clone(),
+        };
+        let bond = self.read_bond(&bond_id);
+        let validator_total_deltas =
+            self.read_validator_total_deltas(validator);
+        let validator_voting_power =
+            self.read_validator_voting_power(validator);
+        let mut total_voting_power = self.read_total_voting_power();
+        let mut validator_set = self.read_validator_set();
+
+        let BondData {
+            bond,
+            validator_total_deltas,
+            validator_voting_power,
+        } = bond_tokens(
+            &params,
+            validator_state,
+            &bond_id,
+            bond,
+            amount,
+            validator_total_deltas,
+            validator_voting_power,
+            &mut total_voting_power,
+            &mut validator_set,
+            current_epoch,
+        )?;
+
+        self.write_bond(&bond_id, bond);
+        self.write_validator_total_deltas(validator, validator_total_deltas);
+        self.write_validator_voting_power(validator, validator_voting_power);
+        self.write_total_voting_power(total_voting_power);
+        self.write_validator_set(validator_set);
+
+        // Transfer the bonded tokens from the source to PoS
+        self.transfer(
+            &Self::staking_token_address(),
+            amount,
+            source,
+            &Self::POS_ADDRESS,
+        );
+
+        Ok(())
+    }
+
+    /// Unbond self-bonded tokens from a validator when `source` is `None` or
+    /// equal to the `validator` address, or unbond delegated tokens from
+    /// the `source` to the `validator`.
+    fn unbond_tokens(
+        &mut self,
+        source: Option<&Self::Address>,
+        validator: &Self::Address,
+        amount: Self::TokenAmount,
+        current_epoch: impl Into<Epoch>,
+    ) -> Result<(), UnbondError<Self::Address, Self::TokenAmount>> {
+        let current_epoch = current_epoch.into();
+        let params = self.read_pos_params();
+        let source = source.unwrap_or(validator);
+        let bond_id = BondId {
+            source: source.clone(),
+            validator: validator.clone(),
+        };
+        let mut bond =
+            self.read_bond(&bond_id).ok_or(UnbondError::NoBondFound)?;
+        let unbond = self.read_unbond(&bond_id);
+        let mut validator_total_deltas =
+            self.read_validator_total_deltas(validator).ok_or_else(|| {
+                UnbondError::ValidatorHasNoBonds(validator.clone())
+            })?;
+        let mut validator_voting_power =
+            self.read_validator_voting_power(validator).ok_or_else(|| {
+                UnbondError::ValidatorHasNoVotingPower(validator.clone())
+            })?;
+        let slashes = self.read_validator_slashes(validator);
+        let mut total_voting_power = self.read_total_voting_power();
+        let mut validator_set = self.read_validator_set();
+
+        let UnbondData { unbond } = unbond_tokens(
+            &params,
+            &bond_id,
+            &mut bond,
+            unbond,
+            amount,
+            slashes,
+            &mut validator_total_deltas,
+            &mut validator_voting_power,
+            &mut total_voting_power,
+            &mut validator_set,
+            current_epoch,
+        )?;
+
+        let total_bonds = bond.get_at_offset(
+            current_epoch,
+            DynEpochOffset::PipelineLen,
+            &params,
+        );
+        match total_bonds {
+            Some(total_bonds) if total_bonds.sum() != 0.into() => {
+                self.write_bond(&bond_id, bond);
+            }
+            _ => {
+                // If the bond is left empty, delete it
+                self.delete_bond(&bond_id)
+            }
+        }
+        self.write_unbond(&bond_id, unbond);
+        self.write_validator_total_deltas(validator, validator_total_deltas);
+        self.write_validator_voting_power(validator, validator_voting_power);
+        self.write_total_voting_power(total_voting_power);
+        self.write_validator_set(validator_set);
+
+        Ok(())
+    }
+
+    /// Withdraw unbonded tokens from a self-bond to a validator when `source`
+    /// is `None` or equal to the `validator` address, or withdraw unbonded
+    /// tokens delegated to the `validator` to the `source`.
+    fn withdraw_tokens(
+        &mut self,
+        source: Option<&Self::Address>,
+        validator: &Self::Address,
+        current_epoch: impl Into<Epoch>,
+    ) -> Result<Self::TokenAmount, WithdrawError<Self::Address>> {
+        let current_epoch = current_epoch.into();
+        let params = self.read_pos_params();
+        let source = source.unwrap_or(validator);
+        let bond_id = BondId {
+            source: source.clone(),
+            validator: validator.clone(),
+        };
+
+        let unbond = self.read_unbond(&bond_id);
+        let slashes = self.read_validator_slashes(&bond_id.validator);
+
+        let WithdrawData {
+            unbond,
+            withdrawn,
+            slashed,
+        } = withdraw_unbonds(
+            &params,
+            &bond_id,
+            unbond,
+            slashes,
+            current_epoch,
+        )?;
+
+        let total_unbonds = unbond.get_at_offset(
+            current_epoch,
+            DynEpochOffset::UnbondingLen,
+            &params,
+        );
+        match total_unbonds {
+            Some(total_unbonds) if total_unbonds.sum() != 0.into() => {
+                self.write_unbond(&bond_id, unbond);
+            }
+            _ => {
+                // If the unbond is left empty, delete it
+                self.delete_unbond(&bond_id)
+            }
+        }
+
+        // Transfer the tokens from PoS back to the source
+        self.transfer(
+            &Self::staking_token_address(),
+            withdrawn,
+            &Self::POS_ADDRESS,
+            source,
+        );
+
+        Ok(slashed)
+    }
+}
+
+/// PoS system base trait for system initialization on genesis block, updating
+/// the validator on a new epoch and applying slashes.
+pub trait PosBase {
+    /// Address type
+    type Address: 'static
+        + Display
+        + Debug
+        + Clone
+        + PartialEq
+        + Eq
+        + PartialOrd
+        + Ord
+        + Hash
+        + BorshDeserialize
+        + BorshSerialize;
+    /// Token amount type
+    type TokenAmount: 'static
+        + Display
+        + Debug
+        + Default
+        + Clone
+        + Copy
+        + Add<Output = Self::TokenAmount>
+        + AddAssign
+        + Sub
+        + PartialOrd
+        + Into<u64>
+        + From<u64>
+        + Into<Self::TokenChange>
+        + SubAssign
+        + BorshDeserialize
+        + BorshSerialize;
+    /// Token change type
+    type TokenChange: 'static
+        + Display
+        + Debug
+        + Default
+        + Clone
+        + Copy
+        + PartialOrd
+        + Add<Output = Self::TokenChange>
+        + Sub<Output = Self::TokenChange>
+        + From<Self::TokenAmount>
+        + From<i128>
+        + Into<i128>
+        + Neg<Output = Self::TokenChange>
+        + BorshDeserialize
+        + BorshSerialize;
+    /// Cryptographic public key type
+    type PublicKey: 'static + Debug + Clone + BorshDeserialize + BorshSerialize;
+
+    /// Address of the PoS account
+    const POS_ADDRESS: Self::Address;
+    /// Address of the staking token
+    /// TODO: this should be `const`, but in the ledger `address::xan` is not a
+    /// `const fn`
+    fn staking_token_address() -> Self::Address;
+    /// Address of the slash pool, into which slashed tokens are transferred.
+    const POS_SLASH_POOL_ADDRESS: Self::Address;
+
+    /// Read PoS parameters.
+    fn read_pos_params(&self) -> PosParams;
+    /// Read PoS raw hash of validator's address.
+    fn read_validator_address_raw_hash(
+        &self,
+        raw_hash: impl AsRef<str>,
+    ) -> Option<Self::Address>;
+    /// Read PoS validator's consensus key (used for signing block votes).
+    fn read_validator_consensus_key(
+        &self,
+        key: &Self::Address,
+    ) -> Option<ValidatorConsensusKeys<Self::PublicKey>>;
+    /// Read PoS validator's total deltas of their bonds (validator self-bonds
+    /// and delegations).
+    fn read_validator_total_deltas(
+        &self,
+        key: &Self::Address,
+    ) -> Option<ValidatorTotalDeltas<Self::TokenChange>>;
+    /// Read PoS validator's voting power.
+    fn read_validator_voting_power(
+        &self,
+        key: &Self::Address,
+    ) -> Option<ValidatorVotingPowers>;
+    /// Read PoS slashes applied to a validator.
+    fn read_validator_slashes(&self, key: &Self::Address) -> Slashes;
+    /// Read PoS validator set (active and inactive).
+    fn read_validator_set(&self) -> ValidatorSets<Self::Address>;
+    /// Read PoS total voting power of all validators (active and inactive).
+    fn read_total_voting_power(&self) -> TotalVotingPowers;
+
+    /// Write PoS parameters.
+    fn write_pos_params(&mut self, params: &PosParams);
+    /// Write PoS validator's raw hash its address.
+    fn write_validator_address_raw_hash(&mut self, address: &Self::Address);
+    /// Write PoS validator's staking reward address, into which staking rewards
+    /// will be credited.
+    fn write_validator_staking_reward_address(
+        &mut self,
+        key: &Self::Address,
+        value: &Self::Address,
+    );
+    /// Write PoS validator's consensus key (used for signing block votes).
+    fn write_validator_consensus_key(
+        &mut self,
+        key: &Self::Address,
+        value: &ValidatorConsensusKeys<Self::PublicKey>,
+    );
+    /// Write PoS validator's state.
+    fn write_validator_state(
+        &mut self,
+        key: &Self::Address,
+        value: &ValidatorStates,
+    );
+    /// Write PoS validator's total deltas of their bonds (validator self-bonds
+    /// and delegations).
+    fn write_validator_total_deltas(
+        &mut self,
+        key: &Self::Address,
+        value: &ValidatorTotalDeltas<Self::TokenChange>,
+    );
+    /// Write PoS validator's voting power.
+    fn write_validator_voting_power(
+        &mut self,
+        key: &Self::Address,
+        value: &ValidatorVotingPowers,
+    );
+    /// Write (append) PoS slash applied to a validator.
+    fn write_validator_slash(
+        &mut self,
+        validator: &Self::Address,
+        value: Slash,
+    );
+    /// Write PoS bond (validator self-bond or a delegation).
+    fn write_bond(
+        &mut self,
+        key: &BondId<Self::Address>,
+        value: &Bonds<Self::TokenAmount>,
+    );
+    /// Write PoS validator set (active and inactive).
+    fn write_validator_set(&mut self, value: &ValidatorSets<Self::Address>);
+    /// Read PoS total voting power of all validators (active and inactive).
+    fn write_total_voting_power(&mut self, value: &TotalVotingPowers);
+    /// Initialize staking reward account with the given public key.
+    fn init_staking_reward_account(
+        &mut self,
+        address: &Self::Address,
+        pk: &Self::PublicKey,
+    );
+    /// Credit tokens to the `target` account. This should only be used at
+    /// genesis.
+    fn credit_tokens(
+        &mut self,
+        token: &Self::Address,
+        target: &Self::Address,
+        amount: Self::TokenAmount,
+    );
+    /// Transfer tokens from the `src` to the `dest`.
+    fn transfer(
+        &mut self,
+        token: &Self::Address,
+        amount: Self::TokenAmount,
+        src: &Self::Address,
+        dest: &Self::Address,
+    );
+
+    /// Initialize the PoS system storage data in the genesis block for the
+    /// given PoS parameters and initial validator set. The validators'
+    /// tokens will be put into self-bonds. The given PoS parameters are written
+    /// with the [`PosBase::write_pos_params`] method.
+    fn init_genesis<'a>(
+        &mut self,
+        params: &'a PosParams,
+        validators: impl Iterator<
+            Item = &'a GenesisValidator<
+                Self::Address,
+                Self::TokenAmount,
+                Self::PublicKey,
+            >,
+        > + Clone
+        + 'a,
+        current_epoch: impl Into<Epoch>,
+    ) -> Result<(), GenesisError> {
+        let current_epoch = current_epoch.into();
+        self.write_pos_params(params);
+
+        let GenesisData {
+            validators,
+            validator_set,
+            total_voting_power,
+            total_bonded_balance,
+        } = init_genesis(params, validators, current_epoch)?;
+
+        for res in validators {
+            let GenesisValidatorData {
+                ref address,
+                staking_reward_address,
+                consensus_key,
+                staking_reward_key,
+                state,
+                total_deltas,
+                voting_power,
+                bond: (bond_id, bond),
+            } = res?;
+            self.write_validator_address_raw_hash(address);
+            self.write_validator_staking_reward_address(
+                address,
+                &staking_reward_address,
+            );
+            self.write_validator_consensus_key(address, &consensus_key);
+            self.write_validator_state(address, &state);
+            self.write_validator_total_deltas(address, &total_deltas);
+            self.write_validator_voting_power(address, &voting_power);
+            self.write_bond(&bond_id, &bond);
+            self.init_staking_reward_account(
+                &staking_reward_address,
+                &staking_reward_key,
+            );
+        }
+        self.write_validator_set(&validator_set);
+        self.write_total_voting_power(&total_voting_power);
+        // Credit the bonded tokens to the PoS account
+        self.credit_tokens(
+            &Self::staking_token_address(),
+            &Self::POS_ADDRESS,
+            total_bonded_balance,
+        );
+        Ok(())
+    }
+
+    /// Calls a closure on each validator update element.
+    fn validator_set_update(
+        &self,
+        current_epoch: impl Into<Epoch>,
+        f: impl FnMut(ValidatorSetUpdate<Self::PublicKey>),
+    ) {
+        let current_epoch = current_epoch.into();
+        let validators = self.read_validator_set();
+        let validators = validators.get(current_epoch).unwrap();
+        let active_validators = validators.active.iter().map(
+            |WeightedValidator {
+                 voting_power,
+                 address,
+             }: &WeightedValidator<Self::Address>| {
+                let consensus_key = self
+                    .read_validator_consensus_key(address)
+                    .unwrap()
+                    .get(current_epoch)
+                    .unwrap()
+                    .clone();
+                ValidatorSetUpdate::Active(ActiveValidator {
+                    consensus_key,
+                    voting_power: *voting_power,
+                })
+            },
+        );
+        // TODO we only need inactive validators that were active in the last
+        // update
+        let inactive_validators = validators.inactive.iter().map(
+            |WeightedValidator {
+                 voting_power: _,
+                 address,
+             }: &WeightedValidator<Self::Address>| {
+                let consensus_key = self
+                    .read_validator_consensus_key(address)
+                    .unwrap()
+                    .get(current_epoch)
+                    .unwrap()
+                    .clone();
+                ValidatorSetUpdate::Deactivated(consensus_key)
+            },
+        );
+        active_validators.chain(inactive_validators).for_each(f)
+    }
+
+    /// Apply a slash to a byzantine validator for the given evidence.
+    fn slash(
+        &mut self,
+        params: &PosParams,
+        current_epoch: impl Into<Epoch>,
+        evidence_epoch: impl Into<Epoch>,
+        evidence_block_height: impl Into<u64>,
+        slash_type: SlashType,
+        validator: &Self::Address,
+    ) -> Result<(), SlashError<Self::Address>> {
+        let current_epoch = current_epoch.into();
+        let evidence_epoch = evidence_epoch.into();
+        let rate = match &slash_type {
+            SlashType::DuplicateVote => params.duplicate_vote_slash_rate,
+            SlashType::LightClientAttack => {
+                params.light_client_attack_slash_rate
+            }
+        };
+        let validator_slash = Slash {
+            epoch: evidence_epoch,
+            r#type: slash_type,
+            rate,
+            block_height: evidence_block_height.into(),
+        };
+
+        let mut total_deltas =
+            self.read_validator_total_deltas(validator).ok_or_else(|| {
+                SlashError::ValidatorHasNoTotalDeltas(validator.clone())
+            })?;
+        let mut voting_power =
+            self.read_validator_voting_power(validator).ok_or_else(|| {
+                SlashError::ValidatorHasNoVotingPower(validator.clone())
+            })?;
+        let mut validator_set = self.read_validator_set();
+        let mut total_voting_power = self.read_total_voting_power();
+
+        let slashed_change = slash(
+            params,
+            current_epoch,
+            validator,
+            &validator_slash,
+            &mut total_deltas,
+            &mut voting_power,
+            &mut validator_set,
+            &mut total_voting_power,
+        )?;
+        let slashed_change: i128 = slashed_change.into();
+        let slashed_amount = u64::try_from(slashed_change)
+            .map_err(|_err| SlashError::InvalidSlashChange(slashed_change))?;
+        let slashed_amount = Self::TokenAmount::from(slashed_amount);
+
+        self.write_validator_total_deltas(validator, &total_deltas);
+        self.write_validator_voting_power(validator, &voting_power);
+        self.write_validator_slash(validator, validator_slash);
+        self.write_validator_set(&validator_set);
+        self.write_total_voting_power(&total_voting_power);
+        // Transfer the slashed tokens to the PoS slash pool
+        self.transfer(
+            &Self::staking_token_address(),
+            slashed_amount,
+            &Self::POS_ADDRESS,
+            &Self::POS_SLASH_POOL_ADDRESS,
+        );
+        Ok(())
+    }
+}
+
+#[allow(missing_docs)]
+#[derive(Error, Debug)]
+pub enum GenesisError {
+    #[error("Voting power overflow: {0}")]
+    VotingPowerOverflow(TryFromIntError),
+}
+
+#[allow(missing_docs)]
+#[derive(Error, Debug)]
+pub enum BecomeValidatorError<Address: Display + Debug> {
+    #[error("The given address {0} is already a validator")]
+    AlreadyValidator(Address),
+}
+
+#[allow(missing_docs)]
+#[derive(Error, Debug)]
+pub enum BondError<Address: Display + Debug> {
+    #[error("The given address {0} is not a validator address")]
+    NotAValidator(Address),
+    #[error(
+        "The given source address {0} is a validator address. Validators may \
+         not delegate."
+    )]
+    SourceMustNotBeAValidator(Address),
+    #[error("The given validator address {0} is inactive")]
+    InactiveValidator(Address),
+    #[error("Voting power overflow: {0}")]
+    VotingPowerOverflow(TryFromIntError),
+    #[error("Given zero amount to unbond")]
+    ZeroAmount,
+}
+
+#[allow(missing_docs)]
+#[derive(Error, Debug)]
+pub enum UnbondError<Address: Display + Debug, TokenAmount: Display + Debug> {
+    #[error("No bond could be found")]
+    NoBondFound,
+    #[error(
+        "Trying to withdraw more tokens ({0}) than the amount bonded ({0})"
+    )]
+    UnbondAmountGreaterThanBond(TokenAmount, TokenAmount),
+    #[error("No bonds found for the validator {0}")]
+    ValidatorHasNoBonds(Address),
+    #[error("Voting power not found for the validator {0}")]
+    ValidatorHasNoVotingPower(Address),
+    #[error("Voting power overflow: {0}")]
+    VotingPowerOverflow(TryFromIntError),
+    #[error("Given zero amount to unbond")]
+    ZeroAmount,
+}
+
+#[allow(missing_docs)]
+#[derive(Error, Debug)]
+pub enum WithdrawError<Address>
+where
+    Address: Display + Debug + Clone + PartialOrd + Ord + Hash,
+{
+    #[error("No unbond could be found for {0}")]
+    NoUnbondFound(BondId<Address>),
+    #[error("No unbond may be withdrawn yet for {0}")]
+    NoWithdrawableUnbond(BondId<Address>),
+}
+
+#[allow(missing_docs)]
+#[derive(Error, Debug)]
+pub enum SlashError<Address>
+where
+    Address: Display + Debug + Clone + PartialOrd + Ord + Hash,
+{
+    #[error("The validator {0} has no total deltas value")]
+    ValidatorHasNoTotalDeltas(Address),
+    #[error("The validator {0} has no voting power")]
+    ValidatorHasNoVotingPower(Address),
+    #[error("Unexpected slash token change")]
+    InvalidSlashChange(i128),
+    #[error("Voting power overflow: {0}")]
+    VotingPowerOverflow(TryFromIntError),
+    #[error("Unexpected negative stake {0} for validator {1}")]
+    NegativeStake(i128, Address),
+}
+
+struct GenesisData<Validators, Address, TokenAmount, TokenChange, PK>
+where
+    Validators: Iterator<
+        Item = Result<
+            GenesisValidatorData<Address, TokenAmount, TokenChange, PK>,
+            GenesisError,
+        >,
+    >,
+    Address: Display
+        + Debug
+        + Clone
+        + Ord
+        + Hash
+        + BorshDeserialize
+        + BorshSerialize,
+    TokenAmount: Debug
+        + Default
+        + Clone
+        + Add<Output = TokenAmount>
+        + AddAssign
+        + BorshDeserialize
+        + BorshSerialize,
+    TokenChange: Debug
+        + Copy
+        + Add<Output = TokenChange>
+        + BorshDeserialize
+        + BorshSerialize,
+    PK: Debug + Clone + BorshDeserialize + BorshSerialize,
+{
+    validators: Validators,
+    /// Active and inactive validator sets
+    validator_set: ValidatorSets<Address>,
+    /// The sum of all active and inactive validators' voting power
+    total_voting_power: TotalVotingPowers,
+    /// The sum of all active and inactive validators' bonded tokens
+    total_bonded_balance: TokenAmount,
+}
+struct GenesisValidatorData<Address, TokenAmount, TokenChange, PK>
+where
+    Address: Display
+        + Debug
+        + Clone
+        + Ord
+        + Hash
+        + BorshDeserialize
+        + BorshSerialize,
+    TokenAmount: Debug
+        + Default
+        + Clone
+        + Add<Output = TokenAmount>
+        + AddAssign
+        + BorshDeserialize
+        + BorshSerialize,
+    TokenChange: Debug
+        + Copy
+        + Add<Output = TokenChange>
+        + BorshDeserialize
+        + BorshSerialize,
+    PK: Debug + Clone + BorshDeserialize + BorshSerialize,
+{
+    address: Address,
+    staking_reward_address: Address,
+    consensus_key: ValidatorConsensusKeys<PK>,
+    staking_reward_key: PK,
+    state: ValidatorStates,
+    total_deltas: ValidatorTotalDeltas<TokenChange>,
+    voting_power: ValidatorVotingPowers,
+    bond: (BondId<Address>, Bonds<TokenAmount>),
+}
+
+/// A function that returns genesis data created from the initial validator set.
+fn init_genesis<'a, Address, TokenAmount, TokenChange, PK>(
+    params: &'a PosParams,
+    validators: impl Iterator<Item = &'a GenesisValidator<Address, TokenAmount, PK>>
+    + Clone
+    + 'a,
+    current_epoch: Epoch,
+) -> Result<
+    GenesisData<
+        impl Iterator<
+            Item = Result<
+                GenesisValidatorData<Address, TokenAmount, TokenChange, PK>,
+                GenesisError,
+            >,
+        > + 'a,
+        Address,
+        TokenAmount,
+        TokenChange,
+        PK,
+    >,
+    GenesisError,
+>
+where
+    Address: 'a
+        + Display
+        + Debug
+        + Clone
+        + Ord
+        + Hash
+        + BorshDeserialize
+        + BorshSerialize,
+    TokenAmount: 'a
+        + Debug
+        + Default
+        + Clone
+        + Copy
+        + Add<Output = TokenAmount>
+        + AddAssign
+        + Into<u64>
+        + BorshDeserialize
+        + BorshSerialize,
+    TokenChange: 'a
+        + Debug
+        + Copy
+        + Add<Output = TokenChange>
+        + From<TokenAmount>
+        + BorshDeserialize
+        + BorshSerialize,
+    PK: 'a + Debug + Clone + BorshDeserialize + BorshSerialize,
+{
+    // Accumulate the validator set and total voting power
+    let mut active: BTreeSet<WeightedValidator<Address>> = BTreeSet::default();
+    let mut total_voting_power = VotingPowerDelta::default();
+    let mut total_bonded_balance = TokenAmount::default();
+    for GenesisValidator {
+        address, tokens, ..
+    } in validators.clone()
+    {
+        total_bonded_balance += *tokens;
+        let delta = VotingPowerDelta::try_from_tokens(*tokens, params)
+            .map_err(GenesisError::VotingPowerOverflow)?;
+        total_voting_power += delta;
+        let voting_power = VotingPower::from_tokens(*tokens, params);
+        active.insert(WeightedValidator {
+            voting_power,
+            address: address.clone(),
+        });
+    }
+    // Pop the smallest validators from the active set until its size is under
+    // the limit and insert them into the inactive set
+    let mut inactive: BTreeSet<WeightedValidator<Address>> =
+        BTreeSet::default();
+    while active.len() > params.max_validator_slots as usize {
+        match active.pop_first_shim() {
+            Some(first) => {
+                inactive.insert(first);
+            }
+            None => break,
+        }
+    }
+    let validator_set = ValidatorSet { active, inactive };
+    let validator_set = Epoched::init_at_genesis(validator_set, current_epoch);
+    let total_voting_power =
+        EpochedDelta::init_at_genesis(total_voting_power, current_epoch);
+
+    // Adapt the genesis validators data to PoS data
+    let validators = validators.map(
+        move |GenesisValidator {
+                  address,
+                  staking_reward_address,
+
+                  tokens,
+                  consensus_key,
+                  staking_reward_key,
+              }| {
+            let consensus_key =
+                Epoched::init_at_genesis(consensus_key.clone(), current_epoch);
+            let state = Epoched::init_at_genesis(
+                ValidatorState::Candidate,
+                current_epoch,
+            );
+            let token_delta = TokenChange::from(*tokens);
+            let total_deltas =
+                EpochedDelta::init_at_genesis(token_delta, current_epoch);
+            let voting_power =
+                VotingPowerDelta::try_from_tokens(*tokens, params)
+                    .map_err(GenesisError::VotingPowerOverflow)?;
+            let voting_power =
+                EpochedDelta::init_at_genesis(voting_power, current_epoch);
+            let bond_id = BondId {
+                source: address.clone(),
+                validator: address.clone(),
+            };
+            let mut deltas = HashMap::default();
+            deltas.insert(current_epoch, *tokens);
+            let bond =
+                EpochedDelta::init_at_genesis(Bond { deltas }, current_epoch);
+            Ok(GenesisValidatorData {
+                address: address.clone(),
+                staking_reward_address: staking_reward_address.clone(),
+                consensus_key,
+                staking_reward_key: staking_reward_key.clone(),
+                state,
+                total_deltas,
+                voting_power,
+                bond: (bond_id, bond),
+            })
+        },
+    );
+
+    Ok(GenesisData {
+        validators,
+        validator_set,
+        total_voting_power,
+        total_bonded_balance,
+    })
+}
+
+/// A function to apply a slash to byzantine validator.
+#[allow(clippy::too_many_arguments)]
+fn slash<Address, TokenChange>(
+    params: &PosParams,
+    current_epoch: Epoch,
+    validator: &Address,
+    slash: &Slash,
+    total_deltas: &mut ValidatorTotalDeltas<TokenChange>,
+    voting_power: &mut ValidatorVotingPowers,
+    validator_set: &mut ValidatorSets<Address>,
+    total_voting_power: &mut TotalVotingPowers,
+) -> Result<TokenChange, SlashError<Address>>
+where
+    Address: Display
+        + Debug
+        + Clone
+        + Ord
+        + Hash
+        + BorshDeserialize
+        + BorshSerialize,
+    TokenChange: Display
+        + Debug
+        + Copy
+        + Default
+        + Neg<Output = TokenChange>
+        + Add<Output = TokenChange>
+        + Sub<Output = TokenChange>
+        + From<i128>
+        + Into<i128>
+        + PartialOrd
+        + BorshDeserialize
+        + BorshSerialize,
+{
+    let current_stake: TokenChange =
+        total_deltas.get(current_epoch).unwrap_or_default();
+    if current_stake < TokenChange::default() {
+        return Err(SlashError::NegativeStake(
+            current_stake.into(),
+            validator.clone(),
+        ));
+    }
+    let raw_current_stake: i128 = current_stake.into();
+    let slashed_amount: TokenChange = (slash.rate * raw_current_stake).into();
+    let token_change = -slashed_amount;
+
+    // Apply slash at pipeline offset
+    let update_offset = DynEpochOffset::PipelineLen;
+
+    // Update validator set. This has to be done before we update the
+    // `validator_total_deltas`, because we need to look-up the validator with
+    // its voting power before the change.
+    update_validator_set(
+        params,
+        validator,
+        token_change,
+        update_offset,
+        validator_set,
+        Some(total_deltas),
+        current_epoch,
+    );
+
+    // Update validator's total deltas
+    total_deltas.add_at_offset(
+        token_change,
+        current_epoch,
+        update_offset,
+        params,
+    );
+
+    // Update the validator's and the total voting power.
+    update_voting_powers(
+        params,
+        update_offset,
+        total_deltas,
+        voting_power,
+        total_voting_power,
+        current_epoch,
+    )
+    .map_err(SlashError::VotingPowerOverflow)?;
+
+    Ok(slashed_amount)
+}
+
+struct BecomeValidatorData<PK>
+where
+    PK: Debug + Clone + BorshDeserialize + BorshSerialize,
+{
+    consensus_key: ValidatorConsensusKeys<PK>,
+    state: ValidatorStates,
+}
+
+/// A function that initialized data for a new validator.
+fn become_validator<Address, PK>(
+    params: &PosParams,
+    address: &Address,
+    consensus_key: &PK,
+    validator_set: &mut ValidatorSets<Address>,
+    current_epoch: Epoch,
+) -> BecomeValidatorData<PK>
+where
+    Address: Debug + Clone + Ord + Hash + BorshDeserialize + BorshSerialize,
+    PK: Debug + Clone + BorshDeserialize + BorshSerialize,
+{
+    let consensus_key =
+        Epoched::init(consensus_key.clone(), current_epoch, params);
+    let mut state =
+        Epoched::init(ValidatorState::Pending, current_epoch, params);
+    state.set(ValidatorState::Candidate, current_epoch, params);
+    validator_set.update_from_offset(
+        |validator_set, _epoch| {
+            let validator = WeightedValidator {
+                voting_power: VotingPower::default(),
+                address: address.clone(),
+            };
+            if validator_set.active.len() < params.max_validator_slots as usize
+            {
+                validator_set.active.insert(validator);
+            } else {
+                validator_set.inactive.insert(validator);
+            }
+        },
+        current_epoch,
+        DynEpochOffset::PipelineLen,
+        params,
+    );
+
+    BecomeValidatorData {
+        consensus_key,
+        state,
+    }
+}
+
+struct BondData<TokenAmount, TokenChange>
+where
+    TokenAmount: Debug
+        + Default
+        + Clone
+        + Copy
+        + Add<Output = TokenAmount>
+        + AddAssign
+        + BorshDeserialize
+        + BorshSerialize,
+    TokenChange: Debug
+        + Clone
+        + Copy
+        + Add<Output = TokenChange>
+        + BorshDeserialize
+        + BorshSerialize,
+{
+    pub bond: Bonds<TokenAmount>,
+    pub validator_total_deltas: ValidatorTotalDeltas<TokenChange>,
+    pub validator_voting_power: ValidatorVotingPowers,
+}
+
+/// Bond tokens to a validator (self-bond or delegation).
+#[allow(clippy::too_many_arguments)]
+fn bond_tokens<Address, TokenAmount, TokenChange>(
+    params: &PosParams,
+    validator_state: Option<ValidatorStates>,
+    bond_id: &BondId<Address>,
+    current_bond: Option<Bonds<TokenAmount>>,
+    amount: TokenAmount,
+    validator_total_deltas: Option<ValidatorTotalDeltas<TokenChange>>,
+    validator_voting_power: Option<ValidatorVotingPowers>,
+    total_voting_power: &mut TotalVotingPowers,
+    validator_set: &mut ValidatorSets<Address>,
+    current_epoch: Epoch,
+) -> Result<BondData<TokenAmount, TokenChange>, BondError<Address>>
+where
+    Address: Display
+        + Debug
+        + Clone
+        + PartialEq
+        + Eq
+        + PartialOrd
+        + Ord
+        + Hash
+        + BorshDeserialize
+        + BorshSerialize,
+    TokenAmount: Display
+        + Debug
+        + Default
+        + Clone
+        + Copy
+        + PartialEq
+        + Add<Output = TokenAmount>
+        + AddAssign
+        + Into<u64>
+        + BorshDeserialize
+        + BorshSerialize,
+    TokenChange: Display
+        + Debug
+        + Default
+        + Clone
+        + Copy
+        + Neg
+        + Add<Output = TokenChange>
+        + Sub
+        + From<TokenAmount>
+        + Into<i128>
+        + BorshDeserialize
+        + BorshSerialize,
+{
+    if amount == TokenAmount::default() {
+        return Err(BondError::ZeroAmount);
+    }
+    // Check the validator state
+    match validator_state {
+        None => {
+            return Err(BondError::NotAValidator(bond_id.validator.clone()));
+        }
+        Some(validator_state) => {
+            // Check that it's not inactive anywhere from the current epoch
+            // to the pipeline offset
+            for epoch in
+                current_epoch.iter_range(OffsetPipelineLen::value(params))
+            {
+                if let Some(ValidatorState::Inactive) =
+                    validator_state.get(epoch)
+                {
+                    return Err(BondError::InactiveValidator(
+                        bond_id.validator.clone(),
+                    ));
+                }
+            }
+        }
+    }
+
+    let update_offset = DynEpochOffset::PipelineLen;
+
+    // Update or create the bond
+    let mut value = Bond {
+        deltas: HashMap::default(),
+    };
+    value
+        .deltas
+        .insert(current_epoch + update_offset.value(params), amount);
+    let bond = match current_bond {
+        None => EpochedDelta::init(value, current_epoch, params),
+        Some(mut bond) => {
+            bond.add(value, current_epoch, params);
+            bond
+        }
+    };
+
+    // Update validator set. This has to be done before we update the
+    // `validator_total_deltas`, because we need to look-up the validator with
+    // its voting power before the change.
+    let token_change = TokenChange::from(amount);
+    update_validator_set(
+        params,
+        &bond_id.validator,
+        token_change,
+        update_offset,
+        validator_set,
+        validator_total_deltas.as_ref(),
+        current_epoch,
+    );
+
+    // Update validator's total deltas
+    let delta = TokenChange::from(amount);
+    let validator_total_deltas = match validator_total_deltas {
+        Some(mut validator_total_deltas) => {
+            validator_total_deltas.add_at_offset(
+                delta,
+                current_epoch,
+                update_offset,
+                params,
+            );
+            validator_total_deltas
+        }
+        None => EpochedDelta::init_at_offset(
+            delta,
+            current_epoch,
+            update_offset,
+            params,
+        ),
+    };
+
+    // Update the validator's and the total voting power.
+    let mut validator_voting_power = match validator_voting_power {
+        Some(voting_power) => voting_power,
+        None => EpochedDelta::init_at_offset(
+            VotingPowerDelta::default(),
+            current_epoch,
+            update_offset,
+            params,
+        ),
+    };
+    update_voting_powers(
+        params,
+        update_offset,
+        &validator_total_deltas,
+        &mut validator_voting_power,
+        total_voting_power,
+        current_epoch,
+    )
+    .map_err(BondError::VotingPowerOverflow)?;
+
+    Ok(BondData {
+        bond,
+        validator_total_deltas,
+        validator_voting_power,
+    })
+}
+
+struct UnbondData<TokenAmount>
+where
+    TokenAmount: Debug
+        + Default
+        + Clone
+        + Copy
+        + Add<Output = TokenAmount>
+        + AddAssign
+        + BorshDeserialize
+        + BorshSerialize,
+{
+    pub unbond: Unbonds<TokenAmount>,
+}
+
+/// Unbond tokens from a validator's bond (self-bond or delegation).
+#[allow(clippy::too_many_arguments)]
+fn unbond_tokens<Address, TokenAmount, TokenChange>(
+    params: &PosParams,
+    bond_id: &BondId<Address>,
+    bond: &mut Bonds<TokenAmount>,
+    unbond: Option<Unbonds<TokenAmount>>,
+    amount: TokenAmount,
+    slashes: Slashes,
+    validator_total_deltas: &mut ValidatorTotalDeltas<TokenChange>,
+    validator_voting_power: &mut ValidatorVotingPowers,
+    total_voting_power: &mut TotalVotingPowers,
+    validator_set: &mut ValidatorSets<Address>,
+    current_epoch: Epoch,
+) -> Result<UnbondData<TokenAmount>, UnbondError<Address, TokenAmount>>
+where
+    Address: Display
+        + Debug
+        + Clone
+        + PartialEq
+        + Eq
+        + PartialOrd
+        + Ord
+        + Hash
+        + BorshDeserialize
+        + BorshSerialize,
+    TokenAmount: Display
+        + Debug
+        + Default
+        + Clone
+        + Copy
+        + PartialOrd
+        + Add<Output = TokenAmount>
+        + AddAssign
+        + Into<u64>
+        + From<u64>
+        + SubAssign
+        + BorshDeserialize
+        + BorshSerialize,
+    TokenChange: Display
+        + Debug
+        + Default
+        + Clone
+        + Copy
+        + Add<Output = TokenChange>
+        + Sub
+        + From<TokenAmount>
+        + Neg<Output = TokenChange>
+        + Into<i128>
+        + BorshDeserialize
+        + BorshSerialize,
+{
+    if amount == TokenAmount::default() {
+        return Err(UnbondError::ZeroAmount);
+    }
+    // We can unbond tokens that are bonded for a future epoch (not yet
+    // active), hence we check the total at the pipeline offset
+    let unbondable_amount = bond
+        .get_at_offset(current_epoch, DynEpochOffset::PipelineLen, params)
+        .unwrap_or_default()
+        .sum();
+    if amount > unbondable_amount {
+        return Err(UnbondError::UnbondAmountGreaterThanBond(
+            amount,
+            unbondable_amount,
+        ));
+    }
+
+    let mut unbond = match unbond {
+        Some(unbond) => unbond,
+        None => EpochedDelta::init(Unbond::default(), current_epoch, params),
+    };
+
+    let update_offset = DynEpochOffset::UnbondingLen;
+    let mut to_unbond = amount;
+    let to_unbond = &mut to_unbond;
+    let mut slashed_amount = TokenAmount::default();
+    // Decrement the bond deltas starting from the rightmost value (a bond in a
+    // future-most epoch) until whole amount is decremented
+    bond.rev_update_while(
+        |bonds, _epoch| {
+            bonds.deltas.retain(|epoch_start, bond_delta| {
+                if *to_unbond == 0.into() {
+                    return true;
+                }
+                let mut unbonded = HashMap::default();
+                let unbond_end =
+                    current_epoch + update_offset.value(params) - 1;
+                // We need to accumulate the slashed delta for multiple slashes
+                // applicable to a bond, where each slash should be
+                // calculated from the delta reduced by the previous slash.
+                let applied_delta = if to_unbond > bond_delta {
+                    unbonded.insert((*epoch_start, unbond_end), *bond_delta);
+                    *to_unbond -= *bond_delta;
+                    let applied_delta = *bond_delta;
+                    *bond_delta = 0.into();
+                    applied_delta
+                } else {
+                    unbonded.insert((*epoch_start, unbond_end), *to_unbond);
+                    *bond_delta -= *to_unbond;
+                    let applied_delta = *to_unbond;
+                    *to_unbond = 0.into();
+                    applied_delta
+                };
+                // Calculate how much the bond delta would be after slashing
+                let mut slashed_bond_delta = applied_delta;
+                for slash in &slashes {
+                    if slash.epoch >= *epoch_start {
+                        let raw_delta: u64 = slashed_bond_delta.into();
+                        let raw_slashed_delta = slash.rate * raw_delta;
+                        let slashed_delta =
+                            TokenAmount::from(raw_slashed_delta);
+                        slashed_bond_delta -= slashed_delta;
+                    }
+                }
+                slashed_amount += slashed_bond_delta;
+
+                // For each decremented bond value write a new unbond
+                unbond.add(Unbond { deltas: unbonded }, current_epoch, params);
+                // Remove bonds with no tokens left
+                *bond_delta != 0.into()
+            });
+            // Stop the update once all the tokens are unbonded
+            *to_unbond != 0.into()
+        },
+        current_epoch,
+        params,
+    );
+
+    // Update validator set. This has to be done before we update the
+    // `validator_total_deltas`, because we need to look-up the validator with
+    // its voting power before the change.
+    let token_change = -TokenChange::from(slashed_amount);
+    update_validator_set(
+        params,
+        &bond_id.validator,
+        token_change,
+        update_offset,
+        validator_set,
+        Some(validator_total_deltas),
+        current_epoch,
+    );
+
+    // Update validator's total deltas
+    validator_total_deltas.add(token_change, current_epoch, params);
+
+    // Update the validator's and the total voting power.
+    update_voting_powers(
+        params,
+        update_offset,
+        validator_total_deltas,
+        validator_voting_power,
+        total_voting_power,
+        current_epoch,
+    )
+    .map_err(UnbondError::VotingPowerOverflow)?;
+
+    Ok(UnbondData { unbond })
+}
+
+/// Update validator set when a validator's receives a new bond and when its
+/// bond is unbonded (self-bond or delegation).
+fn update_validator_set<Address, TokenChange>(
+    params: &PosParams,
+    validator: &Address,
+    token_change: TokenChange,
+    change_offset: DynEpochOffset,
+    validator_set: &mut ValidatorSets<Address>,
+    validator_total_deltas: Option<&ValidatorTotalDeltas<TokenChange>>,
+    current_epoch: Epoch,
+) where
+    Address: Display
+        + Debug
+        + Clone
+        + PartialEq
+        + Eq
+        + PartialOrd
+        + Ord
+        + Hash
+        + BorshDeserialize
+        + BorshSerialize,
+    TokenChange: Display
+        + Default
+        + Debug
+        + Clone
+        + Copy
+        + Add<Output = TokenChange>
+        + Sub
+        + Into<i128>
+        + BorshDeserialize
+        + BorshSerialize,
+{
+    validator_set.update_from_offset(
+        |validator_set, epoch| {
+            // Find the validator's voting power at the epoch that's being
+            // updated from its total deltas
+            let tokens_pre = validator_total_deltas
+                .and_then(|d| d.get(epoch))
+                .unwrap_or_default();
+            let tokens_post = tokens_pre + token_change;
+            let tokens_pre: i128 = tokens_pre.into();
+            let tokens_post: i128 = tokens_post.into();
+            let tokens_pre: u64 = TryFrom::try_from(tokens_pre).unwrap();
+            let tokens_post: u64 = TryFrom::try_from(tokens_post).unwrap();
+            let voting_power_pre = VotingPower::from_tokens(tokens_pre, params);
+            let voting_power_post =
+                VotingPower::from_tokens(tokens_post, params);
+            if voting_power_pre != voting_power_post {
+                let validator_pre = WeightedValidator {
+                    voting_power: voting_power_pre,
+                    address: validator.clone(),
+                };
+                let validator_post = WeightedValidator {
+                    voting_power: voting_power_post,
+                    address: validator.clone(),
+                };
+
+                if validator_set.inactive.contains(&validator_pre) {
+                    let min_active_validator =
+                        validator_set.active.first_shim();
+                    let min_voting_power = min_active_validator
+                        .map(|v| v.voting_power)
+                        .unwrap_or_default();
+                    if voting_power_pre > min_voting_power {
+                        let deactivate_min =
+                            validator_set.active.pop_first_shim();
+                        let popped =
+                            validator_set.inactive.remove(&validator_pre);
+                        debug_assert!(popped);
+                        validator_set.active.insert(validator_post);
+                        if let Some(deactivate_min) = deactivate_min {
+                            validator_set.inactive.insert(deactivate_min);
+                        }
+                    } else {
+                        validator_set.inactive.remove(&validator_pre);
+                        validator_set.inactive.insert(validator_post);
+                    }
+                } else {
+                    debug_assert!(
+                        validator_set.active.contains(&validator_pre)
+                    );
+                    let max_inactive_validator =
+                        validator_set.inactive.last_shim();
+                    let max_voting_power = max_inactive_validator
+                        .map(|v| v.voting_power)
+                        .unwrap_or_default();
+                    if voting_power_pre < max_voting_power {
+                        let activate_max =
+                            validator_set.inactive.pop_last_shim();
+                        let popped =
+                            validator_set.active.remove(&validator_pre);
+                        debug_assert!(popped);
+                        validator_set.inactive.insert(validator_pre);
+                        if let Some(activate_max) = activate_max {
+                            validator_set.active.insert(activate_max);
+                        }
+                    } else {
+                        validator_set.active.remove(&validator_pre);
+                        validator_set.active.insert(validator_post);
+                    }
+                }
+            }
+        },
+        current_epoch,
+        change_offset,
+        params,
+    )
+}
+
+/// Update the validator's voting power and the total voting power.
+fn update_voting_powers<TokenChange>(
+    params: &PosParams,
+    change_offset: DynEpochOffset,
+    validator_total_deltas: &ValidatorTotalDeltas<TokenChange>,
+    validator_voting_power: &mut ValidatorVotingPowers,
+    total_voting_power: &mut TotalVotingPowers,
+    current_epoch: Epoch,
+) -> Result<(), TryFromIntError>
+where
+    TokenChange: Display
+        + Debug
+        + Default
+        + Clone
+        + Copy
+        + Add<Output = TokenChange>
+        + Sub
+        + Into<i128>
+        + BorshDeserialize
+        + BorshSerialize,
+{
+    let change_offset = change_offset.value(params);
+    let start_epoch = current_epoch + change_offset;
+    // Update voting powers from the change offset to the the last epoch of
+    // voting powers data (unbonding epoch)
+    let epochs = start_epoch.iter_range(
+        DynEpochOffset::UnbondingLen.value(params) - change_offset + 1,
+    );
+    for epoch in epochs {
+        // Recalculate validator's voting power from validator's total deltas
+        let total_deltas_at_pipeline =
+            validator_total_deltas.get(epoch).unwrap_or_default();
+        let total_deltas_at_pipeline: i128 = total_deltas_at_pipeline.into();
+        let total_deltas_at_pipeline: u64 =
+            TryFrom::try_from(total_deltas_at_pipeline).unwrap();
+        let voting_power_at_pipeline =
+            validator_voting_power.get(epoch).unwrap_or_default();
+        let voting_power_delta = VotingPowerDelta::try_from_tokens(
+            total_deltas_at_pipeline,
+            params,
+        )? - voting_power_at_pipeline;
+
+        validator_voting_power.add_at_epoch(
+            voting_power_delta,
+            current_epoch,
+            epoch,
+            params,
+        );
+
+        // Update total voting power
+        total_voting_power.add_at_epoch(
+            voting_power_delta,
+            current_epoch,
+            epoch,
+            params,
+        );
+    }
+    Ok(())
+}
+
+struct WithdrawData<TokenAmount>
+where
+    TokenAmount: Debug
+        + Default
+        + Clone
+        + Copy
+        + Add<Output = TokenAmount>
+        + AddAssign
+        + BorshDeserialize
+        + BorshSerialize,
+{
+    pub unbond: Unbonds<TokenAmount>,
+    pub withdrawn: TokenAmount,
+    pub slashed: TokenAmount,
+}
+
+/// Withdraw tokens from unbonds of self-bonds or delegations.
+fn withdraw_unbonds<Address, TokenAmount>(
+    params: &PosParams,
+    bond_id: &BondId<Address>,
+    unbond: Option<Unbonds<TokenAmount>>,
+    slashes: Vec<Slash>,
+    current_epoch: Epoch,
+) -> Result<WithdrawData<TokenAmount>, WithdrawError<Address>>
+where
+    Address: Display
+        + Debug
+        + Clone
+        + PartialEq
+        + Eq
+        + PartialOrd
+        + Ord
+        + Hash
+        + BorshDeserialize
+        + BorshSerialize,
+    TokenAmount: Display
+        + Debug
+        + Default
+        + Clone
+        + Copy
+        + PartialOrd
+        + Add<Output = TokenAmount>
+        + AddAssign
+        + Into<u64>
+        + From<u64>
+        + SubAssign
+        + BorshDeserialize
+        + BorshSerialize,
+{
+    let mut unbond =
+        unbond.ok_or_else(|| WithdrawError::NoUnbondFound(bond_id.clone()))?;
+    let withdrawable_unbond = unbond
+        .get(current_epoch)
+        .ok_or_else(|| WithdrawError::NoWithdrawableUnbond(bond_id.clone()))?;
+    let mut slashed = TokenAmount::default();
+    let withdrawn_amount = withdrawable_unbond.deltas.iter().fold(
+        TokenAmount::default(),
+        |sum, ((epoch_start, epoch_end), delta)| {
+            let mut delta = *delta;
+            // Check and apply slashes, if any
+            for slash in &slashes {
+                if slash.epoch >= *epoch_start && slash.epoch <= *epoch_end {
+                    let raw_delta: u64 = delta.into();
+                    let current_slashed =
+                        TokenAmount::from(slash.rate * raw_delta);
+                    slashed += current_slashed;
+                    delta -= current_slashed;
+                }
+            }
+            sum + delta
+        },
+    );
+    unbond.delete_current(current_epoch, params);
+    Ok(WithdrawData {
+        unbond,
+        withdrawn: withdrawn_amount,
+        slashed,
+    })
+}

--- a/proof_of_stake/src/parameters.rs
+++ b/proof_of_stake/src/parameters.rs
@@ -1,0 +1,51 @@
+//! Proof-of-Stake system parameters
+
+use borsh::{BorshDeserialize, BorshSerialize};
+
+use crate::types::BasisPoints;
+
+/// Proof-of-Stake system parameters
+#[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
+pub struct PosParams {
+    /// A maximum number of active validators
+    pub max_validator_slots: u64,
+    /// Any change applied during an epoch `n` will become active at the
+    /// beginning of epoch `n + pipeline_len`.
+    pub pipeline_len: u64,
+    /// How many epochs after a committed fault a validator can be slashed.
+    /// If a fault is detected in epoch `n`, it can slashed up until the end of
+    /// `n + slashable_period_len` epoch.
+    pub unbonding_len: u64,
+    /// Used in validators' voting power calculation. Given in basis points
+    /// (voting power per ten thousand tokens).
+    pub votes_per_token: BasisPoints,
+    /// Amount of tokens rewarded to a validator for proposing a block
+    pub block_proposer_reward: u64,
+    /// Amount of tokens rewarded to each validator that voted on a block
+    /// proposal
+    pub block_vote_reward: u64,
+    /// Portion of validator's stake that should be slashed on a duplicate
+    /// vote. Given in basis points (slashed amount per ten thousand tokens).
+    pub duplicate_vote_slash_rate: BasisPoints,
+    /// Portion of validator's stake that should be slashed on a light client
+    /// attack. Given in basis points (slashed amount per ten thousand tokens).
+    pub light_client_attack_slash_rate: BasisPoints,
+}
+
+impl Default for PosParams {
+    fn default() -> Self {
+        Self {
+            max_validator_slots: 128,
+            pipeline_len: 2,
+            unbonding_len: 6,
+            // 1 voting power per 1000 tokens
+            votes_per_token: BasisPoints::new(10),
+            block_proposer_reward: 100,
+            block_vote_reward: 1,
+            // slash 5%
+            duplicate_vote_slash_rate: BasisPoints::new(500),
+            // slash 5%
+            light_client_attack_slash_rate: BasisPoints::new(500),
+        }
+    }
+}

--- a/proof_of_stake/src/types.rs
+++ b/proof_of_stake/src/types.rs
@@ -1,0 +1,675 @@
+//! Proof of Stake data types
+
+use core::fmt::Debug;
+use std::collections::{BTreeSet, HashMap};
+use std::convert::TryFrom;
+use std::fmt::Display;
+use std::hash::Hash;
+use std::num::TryFromIntError;
+use std::ops::{Add, AddAssign, Mul, Sub};
+
+use borsh::{BorshDeserialize, BorshSerialize};
+
+use crate::epoched::{
+    Epoched, EpochedDelta, OffsetPipelineLen, OffsetUnboundingLen,
+};
+use crate::parameters::PosParams;
+
+/// Epoched validator's consensus key.
+pub type ValidatorConsensusKeys<PublicKey> =
+    Epoched<PublicKey, OffsetPipelineLen>;
+/// Epoched validator's state.
+pub type ValidatorStates = Epoched<ValidatorState, OffsetPipelineLen>;
+/// Epoched validator's total deltas.
+pub type ValidatorTotalDeltas<TokenChange> =
+    EpochedDelta<TokenChange, OffsetUnboundingLen>;
+/// Epoched validator's voting power.
+pub type ValidatorVotingPowers =
+    EpochedDelta<VotingPowerDelta, OffsetUnboundingLen>;
+/// Epoched bond.
+pub type Bonds<TokenAmount> =
+    EpochedDelta<Bond<TokenAmount>, OffsetPipelineLen>;
+/// Epoched unbond.
+pub type Unbonds<TokenAmount> =
+    EpochedDelta<Unbond<TokenAmount>, OffsetUnboundingLen>;
+/// Epoched validator set.
+pub type ValidatorSets<Address> =
+    Epoched<ValidatorSet<Address>, OffsetUnboundingLen>;
+/// Epoched total voting power.
+pub type TotalVotingPowers =
+    EpochedDelta<VotingPowerDelta, OffsetUnboundingLen>;
+
+/// Epoch identifier. Epochs are identified by consecutive natural numbers.
+///
+/// In the API functions, this type is wrapped in [`Into`]. When using this
+/// library, to replace [`Epoch`] with a custom type, simply implement [`From`]
+/// to and from the types here.
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    BorshDeserialize,
+    BorshSerialize,
+)]
+pub struct Epoch(u64);
+
+/// Voting power is calculated from staked tokens.
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    BorshDeserialize,
+    BorshSerialize,
+)]
+pub struct VotingPower(u64);
+
+/// A change of voting power.
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    BorshDeserialize,
+    BorshSerialize,
+)]
+pub struct VotingPowerDelta(i64);
+
+/// A genesis validator definition.
+#[derive(Debug, Clone)]
+pub struct GenesisValidator<Address, Token, PK> {
+    /// Validator's address
+    pub address: Address,
+    /// An address to which any staking rewards will be credited, must be
+    /// different from the `address`
+    pub staking_reward_address: Address,
+    /// Staked tokens are put into a self-bond
+    pub tokens: Token,
+    /// A public key used for signing validator's consensus actions
+    pub consensus_key: PK,
+    /// An public key associated with the staking reward address
+    pub staking_reward_key: PK,
+}
+
+/// An update of the active and inactive validator set.
+#[derive(Debug, Clone)]
+pub enum ValidatorSetUpdate<PK> {
+    /// A validator is active
+    Active(ActiveValidator<PK>),
+    /// A validator who was active in the last update and is now inactive
+    Deactivated(PK),
+}
+
+/// Active validator's consensus key and its voting power.
+#[derive(Debug, Clone)]
+pub struct ActiveValidator<PK> {
+    /// A public key used for signing validator's consensus actions
+    pub consensus_key: PK,
+    /// Voting power
+    pub voting_power: VotingPower,
+}
+
+/// ID of a bond and/or an unbond.
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    BorshDeserialize,
+    BorshSerialize,
+)]
+pub struct BondId<Address>
+where
+    Address: Display + Debug + Clone + PartialEq + Eq + PartialOrd + Ord + Hash,
+{
+    /// (Un)bond's source address is the owner of the bonded tokens.
+    pub source: Address,
+    /// (Un)bond's validator address.
+    pub validator: Address,
+}
+
+/// Validator's address with its voting power.
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    BorshDeserialize,
+    BorshSerialize,
+)]
+pub struct WeightedValidator<Address>
+where
+    Address: Debug
+        + Clone
+        + PartialEq
+        + Eq
+        + PartialOrd
+        + Ord
+        + Hash
+        + BorshDeserialize
+        + BorshSerialize,
+{
+    /// The `voting_power` field must be on top, because lexicographic ordering
+    /// is based on the top-to-bottom declaration order and in the
+    /// `ValidatorSet` the `WeighedValidator`s these need to be sorted by
+    /// the `voting_power`.
+    pub voting_power: VotingPower,
+    /// Validator's address
+    pub address: Address,
+}
+
+impl<Address> Display for WeightedValidator<Address>
+where
+    Address: Display
+        + Debug
+        + Clone
+        + PartialEq
+        + Eq
+        + PartialOrd
+        + Ord
+        + Hash
+        + BorshDeserialize
+        + BorshSerialize,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} with voting power {}",
+            self.address, self.voting_power
+        )
+    }
+}
+
+/// Active and inactive validator sets.
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    BorshDeserialize,
+    BorshSerialize,
+)]
+pub struct ValidatorSet<Address>
+where
+    Address: Debug
+        + Clone
+        + PartialEq
+        + Eq
+        + PartialOrd
+        + Ord
+        + Hash
+        + BorshDeserialize
+        + BorshSerialize,
+{
+    /// Active validator set with maximum size equal to `max_validator_slots`
+    /// in [`PosParams`].
+    pub active: BTreeSet<WeightedValidator<Address>>,
+    /// All the other validators that are not active
+    pub inactive: BTreeSet<WeightedValidator<Address>>,
+}
+
+/// Validator's state.
+#[derive(Debug, Clone, Copy, BorshDeserialize, BorshSerialize)]
+pub enum ValidatorState {
+    /// Inactive validator may not participate in the consensus.
+    Inactive,
+    /// A `Pending` validator will become `Candidate` in a future epoch.
+    Pending,
+    /// A `Candidate` validator may participate in the consensus. It is either
+    /// in the active or inactive validator set.
+    Candidate,
+    // TODO consider adding `Jailed`
+}
+
+/// A bond is validator's self-bond or a delegation from a regular account to a
+/// validator.
+#[derive(Debug, Clone, Default, BorshDeserialize, BorshSerialize)]
+pub struct Bond<Token: Default> {
+    /// A key is a the epoch set for the bond. This is used in unbonding, where
+    /// it's needed for slash epoch range check.
+    ///
+    /// TODO: For Bonds, there's unnecessary redundancy with this hash map.
+    /// We only need to keep the start `Epoch` for the Epoched head element
+    /// (i.e. the current epoch data), the rest of the array can be calculated
+    /// from the offset from the head
+    pub deltas: HashMap<Epoch, Token>,
+}
+
+/// An unbond contains unbonded tokens from a validator's self-bond or a
+/// delegation from a regular account to a validator.
+#[derive(Debug, Clone, Default, BorshDeserialize, BorshSerialize)]
+pub struct Unbond<Token: Default> {
+    /// A key is a pair of the epoch of the bond from which a unbond was
+    /// created the epoch of unbonding. This is needed for slash epoch range
+    /// check.
+    pub deltas: HashMap<(Epoch, Epoch), Token>,
+}
+
+/// A slash applied to validator, to punish byzantine behavior by removing
+/// their staked tokens at and before the epoch of the slash.
+#[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
+pub struct Slash {
+    /// Epoch at which the slashable event occurred.
+    pub epoch: Epoch,
+    /// Block height at which the slashable event occurred.
+    pub block_height: u64,
+    /// A type of slashsable event.
+    pub r#type: SlashType,
+    /// A rate is the portion of staked tokens that are slashed.
+    pub rate: BasisPoints,
+}
+
+/// Slashes applied to validator, to punish byzantine behavior by removing
+/// their staked tokens at and before the epoch of the slash.
+pub type Slashes = Vec<Slash>;
+
+/// A type of slashsable event.
+#[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
+pub enum SlashType {
+    /// Duplicate block vote.
+    DuplicateVote,
+    /// Light client attack.
+    LightClientAttack,
+}
+
+/// ‱ (Parts per ten thousand). This can be multiplied by any type that
+/// implements [`Into<u64>`] or [`Into<i128>`].
+#[derive(Debug, Clone, Copy, BorshDeserialize, BorshSerialize)]
+pub struct BasisPoints(u64);
+
+impl VotingPower {
+    /// Convert token amount into a voting power.
+    pub fn from_tokens(tokens: impl Into<u64>, params: &PosParams) -> Self {
+        Self(params.votes_per_token * tokens.into() / 1_000_000)
+    }
+}
+
+impl VotingPowerDelta {
+    /// Try to convert token change into a voting power change.
+    pub fn try_from_token_change(
+        change: impl Into<i128>,
+        params: &PosParams,
+    ) -> Result<Self, TryFromIntError> {
+        let delta: i128 = params.votes_per_token * change.into() / 1_000_000;
+        let delta: i64 = TryFrom::try_from(delta)?;
+        Ok(Self(delta))
+    }
+
+    /// Try to convert token amount into a voting power change.
+    pub fn try_from_tokens(
+        tokens: impl Into<u64>,
+        params: &PosParams,
+    ) -> Result<Self, TryFromIntError> {
+        let delta: i64 = TryFrom::try_from(
+            params.votes_per_token * tokens.into() / 1_000_000,
+        )?;
+        Ok(Self(delta))
+    }
+}
+
+impl TryFrom<VotingPower> for VotingPowerDelta {
+    type Error = TryFromIntError;
+
+    fn try_from(value: VotingPower) -> Result<Self, Self::Error> {
+        let delta: i64 = TryFrom::try_from(value.0)?;
+        Ok(Self(delta))
+    }
+}
+
+impl TryFrom<VotingPowerDelta> for VotingPower {
+    type Error = TryFromIntError;
+
+    fn try_from(value: VotingPowerDelta) -> Result<Self, Self::Error> {
+        let vp: u64 = TryFrom::try_from(value.0)?;
+        Ok(Self(vp))
+    }
+}
+
+impl Display for VotingPower {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Display for VotingPowerDelta {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Epoch {
+    /// Iterate a range of consecutive epochs starting from `self` of a given
+    /// length. Work-around for `Step` implementation pending on stabilization of <https://github.com/rust-lang/rust/issues/42168>.
+    pub fn iter_range(self, len: u64) -> impl Iterator<Item = Epoch> + Clone {
+        let start_ix: u64 = self.into();
+        let end_ix: u64 = start_ix + len;
+        (start_ix..end_ix).map(Epoch::from)
+    }
+
+    /// Checked epoch subtraction. Computes self - rhs, returning None if
+    /// overflow occurred.
+    #[must_use = "this returns the result of the operation, without modifying \
+                  the original"]
+    pub fn checked_sub(self, rhs: Epoch) -> Option<Self> {
+        if rhs.0 > self.0 {
+            None
+        } else {
+            Some(Self(self.0 - rhs.0))
+        }
+    }
+
+    /// Checked epoch subtraction. Computes self - rhs, returning default
+    /// `Epoch(0)` if overflow occurred.
+    #[must_use = "this returns the result of the operation, without modifying \
+                  the original"]
+    pub fn sub_or_default(self, rhs: Epoch) -> Self {
+        self.checked_sub(rhs).unwrap_or_default()
+    }
+}
+
+impl From<u64> for Epoch {
+    fn from(epoch: u64) -> Self {
+        Epoch(epoch)
+    }
+}
+
+impl From<Epoch> for u64 {
+    fn from(epoch: Epoch) -> Self {
+        epoch.0
+    }
+}
+
+impl From<Epoch> for usize {
+    fn from(epoch: Epoch) -> Self {
+        epoch.0 as usize
+    }
+}
+
+impl Add<u64> for Epoch {
+    type Output = Self;
+
+    fn add(self, rhs: u64) -> Self::Output {
+        Epoch(self.0 + rhs)
+    }
+}
+
+impl Add<usize> for Epoch {
+    type Output = Self;
+
+    fn add(self, rhs: usize) -> Self::Output {
+        Epoch(self.0 + rhs as u64)
+    }
+}
+
+impl Sub<u64> for Epoch {
+    type Output = Epoch;
+
+    fn sub(self, rhs: u64) -> Self::Output {
+        Epoch(self.0 - rhs)
+    }
+}
+
+impl Sub<Epoch> for Epoch {
+    type Output = Self;
+
+    fn sub(self, rhs: Epoch) -> Self::Output {
+        Epoch(self.0 - rhs.0)
+    }
+}
+
+impl Display for Epoch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<Address> Display for BondId<Address>
+where
+    Address: Display + Debug + Clone + PartialEq + Eq + PartialOrd + Ord + Hash,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{{source: {}, validator: {}}}",
+            self.source, self.validator
+        )
+    }
+}
+
+impl<Token> Bond<Token>
+where
+    Token: Clone + Copy + Add<Output = Token> + Default,
+{
+    /// Find the sum of all the bonds amounts.
+    pub fn sum(&self) -> Token {
+        self.deltas
+            .iter()
+            .fold(Default::default(), |acc, (_epoch, amount)| acc + *amount)
+    }
+}
+
+impl<Token> Add for Bond<Token>
+where
+    Token: Clone + AddAssign + Default,
+{
+    type Output = Self;
+
+    fn add(mut self, rhs: Self) -> Self::Output {
+        // This is almost the same as `self.delta.extend(rhs.delta);`, except
+        // that we add values where a key is present on both sides.
+        let iter = rhs.deltas.into_iter();
+        let reserve = if self.deltas.is_empty() {
+            iter.size_hint().0
+        } else {
+            (iter.size_hint().0 + 1) / 2
+        };
+        self.deltas.reserve(reserve);
+        iter.for_each(|(k, v)| {
+            // Add or insert
+            match self.deltas.get_mut(&k) {
+                Some(value) => *value += v,
+                None => {
+                    self.deltas.insert(k, v);
+                }
+            }
+        });
+        self
+    }
+}
+
+impl<Token> Unbond<Token>
+where
+    Token: Clone + Copy + Add<Output = Token> + Default,
+{
+    /// Find the sum of all the unbonds amounts.
+    pub fn sum(&self) -> Token {
+        self.deltas
+            .iter()
+            .fold(Default::default(), |acc, (_epoch, amount)| acc + *amount)
+    }
+}
+
+impl<Token> Add for Unbond<Token>
+where
+    Token: Clone + AddAssign + Default,
+{
+    type Output = Self;
+
+    fn add(mut self, rhs: Self) -> Self::Output {
+        // This is almost the same as `self.deltas.extend(rhs.deltas);`, except
+        // that we add values where a key is present on both sides.
+        let iter = rhs.deltas.into_iter();
+        let reserve = if self.deltas.is_empty() {
+            iter.size_hint().0
+        } else {
+            (iter.size_hint().0 + 1) / 2
+        };
+        self.deltas.reserve(reserve);
+        iter.for_each(|(k, v)| {
+            // Add or insert
+            match self.deltas.get_mut(&k) {
+                Some(value) => *value += v,
+                None => {
+                    self.deltas.insert(k, v);
+                }
+            }
+        });
+        self
+    }
+}
+
+impl From<u64> for VotingPower {
+    fn from(voting_power: u64) -> Self {
+        Self(voting_power)
+    }
+}
+
+impl From<VotingPower> for u64 {
+    fn from(vp: VotingPower) -> Self {
+        vp.0
+    }
+}
+
+impl Add for VotingPower {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(self.0 + rhs.0)
+    }
+}
+
+impl AddAssign for VotingPower {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0
+    }
+}
+
+impl From<i64> for VotingPowerDelta {
+    fn from(delta: i64) -> Self {
+        Self(delta)
+    }
+}
+
+impl From<VotingPowerDelta> for i64 {
+    fn from(vp: VotingPowerDelta) -> Self {
+        vp.0
+    }
+}
+
+impl Add for VotingPowerDelta {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(self.0 + rhs.0)
+    }
+}
+
+impl AddAssign for VotingPowerDelta {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0
+    }
+}
+
+impl Sub for VotingPowerDelta {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self(self.0 - rhs.0)
+    }
+}
+
+impl Sub<i64> for VotingPowerDelta {
+    type Output = Self;
+
+    fn sub(self, rhs: i64) -> Self::Output {
+        Self(self.0 - rhs)
+    }
+}
+
+impl<Address, Token, PK> GenesisValidator<Address, Token, PK>
+where
+    Token: Copy + Into<u64>,
+{
+    /// Calculate validator's voting power
+    pub fn voting_power(&self, params: &PosParams) -> VotingPower {
+        VotingPower::from_tokens(self.tokens, params)
+    }
+}
+
+impl Display for SlashType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SlashType::DuplicateVote => write!(f, "Duplicate vote"),
+            SlashType::LightClientAttack => write!(f, "Light client attack"),
+        }
+    }
+}
+
+impl BasisPoints {
+    /// Initialize basis points from an integer.
+    pub fn new(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl Display for BasisPoints {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}‱", self.0)
+    }
+}
+
+impl Mul<u64> for BasisPoints {
+    type Output = u64;
+
+    fn mul(self, rhs: u64) -> Self::Output {
+        // TODO checked arithmetics
+        rhs * self.0 / 10_000
+    }
+}
+
+impl Mul<i128> for BasisPoints {
+    type Output = i128;
+
+    fn mul(self, rhs: i128) -> Self::Output {
+        // TODO checked arithmetics
+        rhs * self.0 as i128 / 10_000
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+
+    use std::ops::Range;
+
+    use proptest::prelude::*;
+
+    use super::*;
+
+    /// Generate arbitrary epoch in given range
+    pub fn arb_epoch(range: Range<u64>) -> impl Strategy<Value = Epoch> {
+        range.prop_map(Epoch)
+    }
+}

--- a/proof_of_stake/src/types.rs
+++ b/proof_of_stake/src/types.rs
@@ -619,6 +619,19 @@ where
     }
 }
 
+impl SlashType {
+    /// Get the slash rate applicable to the given slash type from the PoS
+    /// parameters.
+    pub fn get_slash_rate(&self, params: &PosParams) -> BasisPoints {
+        match self {
+            SlashType::DuplicateVote => params.duplicate_vote_slash_rate,
+            SlashType::LightClientAttack => {
+                params.light_client_attack_slash_rate
+            }
+        }
+    }
+}
+
 impl Display for SlashType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/proof_of_stake/src/validation.rs
+++ b/proof_of_stake/src/validation.rs
@@ -1,0 +1,1295 @@
+//! Validation of updated PoS data
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::fmt::{Debug, Display};
+use std::hash::Hash;
+use std::ops::{Add, AddAssign, Neg, Sub, SubAssign};
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use thiserror::Error;
+
+use crate::btree_set::BTreeSetShims;
+use crate::epoched::DynEpochOffset;
+use crate::parameters::PosParams;
+use crate::types::{
+    BondId, Bonds, Epoch, Slashes, TotalVotingPowers, Unbonds, ValidatorSets,
+    ValidatorTotalDeltas, ValidatorVotingPowers, VotingPower, VotingPowerDelta,
+    WeightedValidator,
+};
+
+#[allow(missing_docs)]
+#[derive(Error, Debug)]
+pub enum Error<Address, TokenChange>
+where
+    Address: Display
+        + Debug
+        + Clone
+        + PartialEq
+        + Eq
+        + PartialOrd
+        + Ord
+        + Hash
+        + BorshSerialize
+        + BorshDeserialize,
+    TokenChange: Debug + Display,
+{
+    #[error("Validator staking reward address is required for validator {0}")]
+    StakingRewardAddressIsRequired(Address),
+    #[error(
+        "Staking reward address must be different from the validator's \
+         address {0}"
+    )]
+    StakingRewardAddressEqValidator(Address),
+    #[error("Unexpectedly missing total deltas value for validator {0}")]
+    MissingValidatorTotalDeltas(Address),
+    #[error("The sum of total deltas for validator {0} are negative")]
+    NegativeValidatorTotalDeltasSum(Address),
+    #[error("Unexpectedly missing balance value")]
+    MissingBalance,
+    #[error("Last update should be equal to the current epoch")]
+    InvalidLastUpdate,
+    #[error(
+        "Invalid staking token balances. Balance Δ {balance_delta}, bonds Δ \
+         {bond_delta}, unbonds Δ {unbond_delta}"
+    )]
+    InvalidBalances {
+        balance_delta: TokenChange,
+        bond_delta: TokenChange,
+        unbond_delta: TokenChange,
+    },
+    #[error(
+        "Data must be set or updated in the correct epoch. Got epoch {got}, \
+         expected one of {expected:?}"
+    )]
+    EpochedDataWrongEpoch { got: u64, expected: Vec<u64> },
+    #[error("Empty bond {0} must be deleted")]
+    EmptyBond(BondId<Address>),
+    #[error(
+        "Bond ID {id} must start at the correct epoch. Got epoch {got}, \
+         expected {expected}"
+    )]
+    InvalidBondStartEpoch {
+        id: BondId<Address>,
+        got: u64,
+        expected: u64,
+    },
+    #[error(
+        "Bond ID {id} must be added at the correct epoch. Got epoch {got}, \
+         expected {expected}"
+    )]
+    InvalidNewBondEpoch {
+        id: BondId<Address>,
+        got: u64,
+        expected: u64,
+    },
+    #[error(
+        "Invalid validator {address} sum of total deltas. Total Δ \
+         {total_delta}, bonds Δ {bond_delta}"
+    )]
+    InvalidValidatorTotalDeltasSum {
+        address: Address,
+        total_delta: TokenChange,
+        bond_delta: TokenChange,
+    },
+    #[error("Unexpectedly missing validator set value")]
+    MissingValidatorSet,
+    #[error("Validator {0} not found in the validator set in epoch {1}")]
+    WeightedValidatorNotFound(WeightedValidator<Address>, u64),
+    #[error("Duplicate validator {0} in the validator set in epoch {1}")]
+    ValidatorSetDuplicate(WeightedValidator<Address>, u64),
+    #[error("Validator {0} has an invalid total deltas value {1}")]
+    InvalidValidatorTotalDeltas(Address, i128),
+    #[error("There are too many active validators in the validator set")]
+    TooManyActiveValidators,
+    #[error(
+        "An inactive validator {0} has voting power greater than an active \
+         validator {1}"
+    )]
+    ValidatorSetOutOfOrder(
+        WeightedValidator<Address>,
+        WeightedValidator<Address>,
+    ),
+    #[error("Invalid active validator {0}")]
+    InvalidActiveValidator(WeightedValidator<Address>),
+    #[error("Invalid inactive validator {0}")]
+    InvalidInactiveValidator(WeightedValidator<Address>),
+    #[error("Unexpectedly missing voting power value for validator {0}")]
+    MissingValidatorVotingPower(Address),
+    #[error("Validator {0} has an invalid voting power value {1}")]
+    InvalidValidatorVotingPower(Address, i64),
+    #[error("Validator set should be updated when voting powers change")]
+    ValidatorSetNotUpdated,
+    #[error("Invalid voting power changes")]
+    InvalidVotingPowerChanges,
+    #[error(
+        "Invalid validator {0} voting power changes. Expected {1}, but got \
+         {2:?}"
+    )]
+    InvalidValidatorVotingPowerChange(
+        Address,
+        VotingPower,
+        Option<VotingPower>,
+    ),
+    #[error("Unexpectedly missing total voting power")]
+    MissingTotalVotingPower,
+    #[error("Total voting power should be updated when voting powers change")]
+    TotalVotingPowerNotUpdated,
+    #[error(
+        "Invalid total voting power change in epoch {0}. Expected {1}, but \
+         got {2}"
+    )]
+    InvalidTotalVotingPowerChange(u64, VotingPowerDelta, VotingPowerDelta),
+}
+
+/// An update of PoS data.
+#[derive(Clone, Debug)]
+pub enum DataUpdate<Address, TokenAmount, TokenChange>
+where
+    Address: Display
+        + Debug
+        + Clone
+        + PartialEq
+        + Eq
+        + PartialOrd
+        + Ord
+        + Hash
+        + BorshDeserialize
+        + BorshSerialize,
+    TokenAmount: Clone
+        + Debug
+        + Default
+        + Eq
+        + Sub
+        + Add<Output = TokenAmount>
+        + AddAssign
+        + BorshDeserialize
+        + BorshSerialize,
+    TokenChange: Display
+        + Debug
+        + Default
+        + Clone
+        + Copy
+        + Add<Output = TokenChange>
+        + Sub<Output = TokenChange>
+        + From<TokenAmount>
+        + Into<i128>
+        + PartialEq
+        + Eq
+        + BorshDeserialize
+        + BorshSerialize,
+{
+    /// PoS account's balance update
+    Balance(Data<TokenAmount>),
+    /// Bond update
+    Bond {
+        /// Bond ID
+        id: BondId<Address>,
+        /// Bond prior and posterior state
+        data: Data<Bonds<TokenAmount>>,
+        /// List of slashes applied to the bond's validator
+        slashes: Slashes,
+    },
+    /// Unbond update
+    Unbond {
+        /// Unbond ID
+        id: BondId<Address>,
+        /// Unbond prior and posterior state
+        data: Data<Unbonds<TokenAmount>>,
+        /// List of slashes applied to the bond's validator
+        slashes: Slashes,
+    },
+    /// A validator update
+    Validator {
+        /// Validator's address
+        address: Address,
+        /// Validator's data update
+        update: ValidatorUpdate<Address, TokenChange>,
+    },
+    /// Validator set update
+    ValidatorSet(Data<ValidatorSets<Address>>),
+    /// Total voting power update
+    TotalVotingPower(Data<TotalVotingPowers>),
+}
+
+/// An update of a validator's data.
+#[derive(Clone, Debug)]
+pub enum ValidatorUpdate<Address, TokenChange>
+where
+    Address: Clone + Debug,
+    TokenChange: Display
+        + Debug
+        + Default
+        + Clone
+        + Copy
+        + Add<Output = TokenChange>
+        + Sub<Output = TokenChange>
+        + PartialEq
+        + Eq
+        + BorshDeserialize
+        + BorshSerialize,
+{
+    /// Staking reward address update
+    StakingRewardAddress(Data<Address>),
+    /// Total deltas update
+    TotalDeltas(Data<ValidatorTotalDeltas<TokenChange>>),
+    /// Voting power update
+    VotingPowerUpdate(Data<ValidatorVotingPowers>),
+}
+
+/// Data update with prior and posterior state.
+#[derive(Clone, Debug)]
+pub struct Data<T>
+where
+    T: Clone + Debug,
+{
+    /// State before the update
+    pub pre: Option<T>,
+    /// State after the update
+    pub post: Option<T>,
+}
+
+/// Validate the given list of PoS data `changes`. Returns empty list, if all
+/// the changes are valid.
+pub fn validate<Address, TokenAmount, TokenChange>(
+    params: &PosParams,
+    changes: Vec<DataUpdate<Address, TokenAmount, TokenChange>>,
+    current_epoch: impl Into<Epoch>,
+) -> Vec<Error<Address, TokenChange>>
+where
+    Address: Display
+        + Debug
+        + Clone
+        + PartialEq
+        + Eq
+        + PartialOrd
+        + Ord
+        + Hash
+        + BorshDeserialize
+        + BorshSerialize,
+    TokenAmount: Display
+        + Clone
+        + Copy
+        + Debug
+        + Default
+        + Eq
+        + Add<Output = TokenAmount>
+        + Sub<Output = TokenAmount>
+        + AddAssign
+        + SubAssign
+        + Into<u64>
+        + From<u64>
+        + BorshDeserialize
+        + BorshSerialize,
+    TokenChange: Display
+        + Debug
+        + Default
+        + Clone
+        + Copy
+        + Add<Output = TokenChange>
+        + Sub<Output = TokenChange>
+        + Neg<Output = TokenChange>
+        + SubAssign
+        + AddAssign
+        + From<TokenAmount>
+        + Into<i128>
+        + From<i128>
+        + PartialEq
+        + Eq
+        + PartialOrd
+        + Ord
+        + BorshDeserialize
+        + BorshSerialize,
+{
+    let current_epoch = current_epoch.into();
+    use DataUpdate::*;
+    use ValidatorUpdate::*;
+
+    let pipeline_offset = DynEpochOffset::PipelineLen.value(params);
+    let unbonding_offset = DynEpochOffset::UnbondingLen.value(params);
+    let pipeline_epoch = current_epoch + pipeline_offset;
+    let unbonding_epoch = current_epoch + unbonding_offset;
+
+    let mut errors = vec![];
+
+    let mut balance_delta = TokenChange::default();
+    // Changes of validators' bonds
+    let mut bond_delta: HashMap<Address, TokenChange> = HashMap::default();
+    // Changes of validators' unbonds
+    let mut unbond_delta: HashMap<Address, TokenChange> = HashMap::default();
+
+    // Changes of all validator total deltas (up to `unbonding_epoch`)
+    let mut total_deltas: HashMap<Address, TokenChange> = HashMap::default();
+    // Accumulative stake calculated from validator total deltas for each epoch
+    // in which it has changed
+    let mut total_stake_by_epoch: HashMap<
+        Epoch,
+        HashMap<Address, TokenAmount>,
+    > = HashMap::default();
+    // Accumulative validators' voting power calculated from their total deltas
+    let mut expected_voting_power_by_epoch: HashMap<
+        Epoch,
+        HashMap<Address, VotingPower>,
+    > = HashMap::default();
+    // Total voting power delta calculated from validators' total deltas
+    let mut expected_total_voting_power_delta_by_epoch: HashMap<
+        Epoch,
+        VotingPowerDelta,
+    > = HashMap::default();
+    // Changes of validators' voting power data
+    let mut voting_power_by_epoch: HashMap<
+        Epoch,
+        HashMap<Address, VotingPower>,
+    > = HashMap::default();
+
+    let mut validator_set_pre: Option<ValidatorSets<Address>> = None;
+    let mut validator_set_post: Option<ValidatorSets<Address>> = None;
+
+    let mut total_voting_power_delta_by_epoch: HashMap<
+        Epoch,
+        VotingPowerDelta,
+    > = HashMap::default();
+
+    for change in changes {
+        match change {
+            Validator { address, update } => match update {
+                StakingRewardAddress(data) => match (data.pre, data.post) {
+                    (Some(_), Some(post)) => {
+                        if post == address {
+                            errors.push(
+                                Error::StakingRewardAddressEqValidator(
+                                    address.clone(),
+                                ),
+                            );
+                        }
+                    }
+                    _ => errors.push(Error::StakingRewardAddressIsRequired(
+                        address.clone(),
+                    )),
+                },
+                TotalDeltas(data) => match (data.pre, data.post) {
+                    (Some(pre), Some(post)) => {
+                        if post.last_update() != current_epoch {
+                            errors.push(Error::InvalidLastUpdate)
+                        }
+                        // Changes of all total deltas (up to `unbonding_epoch`)
+                        let mut deltas = TokenChange::default();
+                        // Sum of pre total deltas
+                        let mut pre_deltas_sum = TokenChange::default();
+                        // Sum of post total deltas
+                        let mut post_deltas_sum = TokenChange::default();
+                        // Track voting power change from the predecessor epoch
+                        // to find change in voting power in the current epoch
+                        let mut last_voting_power_delta =
+                            VotingPowerDelta::default();
+                        // Iter from the first epoch to the last epoch of `post`
+                        for epoch in Epoch::iter_range(
+                            post.last_update(),
+                            unbonding_offset + 1,
+                        ) {
+                            // Changes of all total deltas (up to
+                            // `unbonding_epoch`)
+                            let mut delta = TokenChange::default();
+                            // Find the delta in `pre`
+                            if let Some(change) = {
+                                if epoch == post.last_update() {
+                                    // On the first epoch, we have to get the
+                                    // sum of all deltas at and before that
+                                    // epoch as the `pre` could have been set in
+                                    // an older epoch
+                                    pre.get(epoch)
+                                } else {
+                                    pre.get_delta_at_epoch(epoch).copied()
+                                }
+                            } {
+                                delta -= change;
+                                pre_deltas_sum += change;
+                            }
+                            // Find the delta in `post`
+                            if let Some(change) = post.get_delta_at_epoch(epoch)
+                            {
+                                delta += *change;
+                                post_deltas_sum += *change;
+                                let stake_pre: i128 =
+                                    Into::into(pre_deltas_sum);
+                                let stake_post: i128 =
+                                    Into::into(post_deltas_sum);
+                                match (
+                                    u64::try_from(stake_pre),
+                                    u64::try_from(stake_post),
+                                ) {
+                                    (Ok(stake_pre), Ok(stake_post)) => {
+                                        let stake_post =
+                                            TokenAmount::from(stake_post);
+                                        total_stake_by_epoch
+                                            .entry(epoch)
+                                            .or_insert_with(HashMap::default)
+                                            .insert(
+                                                address.clone(),
+                                                stake_post,
+                                            );
+                                        // Check if voting power should change
+                                        let delta_pre =
+                                            VotingPowerDelta::try_from_tokens(
+                                                stake_pre, params,
+                                            )
+                                            .unwrap_or_default();
+                                        let delta_post =
+                                            VotingPowerDelta::try_from_tokens(
+                                                stake_post, params,
+                                            )
+                                            .unwrap_or_default();
+                                        if delta_pre != delta_post {
+                                            // Accumulate expected voting power
+                                            // change
+                                            let voting_power_post =
+                                                VotingPower::from_tokens(
+                                                    stake_post, params,
+                                                );
+                                            expected_voting_power_by_epoch
+                                                .entry(epoch)
+                                                .or_insert_with(
+                                                    HashMap::default,
+                                                )
+                                                .insert(
+                                                    address.clone(),
+                                                    voting_power_post,
+                                                );
+                                            let delta = delta_post
+                                                - delta_pre
+                                                - last_voting_power_delta;
+                                            if delta
+                                                != VotingPowerDelta::default()
+                                            {
+                                                let current_delta = expected_total_voting_power_delta_by_epoch.entry(epoch)
+                                                .or_insert_with(Default::default);
+                                                *current_delta += delta;
+                                            }
+                                            last_voting_power_delta =
+                                                delta_post - delta_pre;
+                                        }
+                                    }
+                                    _ => errors.push(
+                                        Error::InvalidValidatorTotalDeltas(
+                                            address.clone(),
+                                            stake_post,
+                                        ),
+                                    ),
+                                }
+                            }
+                            deltas += delta;
+                            // A total delta can only be increased at
+                            // `pipeline_offset` from bonds and decreased at
+                            // `unbonding_offset` from unbonding
+                            if delta > TokenChange::default()
+                                && epoch != pipeline_epoch
+                            {
+                                errors.push(Error::EpochedDataWrongEpoch {
+                                    got: epoch.into(),
+                                    expected: vec![pipeline_epoch.into()],
+                                })
+                            }
+                            if delta < TokenChange::default()
+                                && epoch != unbonding_epoch
+                            {
+                                errors.push(Error::EpochedDataWrongEpoch {
+                                    got: epoch.into(),
+                                    expected: vec![unbonding_epoch.into()],
+                                })
+                            }
+                        }
+                        if post_deltas_sum < TokenChange::default() {
+                            errors.push(Error::NegativeValidatorTotalDeltasSum(
+                                address.clone(),
+                            ))
+                        }
+                        if deltas != TokenChange::default() {
+                            total_deltas.insert(address.clone(), deltas);
+                        }
+                    }
+                    (None, Some(post)) => {
+                        if post.last_update() != current_epoch {
+                            errors.push(Error::InvalidLastUpdate)
+                        }
+                        // Changes of all total deltas (up to `unbonding_epoch`)
+                        let mut deltas = TokenChange::default();
+                        for epoch in Epoch::iter_range(
+                            current_epoch,
+                            unbonding_offset + 1,
+                        ) {
+                            if let Some(change) = post.get_delta_at_epoch(epoch)
+                            {
+                                // A new total delta can only be initialized
+                                // at `pipeline_offset` (from bonds) and updated
+                                // at `unbonding_offset` (from unbonding)
+                                if epoch != pipeline_epoch
+                                    && epoch != unbonding_epoch
+                                {
+                                    errors.push(Error::EpochedDataWrongEpoch {
+                                        got: epoch.into(),
+                                        expected: vec![pipeline_epoch.into()],
+                                    })
+                                }
+                                deltas += *change;
+                                let stake: i128 = Into::into(deltas);
+                                match u64::try_from(stake) {
+                                    Ok(stake) => {
+                                        let stake = TokenAmount::from(stake);
+                                        total_stake_by_epoch
+                                            .entry(epoch)
+                                            .or_insert_with(HashMap::default)
+                                            .insert(address.clone(), stake);
+                                        // Accumulate expected voting power
+                                        // change
+                                        let voting_power =
+                                            VotingPower::from_tokens(
+                                                stake, params,
+                                            );
+                                        expected_voting_power_by_epoch
+                                            .entry(epoch)
+                                            .or_insert_with(HashMap::default)
+                                            .insert(
+                                                address.clone(),
+                                                voting_power,
+                                            );
+                                        let voting_power_delta = VotingPowerDelta::try_from_token_change(
+                                            *change, params).unwrap_or_default();
+                                        let current_delta = expected_total_voting_power_delta_by_epoch.entry(epoch)
+                                                .or_insert_with(Default::default);
+                                        *current_delta += voting_power_delta;
+                                    }
+                                    Err(_) => errors.push(
+                                        Error::InvalidValidatorTotalDeltas(
+                                            address.clone(),
+                                            stake,
+                                        ),
+                                    ),
+                                }
+                            }
+                        }
+                        if deltas < TokenChange::default() {
+                            errors.push(Error::NegativeValidatorTotalDeltasSum(
+                                address.clone(),
+                            ))
+                        }
+                        if deltas != TokenChange::default() {
+                            total_deltas.insert(address.clone(), deltas);
+                        }
+                    }
+                    (Some(_), None) => {
+                        errors.push(Error::MissingValidatorTotalDeltas(address))
+                    }
+                    (None, None) => continue,
+                },
+                VotingPowerUpdate(data) => match (data.pre, data.post) {
+                    (Some(_), Some(post)) | (None, Some(post)) => {
+                        if post.last_update() != current_epoch {
+                            errors.push(Error::InvalidLastUpdate)
+                        }
+                        let mut voting_power = VotingPowerDelta::default();
+                        // Iter from the first epoch to the last epoch of
+                        // `post`
+                        for epoch in Epoch::iter_range(
+                            current_epoch,
+                            unbonding_offset + 1,
+                        ) {
+                            if let Some(delta) = post.get_delta_at_epoch(epoch)
+                            {
+                                voting_power += *delta;
+                                let vp: i64 = Into::into(voting_power);
+                                match u64::try_from(vp) {
+                                    Ok(vp) => {
+                                        let vp = VotingPower::from(vp);
+                                        voting_power_by_epoch
+                                            .entry(epoch)
+                                            .or_insert_with(HashMap::default)
+                                            .insert(address.clone(), vp);
+                                    }
+                                    Err(_) => errors.push(
+                                        Error::InvalidValidatorVotingPower(
+                                            address.clone(),
+                                            vp,
+                                        ),
+                                    ),
+                                }
+                            }
+                        }
+                    }
+                    (Some(_), None) => errors.push(
+                        Error::MissingValidatorVotingPower(address.clone()),
+                    ),
+                    (None, None) => continue,
+                },
+            },
+            Balance(data) => match (data.pre, data.post) {
+                (None, Some(post)) => balance_delta += TokenChange::from(post),
+                (Some(pre), Some(post)) => {
+                    balance_delta -= TokenChange::from(pre);
+                    balance_delta += TokenChange::from(post);
+                }
+                (Some(_), None) => errors.push(Error::MissingBalance),
+                (None, None) => continue,
+            },
+            Bond { id, data, slashes } => match (data.pre, data.post) {
+                // Bond may be updated from newly bonded tokens and unbonding
+                (Some(pre), Some(post)) => {
+                    if post.last_update() != current_epoch {
+                        errors.push(Error::InvalidLastUpdate)
+                    }
+                    // Pre-bonds keyed by their `start_epoch`
+                    let mut pre_bonds: HashMap<Epoch, TokenChange> =
+                        HashMap::default();
+                    // We have to slash only the difference between post and
+                    // pre, not both pre and post to avoid rounding errors
+                    let mut slashed_deltas: HashMap<Epoch, TokenChange> =
+                        HashMap::default();
+                    // Iter from the first epoch of `pre` to the last epoch of
+                    // `post`
+                    let pre_offset: u64 =
+                        (current_epoch - pre.last_update()).into();
+                    for epoch in Epoch::iter_range(
+                        pre.last_update(),
+                        pre_offset + pipeline_offset + 1,
+                    ) {
+                        if let Some(bond) = pre.get_delta_at_epoch(epoch) {
+                            for (start_epoch, delta) in bond.deltas.iter() {
+                                let delta = TokenChange::from(*delta);
+                                slashed_deltas.insert(*start_epoch, -delta);
+                                pre_bonds.insert(*start_epoch, delta);
+                            }
+                        }
+                        if let Some(bond) = post.get_delta_at_epoch(epoch) {
+                            for (start_epoch, delta) in bond.deltas.iter() {
+                                // An empty bond must be deleted
+                                if *delta == TokenAmount::default() {
+                                    errors.push(Error::EmptyBond(id.clone()))
+                                }
+                                // On the current epoch, all bond's
+                                // `start_epoch`s must be equal or lower than
+                                // `current_epoch`. For all others, the
+                                // `start_epoch` must be equal
+                                // to the `epoch` at which it's set.
+                                if (epoch == current_epoch
+                                    && *start_epoch > current_epoch)
+                                    || (epoch != current_epoch
+                                        && *start_epoch != epoch)
+                                {
+                                    errors.push(Error::InvalidBondStartEpoch {
+                                        id: id.clone(),
+                                        got: (*start_epoch).into(),
+                                        expected: epoch.into(),
+                                    })
+                                }
+                                let delta = TokenChange::from(*delta);
+                                match slashed_deltas.get_mut(start_epoch) {
+                                    Some(pre_delta) => {
+                                        if *pre_delta + delta == 0_i128.into() {
+                                            slashed_deltas.remove(start_epoch);
+                                        } else {
+                                            *pre_delta += delta;
+                                        }
+                                    }
+                                    None => {
+                                        slashed_deltas
+                                            .insert(*start_epoch, delta);
+                                    }
+                                }
+
+                                // Anywhere other than at `pipeline_offset`
+                                // where new bonds are added, check against the
+                                // data in `pre_bonds` to ensure that no new
+                                // bond has been added and that the deltas are
+                                // equal or lower to `pre_bonds` deltas.
+                                // Note that any bonds from any epoch can be
+                                // unbonded, even if they are not yet active.
+                                if epoch != pipeline_epoch {
+                                    match pre_bonds.get(start_epoch) {
+                                        Some(pre_delta) => {
+                                            if &delta > pre_delta {
+                                                errors.push(
+                                                Error::InvalidNewBondEpoch {
+                                                    id: id.clone(),
+                                                    got: epoch.into(),
+                                                    expected: pipeline_epoch
+                                                        .into(),
+                                                });
+                                            }
+                                        }
+                                        None => {
+                                            errors.push(
+                                                Error::InvalidNewBondEpoch {
+                                                    id: id.clone(),
+                                                    got: epoch.into(),
+                                                    expected: (current_epoch
+                                                        + pipeline_offset)
+                                                        .into(),
+                                                },
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    // Check slashes
+                    for (start_epoch, delta) in slashed_deltas.iter_mut() {
+                        for slash in &slashes {
+                            if slash.epoch >= *start_epoch {
+                                let raw_delta: i128 = (*delta).into();
+                                let current_slashed =
+                                    TokenChange::from(slash.rate * raw_delta);
+                                *delta -= current_slashed;
+                            }
+                        }
+                    }
+                    let total = slashed_deltas
+                        .values()
+                        .fold(TokenChange::default(), |acc, delta| {
+                            acc + *delta
+                        });
+                    if total != TokenChange::default() {
+                        bond_delta.insert(id.validator, total);
+                    }
+                }
+                // Bond may be created from newly bonded tokens only
+                (None, Some(post)) => {
+                    if post.last_update() != current_epoch {
+                        errors.push(Error::InvalidLastUpdate)
+                    }
+                    let mut total_delta = TokenChange::default();
+                    for epoch in
+                        Epoch::iter_range(current_epoch, pipeline_offset + 1)
+                    {
+                        if let Some(bond) = post.get_delta_at_epoch(epoch) {
+                            // A new bond must be initialized at
+                            // `pipeline_offset`
+                            if epoch != pipeline_epoch {
+                                errors.push(Error::EpochedDataWrongEpoch {
+                                    got: epoch.into(),
+                                    expected: vec![pipeline_epoch.into()],
+                                })
+                            }
+                            for (start_epoch, delta) in bond.deltas.iter() {
+                                if *start_epoch != epoch {
+                                    errors.push(Error::InvalidBondStartEpoch {
+                                        id: id.clone(),
+                                        got: (*start_epoch).into(),
+                                        expected: epoch.into(),
+                                    })
+                                }
+                                let mut delta = *delta;
+                                // Check slashes
+                                for slash in &slashes {
+                                    if slash.epoch >= *start_epoch {
+                                        let raw_delta: u64 = delta.into();
+                                        let current_slashed = TokenAmount::from(
+                                            slash.rate * raw_delta,
+                                        );
+                                        delta -= current_slashed;
+                                    }
+                                }
+                                let delta = TokenChange::from(delta);
+                                total_delta += delta
+                            }
+                        }
+                    }
+                    // An empty bond must be deleted
+                    if total_delta == TokenChange::default() {
+                        errors.push(Error::EmptyBond(id.clone()))
+                    }
+                    bond_delta.insert(id.validator, total_delta);
+                }
+                // Bond may be deleted when all the tokens are unbonded
+                (Some(pre), None) => {
+                    let mut total_delta = TokenChange::default();
+                    for index in 0..pipeline_offset + 1 {
+                        let index = index as usize;
+                        let epoch = pre.last_update() + index;
+                        if let Some(bond) = pre.get_delta_at_epoch(epoch) {
+                            for (start_epoch, delta) in &bond.deltas {
+                                let mut delta = *delta;
+                                // Check slashes
+                                for slash in &slashes {
+                                    if slash.epoch >= *start_epoch {
+                                        let raw_delta: u64 = delta.into();
+                                        let current_slashed = TokenAmount::from(
+                                            slash.rate * raw_delta,
+                                        );
+                                        delta -= current_slashed;
+                                    }
+                                }
+                                let delta = TokenChange::from(delta);
+                                total_delta -= delta
+                            }
+                        }
+                    }
+                    bond_delta.insert(id.validator, total_delta);
+                }
+                (None, None) => continue,
+            },
+            Unbond { id, data, slashes } => match (data.pre, data.post) {
+                // Unbond may be updated from newly unbonded tokens
+                (Some(pre), Some(post)) => {
+                    if post.last_update() != current_epoch {
+                        errors.push(Error::InvalidLastUpdate)
+                    }
+
+                    // We have to slash only the difference between post and
+                    // pre, not both pre and post to avoid rounding errors
+                    let mut slashed_deltas: HashMap<
+                        (Epoch, Epoch),
+                        TokenChange,
+                    > = HashMap::default();
+                    // Iter from the first epoch of `pre` to the last epoch of
+                    // `post`
+                    let pre_offset: u64 =
+                        (current_epoch - pre.last_update()).into();
+                    for epoch in Epoch::iter_range(
+                        pre.last_update(),
+                        pre_offset + unbonding_offset + 1,
+                    ) {
+                        if let Some(unbond) = pre.get_delta_at_epoch(epoch) {
+                            for ((start_epoch, end_epoch), delta) in
+                                unbond.deltas.iter()
+                            {
+                                let delta = TokenChange::from(*delta);
+                                slashed_deltas
+                                    .insert((*start_epoch, *end_epoch), -delta);
+                            }
+                        }
+                        if let Some(unbond) = post.get_delta_at_epoch(epoch) {
+                            for ((start_epoch, end_epoch), delta) in
+                                unbond.deltas.iter()
+                            {
+                                let delta = TokenChange::from(*delta);
+                                let key = (*start_epoch, *end_epoch);
+                                match slashed_deltas.get_mut(&key) {
+                                    Some(pre_delta) => {
+                                        if *pre_delta + delta == 0_i128.into() {
+                                            slashed_deltas.remove(&key);
+                                        } else {
+                                            *pre_delta += delta;
+                                        }
+                                    }
+                                    None => {
+                                        slashed_deltas.insert(key, delta);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    // Check slashes
+                    for ((start_epoch, end_epoch), delta) in
+                        slashed_deltas.iter_mut()
+                    {
+                        for slash in &slashes {
+                            if slash.epoch >= *start_epoch
+                                && slash.epoch <= *end_epoch
+                            {
+                                let raw_delta: i128 = (*delta).into();
+                                let current_slashed =
+                                    TokenChange::from(slash.rate * raw_delta);
+                                *delta -= current_slashed;
+                            }
+                        }
+                    }
+                    let total = slashed_deltas
+                        .values()
+                        .fold(TokenChange::default(), |acc, delta| {
+                            acc + *delta
+                        });
+                    if total != TokenChange::default() {
+                        unbond_delta.insert(id.validator, total);
+                    }
+                }
+                // Unbond may be created from a bond
+                (None, Some(post)) => {
+                    if post.last_update() != current_epoch {
+                        errors.push(Error::InvalidLastUpdate)
+                    }
+                    let mut total_delta = TokenChange::default();
+                    for epoch in Epoch::iter_range(
+                        post.last_update(),
+                        unbonding_offset + 1,
+                    ) {
+                        if let Some(unbond) = post.get_delta_at_epoch(epoch) {
+                            for ((start_epoch, end_epoch), delta) in
+                                unbond.deltas.iter()
+                            {
+                                let mut delta = *delta;
+                                // Check and apply slashes, if any
+                                for slash in &slashes {
+                                    if slash.epoch >= *start_epoch
+                                        && slash.epoch <= *end_epoch
+                                    {
+                                        let raw_delta: u64 = delta.into();
+                                        let current_slashed = TokenAmount::from(
+                                            slash.rate * raw_delta,
+                                        );
+                                        delta -= current_slashed;
+                                    }
+                                }
+                                let delta = TokenChange::from(delta);
+                                total_delta += delta;
+                            }
+                        }
+                    }
+                    unbond_delta.insert(id.validator, total_delta);
+                }
+                // Unbond may be deleted when all the tokens are withdrawn
+                (Some(pre), None) => {
+                    let mut total_delta = TokenChange::default();
+                    for epoch in Epoch::iter_range(
+                        pre.last_update(),
+                        unbonding_offset + 1,
+                    ) {
+                        if let Some(unbond) = pre.get_delta_at_epoch(epoch) {
+                            for ((start_epoch, end_epoch), delta) in
+                                unbond.deltas.iter()
+                            {
+                                let mut delta = *delta;
+                                // Check and apply slashes, if any
+                                for slash in &slashes {
+                                    if slash.epoch >= *start_epoch
+                                        && slash.epoch <= *end_epoch
+                                    {
+                                        let raw_delta: u64 = delta.into();
+                                        let current_slashed = TokenAmount::from(
+                                            slash.rate * raw_delta,
+                                        );
+                                        delta -= current_slashed;
+                                    }
+                                }
+                                let delta = TokenChange::from(delta);
+                                total_delta -= delta;
+                            }
+                        }
+                    }
+                    unbond_delta.insert(id.validator, total_delta);
+                }
+                (None, None) => continue,
+            },
+            ValidatorSet(data) => match (data.pre, data.post) {
+                (Some(pre), Some(post)) => {
+                    if post.last_update() != current_epoch {
+                        errors.push(Error::InvalidLastUpdate)
+                    }
+                    validator_set_pre = Some(pre);
+                    validator_set_post = Some(post);
+                }
+                _ => errors.push(Error::MissingValidatorSet),
+            },
+            TotalVotingPower(data) => match (data.pre, data.post) {
+                (Some(pre), Some(post)) => {
+                    if post.last_update() != current_epoch {
+                        errors.push(Error::InvalidLastUpdate)
+                    }
+                    // Iter from the first epoch to the last epoch of `post`
+                    for epoch in Epoch::iter_range(
+                        post.last_update(),
+                        unbonding_offset + 1,
+                    ) {
+                        // Find the delta in `pre`
+                        let delta_pre = (if epoch == post.last_update() {
+                            // On the first epoch, we have to get the
+                            // sum of all deltas at and before that
+                            // epoch as the `pre` could have been set in
+                            // an older epoch
+                            pre.get(epoch)
+                        } else {
+                            pre.get_delta_at_epoch(epoch).copied()
+                        })
+                        .unwrap_or_default();
+                        // Find the delta in `post`
+                        let delta_post = post
+                            .get_delta_at_epoch(epoch)
+                            .copied()
+                            .unwrap_or_default();
+                        if delta_pre != delta_post {
+                            total_voting_power_delta_by_epoch
+                                .insert(epoch, delta_post - delta_pre);
+                        }
+                    }
+                }
+                _ => errors.push(Error::MissingTotalVotingPower),
+            },
+        }
+    }
+
+    // Check total deltas against bonds
+    for (validator, total_delta) in total_deltas.iter() {
+        let bond_delta = bond_delta.get(validator).copied().unwrap_or_default();
+        let total_delta = *total_delta;
+        if total_delta != bond_delta {
+            errors.push(Error::InvalidValidatorTotalDeltasSum {
+                address: validator.clone(),
+                total_delta,
+                bond_delta,
+            })
+        }
+    }
+    // Check that all bonds also have a total deltas update
+    for validator in bond_delta.keys() {
+        if !total_deltas.contains_key(validator) {
+            errors.push(Error::MissingValidatorTotalDeltas(validator.clone()))
+        }
+    }
+    // Check that all positive unbond deltas also have a total deltas update.
+    // Negative unbond delta is from withdrawing, which removes tokens from
+    // unbond, but doesn't affect total deltas.
+    for (validator, delta) in &unbond_delta {
+        if *delta > TokenChange::default()
+            && !total_deltas.contains_key(validator)
+        {
+            errors.push(Error::MissingValidatorTotalDeltas(validator.clone()));
+        }
+    }
+
+    // Check validator sets against validator total stakes.
+    // Iter from the first epoch to the last epoch of `validator_set_post`
+    if let Some(post) = validator_set_post {
+        for epoch in Epoch::iter_range(current_epoch, unbonding_offset + 1) {
+            if let Some(post) = post.get_at_epoch(epoch) {
+                // Check that active validators length is not over the limit
+                if post.active.len() > params.max_validator_slots as usize {
+                    errors.push(Error::TooManyActiveValidators)
+                }
+                // Check that all active have voting power >= any inactive
+                if let (
+                    Some(max_inactive_validator),
+                    Some(min_active_validator),
+                ) = (post.inactive.last_shim(), post.active.last_shim())
+                {
+                    if max_inactive_validator.voting_power
+                        > min_active_validator.voting_power
+                    {
+                        errors.push(Error::ValidatorSetOutOfOrder(
+                            max_inactive_validator.clone(),
+                            min_active_validator.clone(),
+                        ));
+                    }
+                }
+
+                match validator_set_pre.as_ref().and_then(|pre| pre.get(epoch))
+                {
+                    Some(pre) => {
+                        let total_stakes = total_stake_by_epoch
+                            .get(&epoch)
+                            .map(Cow::Borrowed)
+                            .unwrap_or_else(|| Cow::Owned(HashMap::default()));
+                        // Check active validators
+                        for validator in &post.active {
+                            match total_stakes.get(&validator.address) {
+                                Some(stake) => {
+                                    let voting_power = VotingPower::from_tokens(
+                                        *stake, params,
+                                    );
+                                    // Any validator who's total deltas changed,
+                                    // should
+                                    // be up-to-date
+                                    if validator.voting_power != voting_power {
+                                        errors.push(
+                                            Error::InvalidActiveValidator(
+                                                validator.clone(),
+                                            ),
+                                        )
+                                    }
+                                }
+                                None => {
+                                    // Others must be the same as in pre
+                                    if !pre.active.contains(validator) {
+                                        errors.push(
+                                            Error::InvalidActiveValidator(
+                                                validator.clone(),
+                                            ),
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                        // Check inactive validators
+                        for validator in &post.inactive {
+                            // Any validator who's total deltas changed, should
+                            // be up-to-date
+                            match total_stakes.get(&validator.address) {
+                                Some(stake) => {
+                                    let voting_power = VotingPower::from_tokens(
+                                        *stake, params,
+                                    );
+                                    if validator.voting_power != voting_power {
+                                        errors.push(
+                                            Error::InvalidInactiveValidator(
+                                                validator.clone(),
+                                            ),
+                                        )
+                                    }
+                                }
+                                None => {
+                                    // Others must be the same as in pre
+                                    if !pre.active.contains(validator) {
+                                        errors.push(
+                                            Error::InvalidInactiveValidator(
+                                                validator.clone(),
+                                            ),
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    None => errors.push(Error::MissingValidatorSet),
+                }
+            } else if let Some(total_stake) = total_stake_by_epoch.get(&epoch) {
+                // When there's some total delta change for this epoch,
+                // check that it wouldn't have affected the validator set
+                // (i.e. the validator's voting power is unchanged).
+                match post.get(epoch) {
+                    Some(post) => {
+                        for (validator, tokens_at_epoch) in total_stake {
+                            let voting_power = VotingPower::from_tokens(
+                                *tokens_at_epoch,
+                                params,
+                            );
+                            let weighted_validator = WeightedValidator {
+                                voting_power,
+                                address: validator.clone(),
+                            };
+                            if !post.active.contains(&weighted_validator) {
+                                if !post.inactive.contains(&weighted_validator)
+                                {
+                                    errors.push(
+                                        Error::WeightedValidatorNotFound(
+                                            weighted_validator,
+                                            epoch.into(),
+                                        ),
+                                    );
+                                }
+                            } else if post
+                                .inactive
+                                .contains(&weighted_validator)
+                            {
+                                // Validator cannot be both active and inactive
+                                errors.push(Error::ValidatorSetDuplicate(
+                                    weighted_validator,
+                                    epoch.into(),
+                                ))
+                            }
+                        }
+                    }
+                    None => errors.push(Error::MissingValidatorSet),
+                }
+            }
+        }
+    } else if !voting_power_by_epoch.is_empty() {
+        errors.push(Error::ValidatorSetNotUpdated)
+    }
+
+    // Check voting power changes against validator total stakes
+    for (epoch, voting_powers) in &voting_power_by_epoch {
+        let mut epoch = *epoch;
+        let mut total_stakes;
+        // Try to find the stakes for this epoch
+        loop {
+            total_stakes = total_stake_by_epoch.get(&epoch);
+            // If there's no stake values in this epoch, it means it hasn't
+            // changed, so we can try to find it from predecessor epochs
+            if total_stakes.is_none() && epoch > current_epoch {
+                epoch = epoch - 1;
+            } else {
+                break;
+            }
+        }
+        if let Some(total_stakes) = total_stakes {
+            for (validator, voting_power) in voting_powers {
+                if let Some(stake) = total_stakes.get(validator) {
+                    let voting_power_from_stake =
+                        VotingPower::from_tokens(*stake, params);
+                    if *voting_power != voting_power_from_stake {
+                        errors.push(Error::InvalidVotingPowerChanges)
+                    }
+                } else {
+                    errors.push(Error::InvalidVotingPowerChanges)
+                }
+            }
+        } else {
+            errors.push(Error::InvalidVotingPowerChanges);
+        }
+    }
+
+    // Check expected voting power changes
+    for (epoch, expected_voting_powers) in expected_voting_power_by_epoch {
+        for (validator, expected_voting_power) in expected_voting_powers {
+            match voting_power_by_epoch.get(&epoch) {
+                Some(actual_voting_powers) => {
+                    match actual_voting_powers.get(&validator) {
+                        Some(actual_voting_power) => {
+                            if *actual_voting_power != expected_voting_power {
+                                errors.push(
+                                    Error::InvalidValidatorVotingPowerChange(
+                                        validator,
+                                        expected_voting_power,
+                                        Some(*actual_voting_power),
+                                    ),
+                                );
+                            }
+                        }
+                        None => errors.push(
+                            Error::InvalidValidatorVotingPowerChange(
+                                validator,
+                                expected_voting_power,
+                                None,
+                            ),
+                        ),
+                    }
+                }
+                None => errors.push(Error::InvalidValidatorVotingPowerChange(
+                    validator,
+                    expected_voting_power,
+                    None,
+                )),
+            }
+        }
+    }
+
+    // Check expected total voting power change
+    for (epoch, expected_delta) in expected_total_voting_power_delta_by_epoch {
+        match total_voting_power_delta_by_epoch.get(&epoch) {
+            Some(actual_delta) => {
+                if *actual_delta != expected_delta {
+                    errors.push(Error::InvalidTotalVotingPowerChange(
+                        epoch.into(),
+                        expected_delta,
+                        *actual_delta,
+                    ));
+                }
+            }
+            None => {
+                if expected_delta != VotingPowerDelta::default() {
+                    errors.push(Error::TotalVotingPowerNotUpdated)
+                }
+            }
+        }
+    }
+
+    // Sum the bond totals
+    let bond_delta = bond_delta
+        .values()
+        .into_iter()
+        .fold(TokenChange::default(), |acc, delta| acc + (*delta));
+    // Sum the unbond totals
+    let unbond_delta = unbond_delta
+        .values()
+        .into_iter()
+        .fold(TokenChange::default(), |acc, delta| acc + (*delta));
+
+    if balance_delta != bond_delta + unbond_delta {
+        errors.push(Error::InvalidBalances {
+            balance_delta,
+            bond_delta,
+            unbond_delta,
+        })
+    }
+
+    errors
+}

--- a/proof_of_stake/src/validation.rs
+++ b/proof_of_stake/src/validation.rs
@@ -1059,7 +1059,7 @@ where
                 if let (
                     Some(max_inactive_validator),
                     Some(min_active_validator),
-                ) = (post.inactive.last_shim(), post.active.last_shim())
+                ) = (post.inactive.last_shim(), post.active.first_shim())
                 {
                     if max_inactive_validator.voting_power
                         > min_active_validator.voting_power


### PR DESCRIPTION
This PR is split from #385. Closes #322 

The PoS system  and its integration is described in #324. Rendered: https://github.com/anoma/anoma/blob/tomas/pos-design/docs/src/explore/design/pos.md and https://github.com/anoma/anoma/blob/tomas/pos-design/docs/src/explore/design/ledger/pos-integration.md, respectively.

Together with #419, #420, #421, these PRs contain the PoS MVP with:

- validator self-bond
  - tx WASM + client cmd
  - VP validation
- delegation
  - tx WASM + client cmd
  - VP validation
- validator unbond from self-bond
  - tx WASM + client cmd
  - VP validation
- delegator unbond from delegation
  - tx WASM + client cmd
  - VP validation
- validator withdraw from unbond
  - tx WASM + client cmd
  - VP validation
- delegator withdraw from unbond
  - tx WASM + client cmd
  - VP validation
- slashing
  - base ledger apply slash on evidence in `BeginBlock`
  - withdraw from unbond apply slashes
  - VP validation of slashes on withdraw
- RPC
  - get bonds/unbonds for a given source address
  - get a validator's voting power
  - get total voting power
  - get validator set (active/inactive)
  - add optional arg for epoch for queries above (use current epoch if not specified)