### PR TITLE
Revert "build: downgrade docker image to Ubuntu 16.04"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG RUST_VERSION=1.54.0
 WORKDIR /var/build
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y \
     build-essential \
-    clang-tools-8 \
+    clang-tools-11 \
     curl \
     git \
     libssl-dev \


### PR DESCRIPTION
This reverts commit 2c9c39210aefeb2f745198c1c3e927b68a9b477b.

Ubuntu 20.04 is necessary due to incompatible OpenSSL versions.