### PR TITLE
CI Use anoma-release image on tag event

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -678,7 +678,7 @@ steps:
     AWS_SECRET_ACCESS_KEY: {from_secret: aws_secret_access_key}
     SCCACHE_BUCKET: heliax-drone-cache-v2
     SCCACHE_S3_KEY_PREFIX: sccache-build-release
-  image: 965844283396.dkr.ecr.eu-west-1.amazonaws.com/anoma-release:release
+  image: 965844283396.dkr.ecr.eu-west-1.amazonaws.com/anoma:release
   name: build-package
   pull: never
 - commands: [sh scripts/ci/release.sh]
@@ -694,6 +694,6 @@ type: docker
 workspace: {path: /usr/local/rust/project}
 ---
 kind: signature
-hmac: fd75ae5b038d1e1aaca70b939181dd707369934dea4595378a5c043bab3b7bbb
+hmac: 40e7c8da9857cd85a3161ccd9449f28f8cc9263a3d3b157aa99ad43755df4209
 
 ...


### PR DESCRIPTION
- The image used to build anoma for new releases uses ubuntu 16.04
- Fix a bug when cloning in specific pipelines where `$DRONE_SOURE_BRANCH` is empty (https://ci.heliax.dev/anoma/anoma/1787)