### PR TITLE
[tests/e2e] the env var should be set on build instead of run

### DIFF
--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -443,6 +443,8 @@ where
     let cmd = CargoBuild::new()
         .package(APPS_PACKAGE)
         .manifest_path(manifest_path)
+        // Explicitly disable dev, in case it's enabled when a test is invoked
+        .env("ANOMA_DEV", "false")
         .bin(bin_name);
     let cmd = if run_debug {
         cmd
@@ -452,8 +454,6 @@ where
     };
     let mut cmd = cmd.run().unwrap().command();
     cmd.env("ANOMA_LOG", "anoma=debug")
-        // Explicitly disable dev, in case it's enabled when a test is invoked
-        .env("ANOMA_DEV", "false")
         .current_dir(working_dir)
         .args(&["--base-dir", &base_dir.as_ref().to_string_lossy()])
         .args(args);


### PR DESCRIPTION
This fixes an issue of `ANOMA_DEV=true` leaking into the e2e tests, which should always run *without* the dev feature