### PR TITLE
[apps/client] handle websocket ping-pong

### DIFF
--- a/apps/src/lib/client/tendermint_websocket_client.rs
+++ b/apps/src/lib/client/tendermint_websocket_client.rs
@@ -3,6 +3,7 @@ use std::convert::TryFrom;
 use std::fmt::{Display, Formatter};
 use std::net::TcpStream;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use sha2::{Digest, Sha256};
@@ -11,6 +12,7 @@ use tendermint::net::Address;
 use tendermint_rpc::query::Query;
 use tendermint_rpc::{Client, Request, Response, SimpleRequest};
 use thiserror::Error;
+use tokio::time::Instant;
 use websocket::result::WebSocketError;
 use websocket::{ClientBuilder, Message, OwnedMessage};
 
@@ -34,6 +36,8 @@ pub enum Error {
     Response(String),
     #[error("Encountered JSONRPC request/response without an id")]
     MissingId,
+    #[error("Connection timed out")]
+    ConnectionTimeout,
 }
 
 type Json = serde_json::Value;
@@ -184,11 +188,16 @@ pub struct TendermintWebsocketClient {
     websocket: Websocket,
     subscribed: Option<Subscription>,
     received_responses: ResponseQueue,
+    connection_timeout: Duration,
 }
 
 impl TendermintWebsocketClient {
-    /// Open up a new websocket given a specified URL
-    pub fn open(url: WebSocketAddress) -> Result<Self, Error> {
+    /// Open up a new websocket given a specified URL.
+    /// If no `connection_timeout` is given, defaults to 5 minutes.
+    pub fn open(
+        url: WebSocketAddress,
+        connection_timeout: Option<Duration>,
+    ) -> Result<Self, Error> {
         match ClientBuilder::new(&url.to_string())
             .unwrap()
             .connect_insecure()
@@ -197,6 +206,8 @@ impl TendermintWebsocketClient {
                 websocket: Arc::new(Mutex::new(websocket)),
                 subscribed: None,
                 received_responses: Arc::new(Mutex::new(HashMap::new())),
+                connection_timeout: connection_timeout
+                    .unwrap_or_else(|| Duration::new(300, 0)),
             }),
             Err(inner) => Err(Error::Websocket(inner)),
         }
@@ -302,7 +313,17 @@ impl TendermintWebsocketClient {
             Some(resp) => OwnedMessage::Text(resp),
             None => {
                 let mut websocket = self.websocket.lock().unwrap();
+                let start = Instant::now();
                 loop {
+                    if Instant::now().duration_since(start)
+                        > self.connection_timeout
+                    {
+                        tracing::error!(
+                            "Websocket connection timed out while waiting for \
+                             response"
+                        );
+                        return Err(Error::ConnectionTimeout);
+                    }
                     match websocket.recv_message().map_err(Error::Websocket)? {
                         text @ OwnedMessage::Text(_) => break text,
                         OwnedMessage::Ping(data) => {
@@ -363,7 +384,16 @@ impl Client for TendermintWebsocketClient {
 
         // Return the response if text is returned, else return empty response
         let mut websocket = self.websocket.lock().unwrap();
+        let start = Instant::now();
         loop {
+            if Instant::now().duration_since(start) > self.connection_timeout {
+                tracing::error!(
+                    "Websocket connection timed out while waiting for response"
+                );
+                return Err(tendermint_rpc::error::Error::websocket_error(
+                    Error::ConnectionTimeout.to_string(),
+                ));
+            }
             let response = match websocket
                 .recv_message()
                 .expect("Failed to receive message from websocket")
@@ -432,6 +462,8 @@ fn get_id(req_json: &str) -> Result<String, Error> {
 /// responses are give for each of the corresponding requests
 #[cfg(test)]
 mod test_tendermint_websocket_client {
+    use std::time::Duration;
+
     use serde::{Deserialize, Serialize};
     use tendermint_rpc::endpoint::abci_info::AbciInfo;
     use tendermint_rpc::query::{EventType, Query};
@@ -566,8 +598,11 @@ mod test_tendermint_websocket_client {
         std::thread::spawn(start);
         // need to make sure that the mock tendermint node has time to boot up
         std::thread::sleep(std::time::Duration::from_secs(1));
-        let mut rpc_client = TendermintWebsocketClient::open(address())
-            .expect("Client could not start");
+        let mut rpc_client = TendermintWebsocketClient::open(
+            address(),
+            Some(Duration::new(10, 0)),
+        )
+        .expect("Client could not start");
         // Check that subscription was successful
         rpc_client.subscribe(Query::from(EventType::Tx)).unwrap();
         assert_eq!(
@@ -586,8 +621,11 @@ mod test_tendermint_websocket_client {
         std::thread::spawn(start);
         // need to make sure that the mock tendermint node has time to boot up
         std::thread::sleep(std::time::Duration::from_secs(1));
-        let mut rpc_client = TendermintWebsocketClient::open(address())
-            .expect("Client could not start");
+        let mut rpc_client = TendermintWebsocketClient::open(
+            address(),
+            Some(Duration::new(10, 0)),
+        )
+        .expect("Client could not start");
         // Check that subscription was successful
         rpc_client.subscribe(Query::from(EventType::Tx)).unwrap();
         assert_eq!(
@@ -607,8 +645,11 @@ mod test_tendermint_websocket_client {
         std::thread::spawn(start);
         // need to make sure that the mock tendermint node has time to boot up
         std::thread::sleep(std::time::Duration::from_secs(1));
-        let mut rpc_client = TendermintWebsocketClient::open(address())
-            .expect("Client could not start");
+        let mut rpc_client = TendermintWebsocketClient::open(
+            address(),
+            Some(Duration::new(10, 0)),
+        )
+        .expect("Client could not start");
         // Check that subscription was successful
         rpc_client.subscribe(Query::from(EventType::Tx)).unwrap();
         assert_eq!(
@@ -639,8 +680,11 @@ mod test_tendermint_websocket_client {
         std::thread::spawn(start);
         // need to make sure that the mock tendermint node has time to boot up
         std::thread::sleep(std::time::Duration::from_secs(1));
-        let mut rpc_client = TendermintWebsocketClient::open(address())
-            .expect("Client could not start");
+        let mut rpc_client = TendermintWebsocketClient::open(
+            address(),
+            Some(Duration::new(10, 0)),
+        )
+        .expect("Client could not start");
         // Check that subscription was successful
         rpc_client.subscribe(Query::from(EventType::Tx)).unwrap();
         assert_eq!(

--- a/apps/src/lib/client/tx.rs
+++ b/apps/src/lib/client/tx.rs
@@ -452,8 +452,10 @@ pub async fn broadcast_tx(
     address: tendermint::net::Address,
     tx_bytes: Vec<u8>,
 ) -> Result<TxResponse, Error> {
-    let mut client =
-        TendermintWebsocketClient::open(WebSocketAddress::try_from(address)?)?;
+    let mut client = TendermintWebsocketClient::open(
+        WebSocketAddress::try_from(address)?,
+        None,
+    )?;
     // It is better to subscribe to the transaction before it is broadcast
     //
     // Note that the `applied.hash` key comes from a custom event


### PR DESCRIPTION
closes #589 

To test locally, in `apps/src/lib/node/ledger/tendermint_node.rs` `fn update_tendermint_config`, change e.g.:
```rust
    config.consensus.create_empty_blocks = true;
    config.consensus.timeout_commit =
        tendermint::Timeout::from_str("50s").unwrap();
```

Then run the ledger and try to submit a transaction, shortly after a new block is executed to make sure there will be a long waiting time before the tx is applied. Then run some client command to submit some transaction with `ANOMA_LOG=debug` and you should see `DEBUG anoma_apps::client::tendermint_websocket_client: Received websocket Ping, sending Pong` at some point.