### PR TITLE
review of user-docs

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -6,7 +6,7 @@ language = "en"
 multilingual = false
 site-url = "https://anoma.github.io/anoma/"
 src = "src"
-title = "Anoma - Technical Specifications"
+title = "Anoma - DOCS"
 
 [output.html]
 additional-css = ["assets/custom.css"]

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -1,4 +1,18 @@
 # Introduction
+Welcome to Anoma's docs!
+
+## About Anoma
+[Anoma](https://anoma.network/) is a sovereign, proof-of-stake blockchain protocol that enables private, asset-agnostic cash and private bartering among any number of parties. To learn more about the protocol, we recommend the following resources:
+- [Introduction to Anoma Medium article](https://medium.com/anomanetwork/introducing-anoma-a-blockchain-for-private-asset-agnostic-bartering-dcc47ac42d9f)
+- [Anoma's Whitepaper](https://anoma.network/papers/whitepaper.pdf)
+- [Anoma's Vision paper](https://anoma.network/papers/vision-paper.pdf)
+
+### Anoma's current testnet: Feigenbaum
+Feigenbaum is the name of Anoma's first public testnet. Find `feigenbaum` on [Github](https://github.com/anoma/anoma/releases).
+
+> ⚠️ Here lay dragons: this codebase is still experimental, try at your own risk!
+
+## About the documentation
 
 The three main sections of this book are:
 
@@ -6,19 +20,20 @@ The three main sections of this book are:
 - [Exploration](./explore): documents the process of exploring the design and implementation space for Anoma
 - [Specifications](./specs): implementation independent technical specifications
 
-## The source
+### The source
 
 This book is written using [mdBook](https://rust-lang.github.io/mdBook/) with [mdbook-mermaid](https://github.com/badboy/mdbook-mermaid) for diagrams, it currently lives in the [Anoma repo](https://github.com/anoma/anoma).
 
-To get started quickly, one can:
+To get started quickly, in the `docs` directory one can:
 
 ```shell
 # Install dependencies
 make dev-deps
+
 # This will open the book in your default browser and rebuild on changes
 make serve
 ```
 
 The mermaid diagrams docs can be found at <https://mermaid-js.github.io/mermaid>.
 
-Contributions to the contents and the structure of this book (nothing is set in stone) should be made via pull requests. Code changes that diverge from the spec should also update this book.
+[Contributions](https://github.com/anoma/anoma/issues) to the contents and the structure of this book (nothing is set in stone) should be made via pull requests. Code changes that diverge from the spec should also update this book.

--- a/docs/src/explore/design/dkg.md
+++ b/docs/src/explore/design/dkg.md
@@ -1,1 +1,2 @@
 # Distributed key generation gossip
+> ⚠️ This section is WIP.

--- a/docs/src/explore/design/gossip.md
+++ b/docs/src/explore/design/gossip.md
@@ -14,4 +14,4 @@ generation application.
 
 ![gossip process](./gossip_process.svg  "gossip process")
 
-[exilidraw link](https://excalidraw.com/#room=5d4a2a84ef52cf5f5f96,r4ghl40frJ9putMy-0vyOQ)
+[Diagram on Excalidraw](https://excalidraw.com/#room=5d4a2a84ef52cf5f5f96,r4ghl40frJ9putMy-0vyOQ)

--- a/docs/src/explore/design/intent_gossip/intent_gossip.md
+++ b/docs/src/explore/design/intent_gossip/intent_gossip.md
@@ -38,7 +38,7 @@ These three intents express user desires to exchange assets.
 
 ![intent gossip and ledger network
 interaction](./example.svg "intent gossip network")
-[exilidraw link](https://excalidraw.com/#room=257e44f4b4b5867bf541,XDEKyGVIpqCrfq55bRqKug)
+[Diagram on Excalidraw](https://excalidraw.com/#room=257e44f4b4b5867bf541,XDEKyGVIpqCrfq55bRqKug)
 
 # Flow diagram: life cycle of intent and global process
 
@@ -47,5 +47,5 @@ desire to the ledger executing the validity predicate to check the crafted
 transaction.
 
 ![intent life cycle](./intent_life_cycle.svg "intent life
-cycle") [exilidraw
-link](https://excalidraw.com/#room=7ac107b3757c64049003,cdMInfvdLtjaGWSZWEKrhw)
+cycle") 
+[Diagram on Excalidraw](https://excalidraw.com/#room=7ac107b3757c64049003,cdMInfvdLtjaGWSZWEKrhw)

--- a/docs/src/explore/design/ledger/wasm-vm.md
+++ b/docs/src/explore/design/ledger/wasm-vm.md
@@ -102,7 +102,7 @@ A validity predicate can read its prior state directly from storage as it is not
 The write log of each transaction included in a block and accepted by VPs is accumulated into the block write log. Once the block is committed, we apply the storage changes from the block write log to the persistent storage.
 
 ![write log](./wasm-vm/storage-write-log.svg  "storage write log")
-<https://excalidraw.com/new#room=333e1db689b083669c80,Y0i8yhvIAZCFICs753CSuA>
+[Diagram on Excalidraw](https://excalidraw.com/new#room=333e1db689b083669c80,Y0i8yhvIAZCFICs753CSuA)
 
 ## Gas metering
 

--- a/docs/src/explore/design/overview.md
+++ b/docs/src/explore/design/overview.md
@@ -1,8 +1,10 @@
 # Overview
 
+> ⚠️ This section is WIP.
+
 - TODO: add high-level interaction diagram(s)
 
 The Rust crates internal dependency graph:
 
 ![crates](./overview/crates.svg  "crates")
-<https://excalidraw.com/#room=e32fc914de750ed4f5e4,6CWRFjnmCoiFR4BQ6i9K4g>
+[Diagram on Excalidraw](https://excalidraw.com/#room=e32fc914de750ed4f5e4,6CWRFjnmCoiFR4BQ6i9K4g)

--- a/docs/src/playnet/README.md
+++ b/docs/src/playnet/README.md
@@ -1,5 +1,7 @@
 # Playnet
 
+> ⚠️ This section is deprecated
+
  🕹🎮👾 Welcome to the very first Anoma testnet and thank you for joining us! 🕹🎮👾
 
 The main goals of this testnet is to try out some of the functionality of the ledger, intent gossip and the matchmaker and to get some early feedback on its current state. To give feedback, ask questions and report issues, please use the #playnet Slack channel. Many issues and limitations are well known and our test coverage is currently very low, so please excuse Anoma while it is rough around the edges.

--- a/docs/src/user-guide/install.md
+++ b/docs/src/user-guide/install.md
@@ -1,4 +1,4 @@
-# 💾Install Anoma
+# 💾 Install Anoma
 
 There's a single command to build and install Anoma executables from source (the node, the client and the wallet). This command will also verify that Tendermint with a compatible version is available and if not, attempt to install it.
 

--- a/docs/src/user-guide/intent-gossip-and-matchmaker.md
+++ b/docs/src/user-guide/intent-gossip-and-matchmaker.md
@@ -14,7 +14,7 @@ cargo run --bin anoman gossip --rpc "127.0.0.1:39111" --matchmaker-path wasm/mm_
 
 This pre-built matchmaker implementation is [the fungible token exchange `mm_token_exch`](https://github.com/anoma/anoma/blob/master/wasm/wasm_source/src/mm_token_exch.rs), that is being used together with [the pre-built `tx_from_intent` transaction WASM](https://github.com/anoma/anoma/blob/master/wasm/wasm_source/src/lib.rs) to submit transaction from matched intents to the ledger.
 
-## ✋Example intents
+## ✋ Example intents
 
 1) We'll be using these addresses in the intents:
 
@@ -53,7 +53,7 @@ This pre-built matchmaker implementation is [the fungible token exchange `mm_tok
 
    The matchmaker should find a match from these intents and submit a transaction to the ledger that performs the n-party transfers of tokens.
 
-## 🤝Custom matchmaker
+## 🤝 Custom matchmaker
 
 A custom matchmaker code can be built from [`wasm/mm_template`](https://github.com/anoma/anoma/tree/master/wasm/mm_template).
 

--- a/docs/src/user-guide/ledger.md
+++ b/docs/src/user-guide/ledger.md
@@ -14,7 +14,7 @@ If not found on start up, the ledger will generate a configuration file at `.ano
 
 The ledger also needs access to the built WASM files that are used in the genesis block. These files are included in release and shouldn't be modified, otherwise your node will fail with consensus error on the genesis block. By default, these are expected to be in the `wasm` directory, relative to the current working directory. This can also be set with `--wasm-dir` CLI global argument, `ANOMA_WASM_DIR` environment variable or the configuration file.
 
-## 📝Initialize an account
+## 📝 Initialize an account
 
 First, let's generate a key in the wallet that we'll use for the account.
 
@@ -35,7 +35,7 @@ Once this transaction has been applied, the client will automatically see the ne
 
 By default, this command will use the prebuilt user validity predicate (from the [vp_user](https://github.com/anoma/anoma/blob/fb445f67ffe3afe3bf50eb71658b01ff760e909d/wasm/wasm_source/src/vp_user.rs) source). You can supply a different validity predicate with `--code-path` argument. We'll come back to this topic and cover how to write and deploy custom validity predicates in the [custom validity predicates section](ledger/customize.md#validity-predicates).
 
-## 💸Token transactions and queries
+## 💸 Token transactions and queries
 
 In Anoma, tokens are implemented as accounts with a token validity predicate. It checks that its total supply is preserved in any transaction that uses this token. Your wallet will be pre-loaded with some token addresses that are initialized in the genesis block.
 

--- a/docs/src/user-guide/ledger/customize.md
+++ b/docs/src/user-guide/ledger/customize.md
@@ -4,7 +4,7 @@ On this page, we'll cover how to tailor your account(s) to your use-case with cu
 
 We currently only support Rust for custom validity predicates and transactions via WASM, but expect many more options to be available in the future!
 
-## 👩🏽‍🏫Anoma accounts primer
+## 👩🏽‍🏫 Anoma accounts primer
 
 Instead of the common smart contract design, in Anoma, all the accounts follow the same basic principles. Each account has exactly one validity predicate. Any transaction that attempts to make some storage modifications will trigger validity predicates of each account whose storage has been modified by it. Validity predicates are stateless functions that decide if an account accepts the transaction.
 
@@ -26,7 +26,7 @@ This approach allows multiparty transactions to be applied atomically, without a
 
 In fact, most of the functionality in the Anoma ledger is being built leveraging the simplicity and flexibility of this account system, from a simple fungible token to more complex accounts that integrate Inter-blockchain Communication protocol and the Proof of Stake system.
 
-## ☑Validity predicates
+## ☑ Validity predicates
 
 A custom validity predicates can be built from scratch using `vp_template` (from root directory [`wasm/vp_template`](https://github.com/anoma/anoma/tree/master/wasm/vp_template)), which is Rust code compiled to WASM. Consult its `README.md` to find out more.
 
@@ -85,7 +85,7 @@ To submit a transaction that updates an account's validity predicate:
 anoma client update --address my-new-acc --code-path my_vp.wasm
 ```
 
-## 📩Custom transactions
+## 📩 Custom transactions
 
 A transaction must contain a WASM code that can perform arbitrary storage changes. It can also contain arbitrary data, which will be passed to the transaction and validity predicates when the transaction is being applied.
 

--- a/docs/src/user-guide/ledger/pos.md
+++ b/docs/src/user-guide/ledger/pos.md
@@ -1,4 +1,4 @@
-# 🔏Interacting with the Proof-of-Stake system
+# 🔏 Interacting with the Proof-of-Stake system
 
 The Anoma Proof of Stake system is using the XAN token as the staking token. It features delegation to any number of validators and customizable validator validity predicates.
 
@@ -82,7 +82,7 @@ anoma client voting-power
 
 With this command, you can specify `--epoch` to find the voting powers at some future epoch. Note that only the voting powers for the current and the next epoch are final.
 
-## 📒PoS Validators
+## 📒 PoS Validators
 
 To register a new validator account, run:
 

--- a/docs/src/user-guide/wallet.md
+++ b/docs/src/user-guide/wallet.md
@@ -6,7 +6,7 @@ The wallet's state is stored under `.anoma/wallet.toml` (with the default `--bas
 
 For the ledger and intent gossip commands that use keys and addresses, you can enter their aliases as as defined in the wallet (case-sensitive).
 
-## 🔐Keys
+## 🔐 Keys
 
 For cryptographic signatures we currently support ed25519 keys. More will be added in future.
 
@@ -30,7 +30,7 @@ anoma wallet key gen --alias my-key
 
 Note that this will also save an implicit address derived from this public key under the same alias. More about addresses below. This command has the same effect as `address gen`.
 
-## 📇Addresses
+## 📇 Addresses
 
 All accounts in Anoma ledger have a unique address, exactly one validity predicate and optionally any additional data in its dynamic storage sub-space.
 


### PR DESCRIPTION
Hey @tzemanovic, 

I've reviewed the user-docs this morning. My branch was created from yours `tomas/docs-user-guide` and I made edits. For this release I won't have time for a in-depth developer UX review of the docs, I've focused on things that I found critical.

Here are some notes:

**The main changes I've made are:**
- Renamed the title to Anoma – DOCS
- Edited the introduction
- Added space between emoji + text 
- Took a look at all the pages, made minor edits (e.g. edited excalidraw links)

**Suggestions for the Engineering team:**
- I would suggest to remove the `playnet` section - keeping it would be confusing
- **Not critical for this release**, but I'd recommend the team to look at other user docs for inspiration on the structure. Good examples are (they're not perfect, they all have pros and cons):
  1. Solana: https://docs.solana.com/running-validator
  2. NEAR: https://docs.near.org/docs/develop/basics/getting-started
  3. Polkadot: https://wiki.polkadot.network/docs/getting-started

**Questions:**
- Shouldn't `2.1. Install` go before `2. User Guide`? Atm, the User Guide starts with
```
> This guide assumes that the Anoma binaries are installed and available on path. These are:
[...]
```