### PR TITLE
wasm_for_tests: Cargo.lock updates

### DIFF
--- a/wasm_for_tests/wasm_source/Cargo.lock
+++ b/wasm_for_tests/wasm_source/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "borsh",
  "chrono",
  "ed25519-dalek",
+ "hex",
  "itertools",
  "loupe",
  "parity-wasm",
@@ -743,6 +744,12 @@ checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "ident_case"
@@ -1642,7 +1649,7 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.20.0"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=tomas/update-genesis-new-prost#460c428953e298d17344092dab930f371e015657"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=tomas/lowercase-node-id#ca0bffdde9a3f1597aea3e0faf518de453b72518"
 dependencies = [
  "anomaly",
  "async-trait",
@@ -1673,7 +1680,7 @@ dependencies = [
 [[package]]
 name = "tendermint-proto"
 version = "0.20.0"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=tomas/update-genesis-new-prost#460c428953e298d17344092dab930f371e015657"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=tomas/lowercase-node-id#ca0bffdde9a3f1597aea3e0faf518de453b72518"
 dependencies = [
  "anomaly",
  "bytes",


### PR DESCRIPTION
Missing the hex package (3b5825a8, "add ed sk wrapper and pk/sk hex
encoding") and a different tendermint-rs branch (7b6eb821, "Added
ability for storage to lookup [...]").