### PR TITLE
wasm dir global arg

### DIFF
--- a/apps/src/bin/anoma-node/cli.rs
+++ b/apps/src/bin/anoma-node/cli.rs
@@ -10,7 +10,7 @@ pub fn main() -> Result<()> {
     match cmd {
         cli::cmds::AnomaNode::Ledger(sub) => match sub {
             cli::cmds::Ledger::Run(_) => {
-                ledger::run(ctx.config.ledger);
+                ledger::run(ctx.config.ledger, ctx.global_args.wasm_dir);
             }
             cli::cmds::Ledger::Reset(_) => {
                 ledger::reset(ctx.config.ledger)

--- a/apps/src/bin/anoma-node/cli.rs
+++ b/apps/src/bin/anoma-node/cli.rs
@@ -10,7 +10,7 @@ pub fn main() -> Result<()> {
     match cmd {
         cli::cmds::AnomaNode::Ledger(sub) => match sub {
             cli::cmds::Ledger::Run(_) => {
-                ledger::run(ctx.config.ledger, ctx.global_args.wasm_dir);
+                ledger::run(ctx.config.ledger);
             }
             cli::cmds::Ledger::Reset(_) => {
                 ledger::reset(ctx.config.ledger)

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -1091,19 +1091,13 @@ pub mod args {
         arg_opt("consensus-key");
     const VALIDATOR_CODE_PATH: ArgOpt<PathBuf> = arg_opt("validator-code-path");
     const VALUE: ArgOpt<String> = arg_opt("value");
-    const WASM_DIR: ArgDefault<PathBuf> = arg_default(
-        "wasm-dir",
-        DefaultFn(|| match env::var("ANOMA_WASM_DIR") {
-            Ok(wasm_dir) => wasm_dir.into(),
-            Err(_) => "wasm".into(),
-        }),
-    );
+    const WASM_DIR: ArgOpt<PathBuf> = arg_opt("wasm-dir");
 
     /// Global command arguments
     #[derive(Clone, Debug)]
     pub struct Global {
         pub base_dir: PathBuf,
-        pub wasm_dir: PathBuf,
+        pub wasm_dir: Option<PathBuf>,
     }
 
     impl Global {

--- a/apps/src/lib/cli/context.rs
+++ b/apps/src/lib/cli/context.rs
@@ -1,7 +1,7 @@
 //! CLI input types can be used for command arguments
 
 use std::marker::PhantomData;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::str::FromStr;
 
@@ -81,6 +81,23 @@ impl Context {
         T: ArgFromMutContext,
     {
         from_context.map(|from_context| from_context.from_mut_ctx(self))
+    }
+
+    /// Read the given WASM file from the WASM directory.
+    pub fn read_wasm(
+        &self,
+        file_name: impl AsRef<Path>,
+    ) -> std::io::Result<Vec<u8>> {
+        std::fs::read(self.wasm_path(file_name))
+    }
+
+    /// Find the path to the given WASM file name.
+    pub fn wasm_path(&self, file_name: impl AsRef<Path>) -> PathBuf {
+        let file_path = file_name.as_ref();
+        if file_path.is_absolute() {
+            return file_path.into();
+        }
+        self.global_args.wasm_dir.join(file_name)
     }
 }
 

--- a/apps/src/lib/client/tx.rs
+++ b/apps/src/lib/client/tx.rs
@@ -19,17 +19,18 @@ use crate::client::tendermint_websocket_client::{
 };
 use crate::node::ledger::tendermint_node;
 
-const TX_INIT_ACCOUNT_WASM: &str = "wasm/tx_init_account.wasm";
-const TX_INIT_VALIDATOR_WASM: &str = "wasm/tx_init_validator.wasm";
-const TX_UPDATE_VP_WASM: &str = "wasm/tx_update_vp.wasm";
-const TX_TRANSFER_WASM: &str = "wasm/tx_transfer.wasm";
-const VP_USER_WASM: &str = "wasm/vp_user.wasm";
-const TX_BOND_WASM: &str = "wasm/tx_bond.wasm";
-const TX_UNBOND_WASM: &str = "wasm/tx_unbond.wasm";
-const TX_WITHDRAW_WASM: &str = "wasm/tx_withdraw.wasm";
+const TX_INIT_ACCOUNT_WASM: &str = "tx_init_account.wasm";
+const TX_INIT_VALIDATOR_WASM: &str = "tx_init_validator.wasm";
+const TX_UPDATE_VP_WASM: &str = "tx_update_vp.wasm";
+const TX_TRANSFER_WASM: &str = "tx_transfer.wasm";
+const VP_USER_WASM: &str = "vp_user.wasm";
+const TX_BOND_WASM: &str = "tx_bond.wasm";
+const TX_UNBOND_WASM: &str = "tx_unbond.wasm";
+const TX_WITHDRAW_WASM: &str = "tx_withdraw.wasm";
 
 pub async fn submit_custom(mut ctx: Context, args: args::TxCustom) {
-    let tx_code = std::fs::read(args.code_path)
+    let tx_code = ctx
+        .read_wasm(args.code_path)
         .expect("Expected a file at given code path");
     let data = args.data_path.map(|data_path| {
         std::fs::read(data_path).expect("Expected a file at given data path")
@@ -65,9 +66,11 @@ pub async fn submit_update_vp(mut ctx: Context, args: args::TxUpdateVp) {
     )
     .await;
 
-    let vp_code = std::fs::read(args.vp_code_path)
+    let vp_code = ctx
+        .read_wasm(args.vp_code_path)
         .expect("Expected a file at given code path");
-    let tx_code = std::fs::read(TX_UPDATE_VP_WASM)
+    let tx_code = ctx
+        .read_wasm(TX_UPDATE_VP_WASM)
         .expect("Expected a file at given code path");
 
     let update_vp = UpdateVp {
@@ -94,13 +97,15 @@ pub async fn submit_init_account(mut ctx: Context, args: args::TxInitAccount) {
     let vp_code = args
         .vp_code_path
         .map(|path| {
-            std::fs::read(path).expect("Expected a file at given code path")
+            ctx.read_wasm(path)
+                .expect("Expected a file at given code path")
         })
         .unwrap_or_else(|| {
-            std::fs::read(VP_USER_WASM)
+            ctx.read_wasm(VP_USER_WASM)
                 .expect("Expected a file at given code path")
         });
-    let tx_code = std::fs::read(TX_INIT_ACCOUNT_WASM)
+    let tx_code = ctx
+        .read_wasm(TX_INIT_ACCOUNT_WASM)
         .expect("Expected a file at given code path");
 
     let data = InitAccount {
@@ -177,21 +182,24 @@ pub async fn submit_init_validator(
 
     let validator_vp_code = validator_vp_code_path
         .map(|path| {
-            std::fs::read(path).expect("Expected a file at given code path")
+            ctx.read_wasm(path)
+                .expect("Expected a file at given code path")
         })
         .unwrap_or_else(|| {
-            std::fs::read(VP_USER_WASM)
+            ctx.read_wasm(VP_USER_WASM)
                 .expect("Expected a file at given code path")
         });
     let rewards_vp_code = rewards_vp_code_path
         .map(|path| {
-            std::fs::read(path).expect("Expected a file at given code path")
+            ctx.read_wasm(path)
+                .expect("Expected a file at given code path")
         })
         .unwrap_or_else(|| {
-            std::fs::read(VP_USER_WASM)
+            ctx.read_wasm(VP_USER_WASM)
                 .expect("Expected a file at given code path")
         });
-    let tx_code = std::fs::read(TX_INIT_VALIDATOR_WASM)
+    let tx_code = ctx
+        .read_wasm(TX_INIT_VALIDATOR_WASM)
         .expect("Expected a file at given code path");
 
     let data = InitValidator {
@@ -320,7 +328,7 @@ pub async fn submit_transfer(mut ctx: Context, args: args::TxTransfer) {
     )
     .await;
 
-    let tx_code = std::fs::read(TX_TRANSFER_WASM).unwrap();
+    let tx_code = ctx.read_wasm(TX_TRANSFER_WASM).unwrap();
     let transfer = token::Transfer {
         source,
         target,
@@ -346,7 +354,7 @@ pub async fn submit_bond(mut ctx: Context, args: args::Bond) {
         args.tx.ledger_address.clone(),
     )
     .await;
-    let tx_code = std::fs::read(TX_BOND_WASM).unwrap();
+    let tx_code = ctx.read_wasm(TX_BOND_WASM).unwrap();
 
     let bond = pos::Bond {
         validator,
@@ -370,7 +378,7 @@ pub async fn submit_unbond(mut ctx: Context, args: args::Unbond) {
         args.tx.ledger_address.clone(),
     )
     .await;
-    let tx_code = std::fs::read(TX_UNBOND_WASM).unwrap();
+    let tx_code = ctx.read_wasm(TX_UNBOND_WASM).unwrap();
 
     let unbond = pos::Unbond {
         validator,
@@ -396,7 +404,7 @@ pub async fn submit_withdraw(mut ctx: Context, args: args::Withdraw) {
         args.tx.ledger_address.clone(),
     )
     .await;
-    let tx_code = std::fs::read(TX_WITHDRAW_WASM).unwrap();
+    let tx_code = ctx.read_wasm(TX_WITHDRAW_WASM).unwrap();
 
     let withdraw = pos::Withdraw { validator, source };
     tracing::debug!("Withdraw data {:?}", withdraw);

--- a/apps/src/lib/config/genesis.rs
+++ b/apps/src/lib/config/genesis.rs
@@ -75,8 +75,8 @@ pub fn genesis() -> Genesis {
 
     use crate::wallet;
 
-    let vp_token_path = "wasm/vp_token.wasm";
-    let vp_user_path = "wasm/vp_user.wasm";
+    let vp_token_path = "vp_token.wasm";
+    let vp_user_path = "vp_user.wasm";
 
     // NOTE When the validator's key changes, tendermint must be reset with
     // `anoma reset` command. To generate a new validator, use the

--- a/apps/src/lib/config/mod.rs
+++ b/apps/src/lib/config/mod.rs
@@ -91,6 +91,7 @@ pub struct Ledger {
     pub ledger_address: SocketAddr,
     pub rpc_address: SocketAddr,
     pub p2p_address: SocketAddr,
+    pub wasm_dir: PathBuf,
 }
 
 impl Default for Ledger {
@@ -112,6 +113,7 @@ impl Default for Ledger {
                 IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
                 26656,
             ),
+            wasm_dir: "wasm".into(),
         }
     }
 }

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -7,7 +7,6 @@ pub mod storage;
 pub mod tendermint_node;
 
 use std::convert::{TryFrom, TryInto};
-use std::path::PathBuf;
 use std::sync::mpsc::channel;
 
 use anoma::types::storage::BlockHash;
@@ -169,13 +168,12 @@ pub fn reset(config: config::Ledger) -> Result<(), shell::Error> {
 async fn run_shell(
     config: config::Ledger,
     abort_registration: AbortRegistration,
-    wasm_dir: PathBuf,
 ) {
     // Construct our ABCI application.
     let service = AbcippShim::new(
         &config.db,
         config::DEFAULT_CHAIN_ID.to_owned(),
-        wasm_dir,
+        config.wasm_dir,
     );
 
     // Split it into components.
@@ -219,7 +217,7 @@ async fn run_shell(
 ///
 /// When the shell process finishes, we check if it finished with a panic. If it
 /// did we stop the tendermint node with a channel that acts as a kill switch.
-pub fn run(config: config::Ledger, wasm_dir: PathBuf) {
+pub fn run(config: config::Ledger) {
     let home_dir = config.tendermint.clone();
     let ledger_address = config.ledger_address.to_string();
     let rpc_address = config.rpc_address.to_string();
@@ -256,7 +254,7 @@ pub fn run(config: config::Ledger, wasm_dir: PathBuf) {
 
     // start the shell + ABCI server
     let shell_handle = std::thread::spawn(move || {
-        run_shell(config, abort_registration, wasm_dir);
+        run_shell(config, abort_registration);
     });
 
     tracing::info!("Anoma ledger node started.");

--- a/apps/src/lib/node/ledger/shims/abcipp_shim.rs
+++ b/apps/src/lib/node/ledger/shims/abcipp_shim.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 use std::future::Future;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -24,9 +24,13 @@ pub struct AbcippShim {
 }
 
 impl AbcippShim {
-    pub fn new(db_path: impl AsRef<Path>, chain_id: String) -> Self {
+    pub fn new(
+        db_path: impl AsRef<Path>,
+        chain_id: String,
+        wasm_dir: PathBuf,
+    ) -> Self {
         Self {
-            service: Shell::new(db_path, chain_id),
+            service: Shell::new(db_path, chain_id, wasm_dir),
             block_txs: vec![],
         }
     }

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -231,6 +231,11 @@ fn ledger_txs_and_queries() -> Result<()> {
         .exp_string("Started node")
         .map_err(|e| eyre!(format!("{}", e)))?;
 
+    let vp_user = wasm_abs_path(VP_USER_WASM);
+    let vp_user = vp_user.to_string_lossy();
+    let tx_no_op = wasm_abs_path(TX_NO_OP_WASM);
+    let tx_no_op = tx_no_op.to_string_lossy();
+
     let txs_args = vec![
             // 2. Submit a token transfer tx
             vec![
@@ -239,12 +244,12 @@ fn ledger_txs_and_queries() -> Result<()> {
             ],
             // 3. Submit a transaction to update an account's validity
             // predicate
-            vec!["update", "--address", BERTHA, "--code-path", VP_USER_WASM],
+            vec!["update", "--address", BERTHA, "--code-path", &vp_user],
             // 4. Submit a custom tx
             vec![
                 "tx",
                 "--code-path",
-                TX_NO_OP_WASM,
+                &tx_no_op,
                 "--data-path",
                 "README.md",
             ],
@@ -257,7 +262,7 @@ fn ledger_txs_and_queries() -> Result<()> {
                 // Value obtained from `anoma::types::key::ed25519::tests::gen_keypair`
                 "200000001be519a321e29020fa3cbfbfd01bd5e92db134305609270b71dace25b5a21168",
                 "--code-path",
-                VP_USER_WASM,
+                &vp_user,
                 "--alias",
                 "test-account"
             ],
@@ -372,19 +377,18 @@ fn invalid_transactions() -> Result<()> {
         .try_to_vec()
         .expect("Encoding unsigned transfer shouldn't fail");
     let source_key = wallet::defaults::key_of(BERTHA);
-    let tx_wasm_path = TX_MINT_TOKENS_WASM;
-    let tx_wasm_path_abs = working_dir.join(&tx_wasm_path);
-    println!("Reading tx wasm for test from {:?}", tx_wasm_path_abs);
-    let tx_code = fs::read(tx_wasm_path_abs).unwrap();
+    let tx_wasm_path = wasm_abs_path(TX_MINT_TOKENS_WASM);
+    let tx_code = fs::read(&tx_wasm_path).unwrap();
     let tx = Tx::new(tx_code, Some(data)).sign(&source_key);
 
     let tx_data = tx.data.unwrap();
     std::fs::write(&tx_data_path, tx_data).unwrap();
+    let tx_wasm_path = tx_wasm_path.to_string_lossy();
     let tx_data_path = tx_data_path.to_string_lossy();
     let tx_args = vec![
         "tx",
         "--code-path",
-        tx_wasm_path,
+        &tx_wasm_path,
         "--data-path",
         &tx_data_path,
     ];

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -89,6 +89,8 @@ fn build_peers(
 
 #[allow(dead_code)]
 pub mod constants {
+    use std::fs;
+    use std::path::PathBuf;
 
     // User addresses
     pub const ALBERT: &str = "a1qq5qqqqqg4znssfsgcurjsfhgfpy2vjyxy6yg3z98pp5zvp5xgersvfjxvcnx3f4xycrzdfkak0xhx";
@@ -115,4 +117,10 @@ pub mod constants {
     pub const VP_ALWAYS_FALSE_WASM: &str =
         "wasm_for_tests/vp_always_false.wasm";
     pub const TX_MINT_TOKENS_WASM: &str = "wasm_for_tests/tx_mint_tokens.wasm";
+
+    /// Find the absolute path to one of the WASM files above
+    pub fn wasm_abs_path(file_name: &str) -> PathBuf {
+        let working_dir = fs::canonicalize("..").unwrap();
+        working_dir.join(file_name)
+    }
 }


### PR DESCRIPTION
This PR adds `--wasm-dir` global arg (related to #451 and #453). They also uses `ANOMA_BASE_DIR` and `ANOMA_WASM_DIR` env vars as default when the `base-dir` and/or `wasm-dir` are not specified.