### PR TITLE
allow to explicitly set tx signer or signing-key for any tx cmd

### DIFF
--- a/apps/src/bin/anoma-node/cli.rs
+++ b/apps/src/bin/anoma-node/cli.rs
@@ -19,8 +19,8 @@ pub fn main() -> Result<()> {
         },
         cli::cmds::AnomaNode::Gossip(sub) => match sub {
             cli::cmds::Gossip::Run(cli::cmds::GossipRun(args)) => {
-                let tx_source_address = ctx.get_opt(args.tx_source_address);
-                let tx_signing_key = ctx.get_opt_cached(args.tx_signing_key);
+                let tx_source_address = ctx.get_opt(&args.tx_source_address);
+                let tx_signing_key = ctx.get_opt_cached(&args.tx_signing_key);
                 let config = ctx.config;
                 let mut gossip_cfg = config.intent_gossiper;
                 gossip_cfg.update(

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -6,7 +6,7 @@
 //! client can be dispatched via `anoma node ...` or `anoma client ...`,
 //! respectively.
 
-mod context;
+pub mod context;
 mod utils;
 
 use clap::{AppSettings, ArgMatches};
@@ -1137,10 +1137,6 @@ pub mod args {
         pub code_path: PathBuf,
         /// Path to the data file
         pub data_path: Option<PathBuf>,
-        /// Sign the tx with the key for the given alias from your wallet
-        pub signing_key: Option<WalletKeypair>,
-        /// Sign the tx with the keypair of the public key of the given address
-        pub signer: Option<WalletAddress>,
     }
 
     impl Args for TxCustom {
@@ -1148,14 +1144,10 @@ pub mod args {
             let tx = Tx::parse(matches);
             let code_path = CODE_PATH.parse(matches);
             let data_path = DATA_PATH_OPT.parse(matches);
-            let signing_key = SIGNING_KEY_OPT.parse(matches);
-            let signer = SIGNER.parse(matches);
             Self {
                 tx,
                 code_path,
                 data_path,
-                signing_key,
-                signer,
             }
         }
 
@@ -1171,25 +1163,6 @@ pub mod args {
                      will be passed to the transaction code when it's \
                      executed.",
                 ))
-                .arg(
-                    SIGNING_KEY_OPT
-                        .def()
-                        .about(
-                            "Sign the transaction with the key for the given \
-                             public key, public key hash or alias from your \
-                             wallet.",
-                        )
-                        .conflicts_with(SIGNER.name),
-                )
-                .arg(
-                    SIGNER
-                        .def()
-                        .about(
-                            "Sign the transaction with the keypair of the \
-                             public key of the given address.",
-                        )
-                        .conflicts_with(SIGNING_KEY_OPT.name),
-                )
         }
     }
 
@@ -1918,6 +1891,10 @@ pub mod args {
         /// If any new account is initialized by the tx, use the given alias to
         /// save it in the wallet.
         pub initialized_account_alias: Option<String>,
+        /// Sign the tx with the key for the given alias from your wallet
+        pub signing_key: Option<WalletKeypair>,
+        /// Sign the tx with the keypair of the public key of the given address
+        pub signer: Option<WalletAddress>,
     }
 
     impl Args for Tx {
@@ -1934,16 +1911,39 @@ pub mod args {
                  initialized, the alias will be the prefix of each new \
                  address joined with a number.",
             ))
+            .arg(
+                SIGNING_KEY_OPT
+                    .def()
+                    .about(
+                        "Sign the transaction with the key for the given \
+                         public key, public key hash or alias from your \
+                         wallet.",
+                    )
+                    .conflicts_with(SIGNER.name),
+            )
+            .arg(
+                SIGNER
+                    .def()
+                    .about(
+                        "Sign the transaction with the keypair of the public \
+                         key of the given address.",
+                    )
+                    .conflicts_with(SIGNING_KEY_OPT.name),
+            )
         }
 
         fn parse(matches: &ArgMatches) -> Self {
             let dry_run = DRY_RUN_TX.parse(matches);
             let ledger_address = LEDGER_ADDRESS_DEFAULT.parse(matches);
             let initialized_account_alias = ALIAS_OPT.parse(matches);
+            let signing_key = SIGNING_KEY_OPT.parse(matches);
+            let signer = SIGNER.parse(matches);
             Self {
                 dry_run,
                 ledger_address,
                 initialized_account_alias,
+                signing_key,
+                signer,
             }
         }
     }

--- a/apps/src/lib/cli/context.rs
+++ b/apps/src/lib/cli/context.rs
@@ -61,7 +61,7 @@ impl Context {
     }
 
     /// Parse and/or look-up the value from the context.
