### PR TITLE
wasm: update checksums

### DIFF
--- a/wasm/checksums.json
+++ b/wasm/checksums.json
@@ -1,15 +1,15 @@
 {
-    "vp_token.wasm": "vp_token.521d89f957670ea542b824f78f79a1f301d65caae0668acebd694654eb253009.wasm", 
-    "tx_unbond.wasm": "tx_unbond.04089436b4975ddbdbf0bb70f38569d1bd4e393d1ad350fd50342b1d8508272d.wasm", 
-    "tx_transfer.wasm": "tx_transfer.a2a6d0f4ec08d874b9b54b400cdd9b7bed303d9846d84cfc6c3560ebc14569ba.wasm", 
-    "tx_bond.wasm": "tx_bond.ec57d84c17889397851a8ee1a6ac7d2224394cc3b6e92c08c0eae9d2f9ff5a4c.wasm", 
-    "tx_init_account.wasm": "tx_init_account.05790a745bfdd25a11c0deb6fd1111a2cff65ce9966e2cad8412f6588f83d71c.wasm", 
-    "tx_init_validator.wasm": "tx_init_validator.21c8a667b1569c52c62f870567108c5f0080fd707620a99fe1b1eda3c9e4a9c3.wasm", 
-    "tx_from_intent.wasm": "tx_from_intent.d64aae398402ec513f56c15c33e31467e44ca1f16ea66a870358569388190054.wasm", 
-    "tx_withdraw.wasm": "tx_withdraw.587922018ab6782e33daa252413746465b4bf5f9906b8f505e8d805a34ba231b.wasm", 
-    "vp_testnet_faucet.wasm": "vp_testnet_faucet.01220a91ebd9e3e2c87965e16816e503e314def95aa5d39ae0a020640f212b20.wasm", 
+    "vp_token.wasm": "vp_token.4a46ff531be6c9458b4d50ac040d3969eb8c88bc6a173c5e595dca5f735cc9ca.wasm", 
+    "tx_unbond.wasm": "tx_unbond.85d874a1254dab4d3f01a2855ca0eb09632d5497a2eeeee94861e451452a23a6.wasm", 
+    "tx_transfer.wasm": "tx_transfer.a0f1b5aad332f424f7a1833d19df21697500672d958b8772401c94ddc75eaa16.wasm", 
+    "tx_bond.wasm": "tx_bond.52c2fda691c63d1b58ed168898090e4264174dca40ecbe7c6f6248bb2975c520.wasm", 
+    "tx_init_account.wasm": "tx_init_account.329b37ce0746138e142b9fd116b88db6f2380130857d02987407d69a64ba74f6.wasm", 
+    "tx_init_validator.wasm": "tx_init_validator.c062c61affa10908ac6d0010063088ca9ce1588f63d2c2d239b75473a1f03836.wasm", 
+    "tx_from_intent.wasm": "tx_from_intent.46ad5bdf3b23f9556e508512f2cd993c8c4cf51a6e14bc35fdfc3b0145d7021d.wasm", 
+    "tx_withdraw.wasm": "tx_withdraw.a7311eb53c8a80215e801800abf056caa97f20165435eb8844ddaff3a4002cb7.wasm", 
+    "vp_testnet_faucet.wasm": "vp_testnet_faucet.41bd487a442586b540f54953041b993b2bafb7cf61273b227db08a0d3e76869b.wasm", 
     "tx_update_vp.wasm": "tx_update_vp.22e4904cc67ea85b8d6d8dea696a59fecc3f3d191ee88da0d2327f5090df5be0.wasm", 
-    "mm_token_exch.wasm": "mm_token_exch.cc94d7b271aadabd9ba13fc95263da0b0cf77a156579ab715464a76f6f4e966f.wasm", 
-    "mm_filter_token_exch.wasm": "mm_filter_token_exch.47cc291cbe768cb7bd01ed1515ffaa12570bcb54c8fe992440998003f8b2e590.wasm", 
-    "vp_user.wasm": "vp_user.f4aaa6131f2c4043a12d34eda0120728757d62439bcbb8f5e48e6fcefd8c3512.wasm"
+    "mm_token_exch.wasm": "mm_token_exch.a49ea82df8f2fcd8e597b05b66c5f57b680156a3bd196190350e95fbafe55432.wasm", 
+    "mm_filter_token_exch.wasm": "mm_filter_token_exch.8012b8ed4e0fa017ed06f18fd46dc556959aec6f79b7915a8bd9a66ce956b7be.wasm", 
+    "vp_user.wasm": "vp_user.74536e29f014d19bad8ed2ddc3fad2649c18ede1a4997b3589e3d065f78b63dd.wasm"
 }


### PR DESCRIPTION
The wasm checksums in wasm/checksums.json are incorrect after
58d778285. Correct them.