### PR TITLE
[intent_gossiper] don't panic on matchmaker wasm run error

### DIFF
--- a/apps/src/lib/node/gossip/intent_gossiper/matchmaker.rs
+++ b/apps/src/lib/node/gossip/intent_gossiper/matchmaker.rs
@@ -140,7 +140,7 @@ impl Matchmaker {
             self.mempool
                 .put(intent.clone())
                 .map_err(Error::MempoolFailed)?;
-            Ok(wasm::run::matchmaker(
+            wasm::run::matchmaker(
                 &self.matchmaker_code.clone(),
                 &self.state,
                 &intent.id().0,
@@ -148,7 +148,6 @@ impl Matchmaker {
                 self.wasm_host.clone(),
             )
             .map_err(Error::RunnerFailed)
-            .unwrap())
         } else {
             Ok(false)
         }


### PR DESCRIPTION
when matchmaker crashes (it does for the token exchange, see #444) it shouldn't panic in the intent node