### PR TITLE
add wasm checksums in init-network cmd

### DIFF
--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -1179,6 +1179,7 @@ pub mod args {
         arg_opt("consensus-key");
     const VALIDATOR_CODE_PATH: ArgOpt<PathBuf> = arg_opt("validator-code-path");
     const VALUE: ArgOpt<String> = arg_opt("value");
+    const WASM_CHECKSUMS_PATH: Arg<PathBuf> = arg("wasm-checksums-path");
     const WASM_DIR: ArgOpt<PathBuf> = arg_opt("wasm-dir");
 
     /// Global command arguments
@@ -2295,6 +2296,7 @@ pub mod args {
     #[derive(Clone, Debug)]
     pub struct InitNetwork {
         pub genesis_path: PathBuf,
+        pub wasm_checksums_path: PathBuf,
         pub chain_id_prefix: ChainIdPrefix,
         pub unsafe_dont_encrypt: bool,
         pub consensus_timeout_commit: Timeout,
@@ -2306,6 +2308,7 @@ pub mod args {
     impl Args for InitNetwork {
         fn parse(matches: &ArgMatches) -> Self {
             let genesis_path = GENESIS_PATH.parse(matches);
+            let wasm_checksums_path = WASM_CHECKSUMS_PATH.parse(matches);
             let chain_id_prefix = CHAIN_ID_PREFIX.parse(matches);
             let unsafe_dont_encrypt = UNSAFE_DONT_ENCRYPT.parse(matches);
             let consensus_timeout_commit =
@@ -2315,6 +2318,7 @@ pub mod args {
             let dont_archive = DONT_ARCHIVE.parse(matches);
             Self {
                 genesis_path,
+                wasm_checksums_path,
                 chain_id_prefix,
                 unsafe_dont_encrypt,
                 consensus_timeout_commit,
@@ -2329,6 +2333,11 @@ pub mod args {
                 GENESIS_PATH.def().about(
                     "Path to the preliminary genesis configuration file.",
                 ),
+            )
+            .arg(
+                WASM_CHECKSUMS_PATH
+                    .def()
+                    .about("Path to the WASM checksums file."),
             )
             .arg(CHAIN_ID_PREFIX.def().about(
                 "The chain ID prefix. Up to 19 alphanumeric, '.', '-' or '_' \

--- a/apps/src/lib/wasm_loader/mod.rs
+++ b/apps/src/lib/wasm_loader/mod.rs
@@ -31,27 +31,33 @@ pub struct Checksums(pub HashMap<String, String>);
 const S3_URL: &str = "https://heliax-anoma-wasm-v1.s3.eu-west-1.amazonaws.com";
 
 impl Checksums {
-    pub fn read_checksums(wasm_directory: impl AsRef<Path>) -> Self {
-        let checksums_path = wasm_directory.as_ref().join("checksums.json");
-        match fs::File::open(checksums_path) {
+    /// Read WASM checksums from the given path
+    pub fn read_checksums_file(checksums_path: impl AsRef<Path>) -> Self {
+        match fs::File::open(&checksums_path) {
             Ok(file) => match serde_json::from_reader(file) {
                 Ok(result) => result,
                 Err(_) => {
                     eprintln!(
-                        "Can't read checksums.json in {}",
-                        wasm_directory.as_ref().to_string_lossy()
+                        "Can't read checksums from {}",
+                        checksums_path.as_ref().to_string_lossy()
                     );
                     safe_exit(1);
                 }
             },
             Err(_) => {
                 eprintln!(
-                    "Can't find checksums.json in {}",
-                    wasm_directory.as_ref().to_string_lossy()
+                    "Can't find checksums at {}",
+                    checksums_path.as_ref().to_string_lossy()
                 );
                 safe_exit(1);
             }
         }
+    }
+
+    /// Read WASM checksums from "checksums.json" in the given directory
+    pub fn read_checksums(wasm_directory: impl AsRef<Path>) -> Self {
+        let checksums_path = wasm_directory.as_ref().join("checksums.json");
+        Self::read_checksums_file(checksums_path)
     }
 }
 

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -9,7 +9,7 @@ use std::{env, fs, mem, thread, time};
 use anoma::types::chain::ChainId;
 use anoma_apps::client::utils;
 use anoma_apps::config::genesis::genesis_config::{self, GenesisConfig};
-use anoma_apps::{config, wallet, wasm_loader};
+use anoma_apps::{config, wallet};
 use assert_cmd::assert::OutputAssertExt;
 use color_eyre::eyre::Result;
 use color_eyre::owo_colors::OwoColorize;
@@ -85,28 +85,10 @@ pub fn network(
     );
 
     // Run the provided function on it
-    let mut genesis = update_genesis(genesis);
-
-    // Update the WASM sha256 fields
-    let checksums =
-        wasm_loader::Checksums::read_checksums(working_dir.join("wasm"));
-    genesis.wasm.iter_mut().for_each(|(name, config)| {
-        // Find the sha256 from checksums.json
-        let name = format!("{}.wasm", name);
-        // Full name in format `{name}.{sha256}.wasm`
-        let full_name = checksums.0.get(&name).unwrap();
-        let hash = full_name
-            .split_once(".")
-            .unwrap()
-            .1
-            .split_once(".")
-            .unwrap()
-            .0;
-        config.sha256 = genesis_config::HexString(hash.to_owned());
-    });
+    let genesis = update_genesis(genesis);
 
     // Run `init-network` to generate the finalized genesis config, keys and
-    // addresses
+    // addresses and update WASM checksums
     let genesis_file = base_dir.path().join("e2e-test-genesis-src.toml");
     genesis_config::write_genesis_config(&genesis, &genesis_file);
     let genesis_path = genesis_file.to_string_lossy();

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -123,6 +123,8 @@ pub fn network(
             "e2e-test",
             "--localhost",
             "--dont-archive",
+            "--wasm-checksums-path",
+            &working_dir.join("wasm/checksums.json").to_string_lossy(),
         ],
         Some(5),
         &working_dir,


### PR DESCRIPTION
Depends on #616 (included here).
Closes #624.

I've also updated the release https://github.com/heliaxdev/anoma-network-config/releases/tag/anoma-feigenbaum-0.ebb9e9f9013 to include the WASM checksums.