### PR TITLE
sym-link rust-nightly-version

### DIFF
--- a/apps/build.rs
+++ b/apps/build.rs
@@ -6,7 +6,7 @@ use std::{env, str};
 const PROTO_SRC: &str = "./proto";
 
 /// The version should match the one we use in the `Makefile`
-const RUSTFMT_TOOLCHAIN_SRC: &str = "../rust-nightly-version";
+const RUSTFMT_TOOLCHAIN_SRC: &str = "./rust-nightly-version";
 
 fn main() {
     // Tell Cargo that if the given file changes, to rerun this build script.

--- a/apps/rust-nightly-version
+++ b/apps/rust-nightly-version
@@ -1,0 +1,1 @@
+../rust-nightly-version

--- a/shared/build.rs
+++ b/shared/build.rs
@@ -6,7 +6,7 @@ use std::{env, str};
 const PROTO_SRC: &str = "./proto";
 
 /// The version should match the one we use in the `Makefile`
-const RUSTFMT_TOOLCHAIN_SRC: &str = "../rust-nightly-version";
+const RUSTFMT_TOOLCHAIN_SRC: &str = "./rust-nightly-version";
 
 fn main() {
     if let Ok(val) = env::var("COMPILE_PROTO") {

--- a/shared/rust-nightly-version
+++ b/shared/rust-nightly-version
@@ -1,0 +1,1 @@
+../rust-nightly-version


### PR DESCRIPTION
Similar to what was done in #467 for the proto files, this adds a symlink to the `rust-nightly-version` in `apps` and `shared` that use it in their build.rs script. This fixes rust-analyzer which runs from the workspace root and fails to find these from the previous relative path `../rust-nightly-version`.