### PR TITLE
genesis validator setup helper

### DIFF
--- a/apps/src/bin/anoma-client/cli.rs
+++ b/apps/src/bin/anoma-client/cli.rs
@@ -3,9 +3,9 @@
 use std::collections::HashSet;
 use std::io::Write;
 
-use anoma::types::{address, token};
 use anoma::types::intent::{Exchange, FungibleTokenIntent};
 use anoma::types::key::ed25519::Signed;
+use anoma::types::{address, token};
 use anoma_apps::cli;
 use anoma_apps::cli::{args, cmds, Context};
 use anoma_apps::client::{rpc, signing, tx};
@@ -190,29 +190,27 @@ fn init_genesis_validator(
     let rewards_address =
         address::gen_established_address("genesis validator reward address");
     let rewards_address_alias = format!("{}-rewards", alias);
-    if !wallet.add_address(rewards_address_alias.clone(), rewards_address.clone()) {
+    if !wallet
+        .add_address(rewards_address_alias.clone(), rewards_address.clone())
+    {
         cli::safe_exit(1)
     }
 
     println!("Generating validator account key...");
-    let validator_key_alias = wallet.gen_key(
+    let (validator_key_alias, validator_key) = wallet.gen_key(
         Some(format!("{}-validator-key", alias)),
         unsafe_dont_encrypt,
     );
     println!("Generating consensus key...");
-    let consensus_key_alias = wallet.gen_key(
+    let (consensus_key_alias, consensus_key) = wallet.gen_key(
         Some(format!("{}-consensus-key", alias)),
         unsafe_dont_encrypt,
     );
     println!("Generating staking reward account key...");
-    let rewards_key_alias = wallet
+    let (rewards_key_alias, rewards_key) = wallet
         .gen_key(Some(format!("{}-rewards-key", alias)), unsafe_dont_encrypt);
 
     wallet.save().unwrap_or_else(|err| eprintln!("{}", err));
-
-    let validator_key = wallet.find_key(&validator_key_alias).unwrap();
-    let consensus_key = wallet.find_key(&consensus_key_alias).unwrap();
-    let rewards_key = wallet.find_key(&rewards_key_alias).unwrap();
 
     let tendermint_home = &ctx.config.ledger.tendermint;
     tendermint_node::write_validator_key(

--- a/apps/src/bin/anoma-wallet/cli.rs
+++ b/apps/src/bin/anoma-wallet/cli.rs
@@ -50,7 +50,7 @@ fn key_and_address_gen(
     }: args::KeyAndAddressGen,
 ) {
     let mut wallet = ctx.wallet;
-    let alias = wallet.gen_key(alias, unsafe_dont_encrypt);
+    let (alias, _key) = wallet.gen_key(alias, unsafe_dont_encrypt);
     wallet.save().unwrap_or_else(|err| eprintln!("{}", err));
     println!(
         "Successfully added a key and an address with alias: \"{}\"",

--- a/apps/src/lib/cli/utils.rs
+++ b/apps/src/lib/cli/utils.rs
@@ -7,7 +7,6 @@ use clap::ArgMatches;
 
 use super::args;
 use super::context::{Context, FromContext};
-use crate::wallet::Wallet;
 
 // We only use static strings
 pub type App = clap::App<'static>;
@@ -23,11 +22,7 @@ pub trait Cmd: Sized {
         match Self::parse(&matches) {
             Some(cmd) => {
                 let global_args = args::Global::parse(&matches);
-                let wallet = Wallet::load_or_new(&global_args.base_dir);
-                let context = Context {
-                    global_args,
-                    wallet,
-                };
+                let context = Context::new(global_args);
                 (cmd, context)
             }
             None => {

--- a/apps/src/lib/config/genesis.rs
+++ b/apps/src/lib/config/genesis.rs
@@ -13,9 +13,6 @@ use anoma::types::{storage, token};
 #[derive(Debug)]
 pub struct Genesis {
     pub validators: Vec<Validator>,
-    /// The consensus key will be written into Tendermint node's
-    /// `priv_validator_key.json`
-    #[cfg(feature = "dev")]
     pub token_accounts: Vec<TokenAccount>,
     pub established_accounts: Vec<EstablishedAccount>,
     pub implicit_accounts: Vec<ImplicitAccount>,

--- a/apps/src/lib/config/genesis.rs
+++ b/apps/src/lib/config/genesis.rs
@@ -16,7 +16,6 @@ pub struct Genesis {
     /// The consensus key will be written into Tendermint node's
     /// `priv_validator_key.json`
     #[cfg(feature = "dev")]
-    pub validator_consensus_key: Keypair,
     pub token_accounts: Vec<TokenAccount>,
     pub established_accounts: Vec<EstablishedAccount>,
     pub implicit_accounts: Vec<ImplicitAccount>,
@@ -101,7 +100,7 @@ pub fn genesis() -> Genesis {
             address,
             staking_reward_address,
             tokens: token::Amount::whole(200_000),
-            consensus_key: consensus_keypair.public.clone(),
+            consensus_key: consensus_keypair.public,
             staking_reward_key: staking_reward_keypair.public,
         },
         account_key: account_keypair.public,
@@ -159,7 +158,6 @@ pub fn genesis() -> Genesis {
         .collect();
     Genesis {
         validators: vec![validator],
-        validator_consensus_key: consensus_keypair,
         established_accounts: vec![albert, bertha, christel, matchmaker],
         implicit_accounts,
         token_accounts,

--- a/apps/src/lib/config/mod.rs
+++ b/apps/src/lib/config/mod.rs
@@ -246,15 +246,15 @@ impl Default for IntentGossiper {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
-    pub ledger: Option<Ledger>,
-    pub intent_gossiper: Option<IntentGossiper>,
+    pub ledger: Ledger,
+    pub intent_gossiper: IntentGossiper,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
-            ledger: Some(Ledger::default()),
-            intent_gossiper: Some(IntentGossiper::default()),
+            ledger: Ledger::default(),
+            intent_gossiper: IntentGossiper::default(),
         }
     }
 }
@@ -279,10 +279,7 @@ impl Config {
     /// Generate configuration and write it to a file.
     pub fn generate(base_dir: &Path, replace: bool) -> Result<Self> {
         let mut config = Config::default();
-        let mut ledger_cfg = config
-            .ledger
-            .as_mut()
-            .expect("safe because default has ledger");
+        let ledger_cfg = &mut config.ledger;
         ledger_cfg.db = base_dir.join(DB_DIR).join(DEFAULT_CHAIN_ID);
         ledger_cfg.tendermint = base_dir.join(TENDERMINT_DIR);
         config.write(base_dir, replace)?;

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -4,7 +4,7 @@ pub mod rpc;
 mod shell;
 mod shims;
 pub mod storage;
-mod tendermint_node;
+pub mod tendermint_node;
 
 use std::convert::{TryFrom, TryInto};
 use std::sync::mpsc::channel;

--- a/apps/src/lib/node/ledger/tendermint_node.rs
+++ b/apps/src/lib/node/ledger/tendermint_node.rs
@@ -14,9 +14,9 @@ use signal_hook::iterator::Signals;
 use tendermint::config::TendermintConfig;
 use thiserror::Error;
 
-use crate::config;
 use crate::config::genesis;
 use crate::std::sync::mpsc::Sender;
+use crate::{config, wallet};
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -68,7 +68,7 @@ pub fn run(
                 .expect("There should be one genesis validator in \"dev\" mode")
                 .pos_data
                 .address,
-            &genesis.validator_consensus_key,
+            &wallet::defaults::validator_keypair(),
         );
     }
 

--- a/apps/src/lib/node/ledger/tendermint_node.rs
+++ b/apps/src/lib/node/ledger/tendermint_node.rs
@@ -14,9 +14,8 @@ use signal_hook::iterator::Signals;
 use tendermint::config::TendermintConfig;
 use thiserror::Error;
 
-use crate::config::genesis;
+use crate::config;
 use crate::std::sync::mpsc::Sender;
-use crate::{config, wallet};
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -58,7 +57,7 @@ pub fn run(
 
     #[cfg(feature = "dev")]
     {
-        let genesis = &genesis::genesis();
+        let genesis = &crate::config::genesis::genesis();
         // override the validator key file
         write_validator_key(
             &home_dir,
@@ -68,7 +67,7 @@ pub fn run(
                 .expect("There should be one genesis validator in \"dev\" mode")
                 .pos_data
                 .address,
-            &wallet::defaults::validator_keypair(),
+            &crate::wallet::defaults::validator_keypair(),
         );
     }
 

--- a/apps/src/lib/node/ledger/tendermint_node.rs
+++ b/apps/src/lib/node/ledger/tendermint_node.rs
@@ -6,16 +6,16 @@ use std::str::FromStr;
 use std::sync::mpsc::Receiver;
 use std::time::Duration;
 
-#[cfg(feature = "dev")]
+use anoma::types::address::Address;
 use anoma::types::key::ed25519::Keypair;
+use serde_json::json;
 use signal_hook::consts::TERM_SIGNALS;
 use signal_hook::iterator::Signals;
 use tendermint::config::TendermintConfig;
 use thiserror::Error;
 
 use crate::config;
-#[cfg(feature = "dev")]
-use crate::config::genesis::{self, Validator};
+use crate::config::genesis;
 use crate::std::sync::mpsc::Sender;
 
 #[derive(Error, Debug)]
@@ -62,9 +62,12 @@ pub fn run(
         // override the validator key file
         write_validator_key(
             &home_dir,
-            genesis.validators.first().expect(
-                "There should be one genesis validator in \"dev\" mode",
-            ),
+            &genesis
+                .validators
+                .first()
+                .expect("There should be one genesis validator in \"dev\" mode")
+                .pos_data
+                .address,
             &genesis.validator_consensus_key,
         );
     }
@@ -146,6 +149,50 @@ pub fn reset(config: config::Ledger) -> Result<()> {
     Ok(())
 }
 
+/// Initialize validator private key for Tendermint
+pub fn write_validator_key(
+    home_dir: impl AsRef<Path>,
+    address: &Address,
+    consensus_key: &Keypair,
+) {
+    let home_dir = home_dir.as_ref();
+    let path = home_dir.join("config").join("priv_validator_key.json");
+    let file =
+        File::create(path).expect("Couldn't create private validator key file");
+    let pk: ed25519_dalek::PublicKey = consensus_key.public.clone().into();
+    let pk = base64::encode(pk.as_bytes());
+    let sk = base64::encode(consensus_key.to_bytes());
+    let address = address.raw_hash().unwrap();
+    let key = json!({
+       "address": address,
+       "pub_key": {
+         "type": "tendermint/PubKeyEd25519",
+         "value": pk,
+       },
+       "priv_key": {
+         "type": "tendermint/PrivKeyEd25519",
+         "value": sk,
+      }
+    });
+    serde_json::to_writer_pretty(file, &key)
+        .expect("Couldn't write private validator key file");
+}
+
+/// Initialize validator private state for Tendermint
+pub fn write_validator_state(home_dir: impl AsRef<Path>) {
+    let home_dir = home_dir.as_ref();
+    let path = home_dir.join("data").join("priv_validator_state.json");
+    let file = File::create(path)
+        .expect("Couldn't create private validator state file");
+    let state = json!({
+       "height": "0",
+       "round": 0,
+       "step": 0
+    });
+    serde_json::to_writer_pretty(file, &state)
+        .expect("Couldn't write private validator state file");
+}
+
 fn update_tendermint_config(home_dir: impl AsRef<Path>) -> Result<()> {
     let home_dir = home_dir.as_ref();
     let path = home_dir.join("config").join("config.toml");
@@ -177,38 +224,6 @@ fn update_tendermint_config(home_dir: impl AsRef<Path>) -> Result<()> {
         toml::to_string(&config).map_err(Error::ConfigSerializeToml)?;
     file.write_all(config_str.as_bytes())
         .map_err(Error::WriteConfig)
-}
-
-#[cfg(feature = "dev")]
-fn write_validator_key(
-    home_dir: impl AsRef<Path>,
-    validator: &Validator,
-    validator_key: &Keypair,
-) {
-    use serde_json::json;
-
-    let home_dir = home_dir.as_ref();
-    let path = home_dir.join("config").join("priv_validator_key.json");
-    let file =
-        File::create(path).expect("Couldn't create private validator key file");
-    let pk: ed25519_dalek::PublicKey =
-        validator.pos_data.consensus_key.clone().into();
-    let pk = base64::encode(pk.as_bytes());
-    let sk = base64::encode(validator_key.to_bytes());
-    let address = validator.pos_data.address.raw_hash().unwrap();
-    let key = json!({
-       "address": address,
-       "pub_key": {
-         "type": "tendermint/PubKeyEd25519",
-         "value": pk,
-       },
-       "priv_key": {
-         "type": "tendermint/PrivKeyEd25519",
-         "value": sk,
-      }
-    });
-    serde_json::to_writer_pretty(file, &key)
-        .expect("Couldn't write private validator key file");
 }
 
 fn write_chain_id(home_dir: impl AsRef<Path>, chain_id: impl AsRef<str>) {

--- a/shared/src/types/address.rs
+++ b/shared/src/types/address.rs
@@ -398,12 +398,29 @@ pub mod tests {
     }
 }
 
+/// Generate a new established address.
+#[cfg(feature = "rand")]
+pub fn gen_established_address(seed: impl AsRef<str>) -> Address {
+    use rand::prelude::ThreadRng;
+    use rand::{thread_rng, RngCore};
+
+    let mut key_gen = EstablishedAddressGen::new(seed);
+
+    let mut rng: ThreadRng = thread_rng();
+    let mut rng_bytes = vec![0u8; 32];
+    rng.fill_bytes(&mut rng_bytes[..]);
+    let rng_source = rng_bytes
+        .iter()
+        .map(|b| format!("{:02X}", b))
+        .collect::<Vec<String>>()
+        .join("");
+    key_gen.generate_address(rng_source)
+}
+
 /// Helpers for testing with addresses.
 #[cfg(any(test, feature = "testing"))]
 pub mod testing {
     use proptest::prelude::*;
-    use rand::prelude::ThreadRng;
-    use rand::{thread_rng, RngCore};
 
     use super::*;
     use crate::types::key::ed25519;
@@ -411,17 +428,7 @@ pub mod testing {
     /// Generate a new established address.
     pub fn gen_established_address() -> Address {
         let seed = "such randomness, much wow";
-        let mut key_gen = EstablishedAddressGen::new(seed);
-
-        let mut rng: ThreadRng = thread_rng();
-        let mut rng_bytes = vec![0u8; 32];
-        rng.fill_bytes(&mut rng_bytes[..]);
-        let rng_source = rng_bytes
-            .iter()
-            .map(|b| format!("{:02X}", b))
-            .collect::<Vec<String>>()
-            .join("");
-        key_gen.generate_address(rng_source)
+        super::gen_established_address(seed)
     }
 
     /// A sampled established address for tests

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -38,15 +38,6 @@ pub fn generate_network_of(
     while index < n_of_peers {
         let node_path = path.join(format!("anoma-{}", index));
 
-        let mut config = Config {
-            ledger: Some(Ledger {
-                tendermint: node_path.join("tendermint").to_path_buf(),
-                db: node_path.join("db").to_path_buf(),
-                ..Default::default()
-            }),
-            ..Config::default()
-        };
-
         let info = build_peers(index, node_dirs.clone());
 
         let gossiper_config = IntentGossiper::default_with_address(
@@ -63,7 +54,14 @@ pub fn generate_network_of(
 
         node_dirs.push((node_path.clone(), peer_id));
 
-        config.intent_gossiper = Some(gossiper_config);
+        let config = Config {
+            ledger: Ledger {
+                tendermint: node_path.join("tendermint").to_path_buf(),
+                db: node_path.join("db").to_path_buf(),
+                ..Default::default()
+            },
+            intent_gossiper: gossiper_config,
+        };
 
         config.write(&node_path, false).unwrap();
         index += 1;


### PR DESCRIPTION
closes #457 

This PR adds a utils cmd `anomac utils init-genesis-validator --alias my-validator` that will initialize genesis validator's address, staking reward address, consensus key, validator account key and staking rewards key, add them to the wallet and setup the ledger's node (concretely, it creates `{base_dir}/tendermint/config/priv_validator_key.json` and `{base_dir}/tendermint/data/priv_validator_data.json`). It will also print out the genesis config for the created validator to stdout (TOML format pending on #425).