-    pub fn get<T>(&self, from_context: FromContext<T>) -> T
+    pub fn get<T>(&self, from_context: &FromContext<T>) -> T
     where
         T: ArgFromContext,
     {
@@ -69,15 +69,17 @@ impl Context {
     }
 
     /// Try to parse and/or look-up an optional value from the context.
-    pub fn get_opt<T>(&self, from_context: Option<FromContext<T>>) -> Option<T>
+    pub fn get_opt<T>(&self, from_context: &Option<FromContext<T>>) -> Option<T>
     where
         T: ArgFromContext,
     {
-        from_context.map(|from_context| from_context.from_ctx(self))
+        from_context
+            .as_ref()
+            .map(|from_context| from_context.from_ctx(self))
     }
 
     /// Parse and/or look-up the value from the context with cache.
-    pub fn get_cached<T>(&mut self, from_context: FromContext<T>) -> T
+    pub fn get_cached<T>(&mut self, from_context: &FromContext<T>) -> T
     where
         T: ArgFromMutContext,
     {
@@ -88,12 +90,14 @@ impl Context {
     /// cache.
     pub fn get_opt_cached<T>(
         &mut self,
-        from_context: Option<FromContext<T>>,
+        from_context: &Option<FromContext<T>>,
     ) -> Option<T>
     where
         T: ArgFromMutContext,
     {
-        from_context.map(|from_context| from_context.from_mut_ctx(self))
+        from_context
+            .as_ref()
+            .map(|from_context| from_context.from_mut_ctx(self))
     }
 
     /// Read the given WASM file from the WASM directory.

--- a/apps/src/lib/client/gossip.rs
+++ b/apps/src/lib/client/gossip.rs
@@ -34,10 +34,10 @@ pub async fn gossip_intent(
         signed_exchanges.insert(signed);
     }
 
-    let source_keypair = match ctx.get_opt_cached(signing_key) {
+    let source_keypair = match ctx.get_opt_cached(&signing_key) {
         Some(key) => key,
         None => {
-            let source = ctx.get_opt(source).unwrap_or_else(|| {
+            let source = ctx.get_opt(&source).unwrap_or_else(|| {
                 eprintln!("A source or a signing key is required.");
                 cli::safe_exit(1)
             });

--- a/apps/src/lib/client/rpc.rs
+++ b/apps/src/lib/client/rpc.rs
@@ -60,8 +60,8 @@ pub async fn query_balance(ctx: Context, args: args::QueryBalance) {
     let tokens = address::tokens();
     match (args.token, args.owner) {
         (Some(token), Some(owner)) => {
-            let token = ctx.get(token);
-            let owner = ctx.get(owner);
+            let token = ctx.get(&token);
+            let owner = ctx.get(&owner);
             let key = token::balance_key(&token, &owner);
             let currency_code = tokens
                 .get(&token)
@@ -77,7 +77,7 @@ pub async fn query_balance(ctx: Context, args: args::QueryBalance) {
             }
         }
         (None, Some(owner)) => {
-            let owner = ctx.get(owner);
+            let owner = ctx.get(&owner);
             let mut found_any = false;
             for (token, currency_code) in tokens {
                 let key = token::balance_key(&token, &owner);
@@ -94,7 +94,7 @@ pub async fn query_balance(ctx: Context, args: args::QueryBalance) {
             }
         }
         (Some(token), None) => {
-            let token = ctx.get(token);
+            let token = ctx.get(&token);
             let key = token::balance_prefix(&token);
             let balances =
                 query_storage_prefix::<token::Amount>(client, key).await;
@@ -153,8 +153,8 @@ pub async fn query_bonds(ctx: Context, args: args::QueryBonds) {
         let client = HttpClient::new(args.query.ledger_address).unwrap();
         match (args.owner, args.validator) {
             (Some(owner), Some(validator)) => {
-                let source = ctx.get(owner);
-                let validator = ctx.get(validator);
+                let source = ctx.get(&owner);
+                let validator = ctx.get(&validator);
                 // Find owner's delegations to the given validator
                 let bond_id = pos::BondId { source, validator };
                 let bond_key = pos::bond_key(&bond_id);
@@ -215,7 +215,7 @@ pub async fn query_bonds(ctx: Context, args: args::QueryBonds) {
                 }
             }
             (None, Some(validator)) => {
-                let validator = ctx.get(validator);
+                let validator = ctx.get(&validator);
                 // Find validator's self-bonds
                 let bond_id = pos::BondId {
                     source: validator.clone(),
@@ -267,7 +267,7 @@ pub async fn query_bonds(ctx: Context, args: args::QueryBonds) {
                 }
             }
             (Some(owner), None) => {
-                let owner = ctx.get(owner);
+                let owner = ctx.get(&owner);
                 // Find owner's bonds to any validator
                 let bonds_prefix = pos::bonds_for_source_prefix(&owner);
                 let bonds = query_storage_prefix::<pos::Bonds>(
@@ -549,7 +549,7 @@ pub async fn query_voting_power(ctx: Context, args: args::QueryVotingPower) {
             .expect("Validator set should be always set in the current epoch");
         match args.validator {
             Some(validator) => {
-                let validator = ctx.get(validator);
+                let validator = ctx.get(&validator);
                 // Find voting power for the given validator
                 let voting_power_key =
                     pos::validator_voting_power_key(&validator);
@@ -639,7 +639,7 @@ pub async fn query_slashes(ctx: Context, args: args::QuerySlashes) {
     let client = HttpClient::new(args.query.ledger_address).unwrap();
     match args.validator {
         Some(validator) => {
-            let validator = ctx.get(validator);
+            let validator = ctx.get(&validator);
             // Find slashes for the given validator
             let slashes_key = pos::validator_slashes_key(&validator);
             let slashes = query_storage_value::<pos::Slashes>(


### PR DESCRIPTION
This PR:
- moves the explicit `--signing-key`/`--signer` arguments from the `cmds::TxCustom` to the common transaction arguments `args::Tx`, to allow to override the default signer for any tx command
- adds a helper function `tx::sign_tx`
- makes `anoma_apps::cli::context` module public
- use ref for context look-ups (owned values are not needed)