### PR TITLE
init-network create archive for anoma-network-config release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "derivative",
  "ed25519-dalek",
  "eyre",
+ "flate2",
  "futures 0.3.17",
  "hex",
  "itertools 0.10.1",
@@ -176,6 +177,7 @@ dependencies = [
  "sha2 0.9.8",
  "signal-hook",
  "sparse-merkle-tree",
+ "tar",
  "tempfile",
  "tendermint 0.20.0 (git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-integration)",
  "tendermint 0.20.0 (git+https://github.com/heliaxdev/tendermint-rs?branch=tomas/lowercase-node-id)",
@@ -5537,6 +5539,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7164,6 +7177,15 @@ dependencies = [
  "curve25519-dalek",
  "rand_core 0.5.1",
  "zeroize",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -78,6 +78,7 @@ derivative = "2.2.0"
 # TODO the older versions of rand and rand_core are currently required to avoid mismatching version issue (https://github.com/dalek-cryptography/ed25519-dalek/pull/159)
 ed25519-dalek = {version = "1.0.1", default-features = false, features = ["rand", "u64_backend", "serde"]}
 eyre = "0.6.5"
+flate2 = "1.0.22"
 futures = "0.3"
 hex = "0.4.3"
 itertools = "0.10.1"
@@ -105,6 +106,7 @@ serde_regex = "1.1.0"
 sha2 = "0.9.3"
 signal-hook = "0.3.9"
 sparse-merkle-tree = {git = "https://github.com/heliaxdev/sparse-merkle-tree", branch = "yuji/ics23-proof", features = ["borsh"]}
+tar = "0.4.37"
 # temporarily using fork work-around for https://github.com/informalsystems/tendermint-rs/issues/916
 # and https://github.com/anoma/anoma/issues/445
 tendermint = {git = "https://github.com/heliaxdev/tendermint-rs", branch = "bat/abcipp-integration", optional = true}

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -1123,6 +1123,7 @@ pub mod args {
     const DATA_PATH_OPT: ArgOpt<PathBuf> = arg_opt("data-path");
     const DATA_PATH: Arg<PathBuf> = arg("data-path");
     const DECRYPT: ArgFlag = flag("decrypt");
+    const DONT_ARCHIVE: ArgFlag = flag("dont-archive");
     const DRY_RUN_TX: ArgFlag = flag("dry-run");
     const EPOCH: ArgOpt<Epoch> = arg_opt("epoch");
     const FEE_AMOUNT: Arg<token::Amount> = arg("fee-amount");
@@ -2299,6 +2300,7 @@ pub mod args {
         pub consensus_timeout_commit: Timeout,
         pub localhost: bool,
         pub allow_duplicate_ip: bool,
+        pub dont_archive: bool,
     }
 
     impl Args for InitNetwork {
@@ -2310,6 +2312,7 @@ pub mod args {
                 CONSENSUS_TIMEOUT_COMMIT.parse(matches);
             let localhost = LOCALHOST.parse(matches);
             let allow_duplicate_ip = ALLOW_DUPLICATE_IP.parse(matches);
+            let dont_archive = DONT_ARCHIVE.parse(matches);
             Self {
                 genesis_path,
                 chain_id_prefix,
@@ -2317,6 +2320,7 @@ pub mod args {
                 consensus_timeout_commit,
                 localhost,
                 allow_duplicate_ip,
+                dont_archive,
             }
         }
 
@@ -2346,6 +2350,11 @@ pub mod args {
                 "Toggle to disable guard against peers connecting from the \
                  same IP. This option shouldn't be used in mainnet.",
             ))
+            .arg(
+                DONT_ARCHIVE
+                    .def()
+                    .about("Do NOT create the release archive."),
+            )
         }
     }
 

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
-use std::fs::{self, OpenOptions};
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -8,6 +9,8 @@ use anoma::types::chain::ChainId;
 use anoma::types::key::ed25519::Keypair;
 use anoma::types::{address, token};
 use borsh::BorshSerialize;
+use flate2::write::GzEncoder;
+use flate2::Compression;
 use rand::prelude::ThreadRng;
 use rand::thread_rng;
 use serde_json::json;
@@ -501,6 +504,34 @@ pub fn init_network(
         "Genesis file generated at {}",
         genesis_path.to_string_lossy()
     );
+
+    // Create a release tarball for anoma-network-config
+    let mut release = tar::Builder::new(Vec::new());
+    let release_genesis_path = PathBuf::from(config::DEFAULT_BASE_DIR)
+        .join(format!("{}.toml", chain_id.as_str()));
+    release
+        .append_path_with_name(genesis_path, release_genesis_path)
+        .unwrap();
+    let global_config_path = GlobalConfig::file_path(&global_args.base_dir);
+    let release_global_config_path =
+        GlobalConfig::file_path(config::DEFAULT_BASE_DIR);
+    release
+        .append_path_with_name(global_config_path, release_global_config_path)
+        .unwrap();
+    let chain_config_path = Config::file_path(&global_args.base_dir, &chain_id);
+    let release_chain_config_path =
+        Config::file_path(config::DEFAULT_BASE_DIR, &chain_id);
+    release
+        .append_path_with_name(chain_config_path, release_chain_config_path)
+        .unwrap();
+
+    // Gzip tar release and write to file
+    let release_file = format!("{}.tar.gz", chain_id);
+    let compressed_file = File::create(&release_file).unwrap();
+    let mut encoder = GzEncoder::new(compressed_file, Compression::default());
+    encoder.write_all(&release.into_inner().unwrap()).unwrap();
+    encoder.finish().unwrap();
+    println!("Release archive created at {}", release_file);
 }
 
 fn init_established_account(

--- a/apps/src/lib/config/global.rs
+++ b/apps/src/lib/config/global.rs
@@ -67,7 +67,8 @@ impl GlobalConfig {
         file.write_all(toml.as_bytes()).map_err(Error::WriteError)
     }
 
-    fn file_path(base_dir: &Path) -> PathBuf {
-        base_dir.join(FILENAME)
+    /// Get the file path to the global config
+    pub fn file_path(base_dir: impl AsRef<Path>) -> PathBuf {
+        base_dir.as_ref().join(FILENAME)
     }
 }

--- a/apps/src/lib/config/mod.rs
+++ b/apps/src/lib/config/mod.rs
@@ -354,9 +354,13 @@ impl Config {
         }
     }
 
-    fn file_path(base_dir: &Path, chain_id: &ChainId) -> PathBuf {
+    /// Get the file path to the config
+    pub fn file_path(
+        base_dir: impl AsRef<Path>,
+        chain_id: &ChainId,
+    ) -> PathBuf {
         // Join base dir to the chain ID
-        base_dir.join(chain_id.to_string()).join(FILENAME)
+        base_dir.as_ref().join(chain_id.to_string()).join(FILENAME)
     }
 }
 

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -124,6 +124,7 @@ pub fn network(
             "--chain-prefix",
             "e2e-test",
             "--localhost",
+            "--dont-archive",
         ],
         Some(5),
         &working_dir,


### PR DESCRIPTION
This PR adds tar.gz creation in `init-network` cmd that can be used to make a release for the anoma-network-config repo using a script from https://github.com/heliaxdev/anoma-network-config/pull/4. The command to `join-network` has been updated to then use the GH releases in https://github.com/anoma/anoma/pull/619