### PR TITLE
Tx data contains tx type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
- "gimli 0.25.0",
+ "gimli 0.26.1",
 ]
 
 [[package]]
@@ -91,6 +91,7 @@ dependencies = [
  "borsh",
  "chrono",
  "ed25519-dalek",
+ "ferveo",
  "group-threshold-cryptography",
  "hex",
  "ibc 0.6.0 (git+https://github.com/heliaxdev/ibc-rs?branch=bat/abci++-integration)",
@@ -149,6 +150,7 @@ dependencies = [
  "derivative",
  "ed25519-dalek",
  "eyre",
+ "ferveo",
  "futures 0.3.17",
  "hex",
  "itertools 0.10.1",
@@ -285,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 
 [[package]]
 name = "ark-bls12-381"
@@ -312,6 +314,18 @@ dependencies = [
  "derivative",
  "num-traits 0.2.14",
  "zeroize",
+]
+
+[[package]]
+name = "ark-ed-on-bls12-381"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b7ada17db3854f5994e74e60b18e10e818594935ee7e1d329800c117b32970"
+dependencies = [
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
 ]
 
 [[package]]
@@ -517,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b21b63ab5a0db0369deb913540af2892750e42d949faacc7a61495ac418a1692"
+checksum = "83137067e3a2a6a06d67168e49e68a0957d215410473a740cea95a2425c0b7c6"
 dependencies = [
  "async-io",
  "blocking",
@@ -643,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "atomic"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3410529e8288c463bedb5930f82833bc0c90e5d2fe639a56582a4d09220b281"
+checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
 dependencies = [
  "autocfg 1.0.1",
 ]
@@ -681,16 +695,16 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
+checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
 dependencies = [
  "addr2line",
  "cc",
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object 0.26.2",
+ "object 0.27.1",
  "rustc-demangle",
 ]
 
@@ -730,6 +744,15 @@ name = "bech32"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde 1.0.130",
+]
 
 [[package]]
 name = "bindgen"
@@ -854,9 +877,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blocking"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
+checksum = "046e47d4b2d391b1f6f8b407b1deb8dee56c1852ccd868becf2710f601b5f427"
 dependencies = [
  "async-channel",
  "async-task",
@@ -989,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 dependencies = [
  "jobserver",
 ]
@@ -1067,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10612c0ec0e0a1ff0e97980647cb058a6e7aedb913d01d009c406b8b7d0b26ee"
+checksum = "fa66045b9cb23c2e9c1520732030608b02ee07e5cfaa5a521ec15ded7fa24c90"
 dependencies = [
  "glob",
  "libc",
@@ -1679,6 +1702,7 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
+ "merlin",
  "rand 0.7.3",
  "serde 1.0.130",
  "serde_bytes",
@@ -1694,9 +1718,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "embed-resource"
-version = "1.6.4"
+version = "1.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "254a67531cc22d81bf92a24358a1dfa3d3b30f8d326fed8c5780eb6f2e5c784f"
+checksum = "85505eb239fc952b300f29f0556d2d884082a83566768d980278d8faf38c780d"
 dependencies = [
  "cc",
  "vswhom",
@@ -1726,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e76129da36102af021b8e5000dab2c1c30dbef85c1e482beeff8da5dde0e0b0"
+checksum = "6216d2c19a6fb5f29d1ada1dc7bc4367a8cbf0fa4af5cf12e07b5bbdde6b5b2c"
 dependencies = [
  "enumset_derive",
 ]
@@ -1766,9 +1790,9 @@ dependencies = [
 
 [[package]]
 name = "escargot"
-version = "0.5.2"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bb3f795fe1b9d34f089c7fab034c2b757998d65361d95ef008045b57665262"
+checksum = "9ead7d8a70259beb627c1ffdd19b0372381f247f88e46a3bd52bb797182690b3"
 dependencies = [
  "log 0.4.14",
  "once_cell",
@@ -1811,6 +1835,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "ferveo"
+version = "0.1.0"
+source = "git+https://github.com/anoma/ferveo#d6d603fbe82706525a194f42cbab9c3431dd7cc4"
+dependencies = [
+ "anyhow",
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ed-on-bls12-381",
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "bincode",
+ "blake2",
+ "blake2b_simd",
+ "borsh",
+ "digest 0.9.0",
+ "ed25519-dalek",
+ "either",
+ "ferveo-common",
+ "group-threshold-cryptography",
+ "hex",
+ "itertools 0.10.1",
+ "measure_time",
+ "miracl_core",
+ "num",
+ "rand 0.7.3",
+ "rand 0.8.4",
+ "serde 1.0.130",
+ "serde_bytes",
+ "serde_json",
+ "subtle 2.4.1",
+ "tendermint 0.20.0 (git+https://github.com/heliaxdev/tendermint-rs?branch=tomas/lowercase-node-id)",
+ "zeroize",
+]
+
+[[package]]
+name = "ferveo-common"
+version = "0.1.0"
+source = "git+https://github.com/anoma/ferveo#d6d603fbe82706525a194f42cbab9c3431dd7cc4"
+dependencies = [
+ "ark-ec",
+ "ark-serialize",
+ "ark-std",
+ "serde 1.0.130",
+ "serde_bytes",
 ]
 
 [[package]]
@@ -2119,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "glob"
@@ -2158,7 +2231,7 @@ dependencies = [
 [[package]]
 name = "group-threshold-cryptography"
 version = "0.1.0"
-source = "git+https://github.com/anoma/ferveo?branch=bat/workspace-cleanup#ad859d098a77ae952987ad7077c2744a9871378a"
+source = "git+https://github.com/anoma/ferveo#d6d603fbe82706525a194f42cbab9c3431dd7cc4"
 dependencies = [
  "anyhow",
  "ark-bls12-381",
@@ -2200,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c06815895acec637cd6ed6e9662c935b866d20a106f8361892893a7d9234964"
+checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
@@ -2349,9 +2422,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
  "bytes 1.1.0",
  "http",
@@ -2391,9 +2464,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.13"
+version = "0.14.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d1cfb9e4f68655fa04c01f59edb405b6074a0f7118ea881e5026e4a1cd8593"
+checksum = "2b91bb1f221b6ea1f1e4371216b70f40748774c2fb5971b450c07773fb92d26b"
 dependencies = [
  "bytes 1.1.0",
  "futures-channel",
@@ -2423,7 +2496,7 @@ dependencies = [
  "futures 0.3.17",
  "headers",
  "http",
- "hyper 0.14.13",
+ "hyper 0.14.14",
  "hyper-tls",
  "native-tls",
  "tokio",
@@ -2439,7 +2512,7 @@ checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
 dependencies = [
  "ct-logs",
  "futures-util",
- "hyper 0.14.13",
+ "hyper 0.14.14",
  "log 0.4.14",
  "rustls",
  "rustls-native-certs",
@@ -2454,7 +2527,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.13",
+ "hyper 0.14.14",
  "pin-project-lite 0.2.7",
  "tokio",
  "tokio-io-timeout",
@@ -2467,7 +2540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes 1.1.0",
- "hyper 0.14.13",
+ "hyper 0.14.14",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -2600,9 +2673,9 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a83ec4af652890ac713ffd8dc859e650420a5ef47f7b9be29b6664ab50fbc8"
+checksum = "2273e421f7c4f0fc99e1934fe4776f59d8df2972f4199d703fc0da9f2a9f73de"
 dependencies = [
  "if-addrs-sys",
  "libc",
@@ -2840,9 +2913,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.104"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f96d100e1cf1929e7719b7edb3b90ab5298072638fccd77be9ce942ecdfce"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "libloading"
@@ -2922,7 +2995,7 @@ dependencies = [
  "sha2 0.9.8",
  "smallvec 1.7.0",
  "thiserror",
- "unsigned-varint 0.7.0",
+ "unsigned-varint 0.7.1",
  "void",
  "zeroize",
 ]
@@ -2992,7 +3065,7 @@ dependencies = [
  "regex",
  "sha2 0.9.8",
  "smallvec 1.7.0",
- "unsigned-varint 0.7.0",
+ "unsigned-varint 0.7.1",
  "wasm-timer",
 ]
 
@@ -3033,7 +3106,7 @@ dependencies = [
  "sha2 0.9.8",
  "smallvec 1.7.0",
  "uint",
- "unsigned-varint 0.7.0",
+ "unsigned-varint 0.7.1",
  "void",
  "wasm-timer",
 ]
@@ -3074,7 +3147,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "rand 0.7.3",
  "smallvec 1.7.0",
- "unsigned-varint 0.7.0",
+ "unsigned-varint 0.7.1",
 ]
 
 [[package]]
@@ -3127,7 +3200,7 @@ dependencies = [
  "log 0.4.14",
  "prost 0.7.0",
  "prost-build 0.7.0",
- "unsigned-varint 0.7.0",
+ "unsigned-varint 0.7.1",
  "void",
 ]
 
@@ -3163,7 +3236,7 @@ dependencies = [
  "prost-build 0.7.0",
  "rand 0.7.3",
  "smallvec 1.7.0",
- "unsigned-varint 0.7.0",
+ "unsigned-varint 0.7.1",
  "void",
  "wasm-timer",
 ]
@@ -3184,7 +3257,7 @@ dependencies = [
  "minicbor",
  "rand 0.7.3",
  "smallvec 1.7.0",
- "unsigned-varint 0.7.0",
+ "unsigned-varint 0.7.1",
  "wasm-timer",
 ]
 
@@ -3446,6 +3519,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
+name = "measure_time"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68c8a1703dd54ab3307c03401e8b6c42121b67501dd6c6deb5077914ccb8085"
+dependencies = [
+ "log 0.4.14",
+]
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3467,6 +3549,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg 1.0.1",
+]
+
+[[package]]
+name = "merlin"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e261cf0f8b3c42ded9f7d2bb59dea03aa52bc8a1cbc7482f9fc3fd1229d3b42"
+dependencies = [
+ "byteorder",
+ "keccak",
+ "rand_core 0.5.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -3635,7 +3729,7 @@ dependencies = [
  "log 0.4.14",
  "pin-project 1.0.8",
  "smallvec 1.7.0",
- "unsigned-varint 0.7.0",
+ "unsigned-varint 0.7.1",
 ]
 
 [[package]]
@@ -3759,13 +3853,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.2"
+name = "num"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg 1.0.1",
  "num-integer",
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
+dependencies = [
  "num-traits 0.2.14",
 ]
 
@@ -3787,6 +3904,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg 1.0.1",
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-bigint",
+ "num-integer",
  "num-traits 0.2.14",
 ]
 
@@ -3837,9 +3977,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.26.2"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
+checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
 dependencies = [
  "memchr",
 ]
@@ -3864,9 +4004,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.36"
+version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -3884,9 +4024,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.67"
+version = "0.9.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
+checksum = "c6517987b3f8226b5da3661dad65ff7f300cc59fb5ea8333ca191fc65fde3edf"
 dependencies = [
  "autocfg 1.0.1",
  "cc",
@@ -3897,9 +4037,9 @@ dependencies = [
 
 [[package]]
 name = "orion"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118f94b4ca56d1eb99466a26a216b87fad822a51af8b308264c88a9337eb0a15"
+checksum = "c6624905ddd92e460ff0685567539ed1ac985b2dee4c92c7edcd64fce905b00c"
 dependencies = [
  "ct-codecs",
  "getrandom 0.2.3",
@@ -3942,7 +4082,7 @@ dependencies = [
  "percent-encoding 2.1.0",
  "serde 1.0.130",
  "static_assertions",
- "unsigned-varint 0.7.0",
+ "unsigned-varint 0.7.1",
  "url 2.2.2",
 ]
 
@@ -4017,9 +4157,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "peeking_take_while"
@@ -4118,15 +4258,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
+checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
 name = "polling"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92341d779fa34ea8437ef4d82d440d5e1ce3f3ff7f824aa64424cd481f9a1f25"
+checksum = "685404d509889fade3e86fe3a5803bca2ec09b0c0778d5ada6ec8bf7a8de5259"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -4160,9 +4300,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ca011bd0129ff4ae15cd04c4eef202cadf6c51c21e47aba319b4e0501db741"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "predicates"
@@ -4260,9 +4400,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
@@ -4802,7 +4942,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
- "hyper 0.14.13",
+ "hyper 0.14.14",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -4932,9 +5072,9 @@ checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
 name = "rust_decimal"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f1028de22e436bb35fce070310ee57d57b5e59ae77b4e3f24ce4773312b813"
+checksum = "353775f96a1f400edcca737f843cb201af3645912e741e64456a257c770173e8"
 dependencies = [
  "arrayvec",
  "num-traits 0.2.14",
@@ -5192,9 +5332,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
 dependencies = [
  "indexmap",
  "itoa",
@@ -5339,9 +5479,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
+checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
 
 [[package]]
 name = "simple-error"
@@ -5509,9 +5649,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5666,7 +5806,7 @@ dependencies = [
  "futures 0.3.17",
  "getrandom 0.1.16",
  "http",
- "hyper 0.14.13",
+ "hyper 0.14.14",
  "hyper-proxy",
  "hyper-rustls",
  "pin-project 1.0.8",
@@ -5696,7 +5836,7 @@ dependencies = [
  "futures 0.3.17",
  "getrandom 0.1.16",
  "http",
- "hyper 0.14.13",
+ "hyper 0.14.14",
  "hyper-proxy",
  "hyper-rustls",
  "pin-project 1.0.8",
@@ -5775,9 +5915,9 @@ dependencies = [
 
 [[package]]
 name = "termtree"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78fbf2dd23e79c28ccfa2472d3e6b3b189866ffef1aeb91f17c2d968b6586378"
+checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
 
 [[package]]
 name = "test-env-log"
@@ -5811,18 +5951,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5861,9 +6001,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5876,9 +6016,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.1.0",
@@ -5938,9 +6078,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
+checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5989,9 +6129,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.7",
@@ -6048,9 +6188,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes 1.1.0",
  "futures-core",
@@ -6084,7 +6224,7 @@ dependencies = [
  "h2",
  "http",
  "http-body",
- "hyper 0.14.13",
+ "hyper 0.14.14",
  "hyper-timeout",
  "percent-encoding 2.1.0",
  "pin-project 1.0.8",
@@ -6194,7 +6334,7 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 [[package]]
 name = "tracing"
 version = "0.1.29"
-source = "git+https://github.com/tokio-rs/tracing/?branch=v0.1.x#4e5f0f06abb7e38e2f0051f83885952fc0e0e9ad"
+source = "git+https://github.com/tokio-rs/tracing/?branch=v0.1.x#0a16972ba4a5da5b9fd6534b9674d3df88652029"
 dependencies = [
  "cfg-if 1.0.0",
  "log 0.4.14",
@@ -6206,7 +6346,7 @@ dependencies = [
 [[package]]
 name = "tracing-attributes"
 version = "0.1.18"
-source = "git+https://github.com/tokio-rs/tracing/?branch=v0.1.x#4e5f0f06abb7e38e2f0051f83885952fc0e0e9ad"
+source = "git+https://github.com/tokio-rs/tracing/?branch=v0.1.x#0a16972ba4a5da5b9fd6534b9674d3df88652029"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6216,7 +6356,7 @@ dependencies = [
 [[package]]
 name = "tracing-core"
 version = "0.1.21"
-source = "git+https://github.com/tokio-rs/tracing/?branch=v0.1.x#4e5f0f06abb7e38e2f0051f83885952fc0e0e9ad"
+source = "git+https://github.com/tokio-rs/tracing/?branch=v0.1.x#0a16972ba4a5da5b9fd6534b9674d3df88652029"
 dependencies = [
  "lazy_static 1.4.0",
 ]
@@ -6244,7 +6384,7 @@ dependencies = [
 [[package]]
 name = "tracing-futures"
 version = "0.2.5"
-source = "git+https://github.com/tokio-rs/tracing/?branch=v0.1.x#4e5f0f06abb7e38e2f0051f83885952fc0e0e9ad"
+source = "git+https://github.com/tokio-rs/tracing/?branch=v0.1.x#0a16972ba4a5da5b9fd6534b9674d3df88652029"
 dependencies = [
  "pin-project-lite 0.2.7",
  "tracing",
@@ -6296,7 +6436,7 @@ dependencies = [
 [[package]]
 name = "tracing-tower"
 version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tracing/?branch=v0.1.x#4e5f0f06abb7e38e2f0051f83885952fc0e0e9ad"
+source = "git+https://github.com/tokio-rs/tracing/?branch=v0.1.x#0a16972ba4a5da5b9fd6534b9674d3df88652029"
 dependencies = [
  "futures 0.3.17",
  "pin-project-lite 0.2.7",
@@ -6480,9 +6620,9 @@ checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
 
 [[package]]
 name = "unsigned-varint"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f8d425fafb8cd76bc3f22aace4af471d3156301d7508f2107e98fbeae10bc7f"
+checksum = "d86a8dc7f45e4c1b0d30e43038c38f274e77af056aa5f74b93c2cf9eb3c1c836"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.1.0",
@@ -6533,9 +6673,9 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd320e1520f94261153e96f7534476ad869c14022aee1e59af7c778075d840ae"
+checksum = "79923f7731dc61ebfba3633098bf3ac533bbd35ccd8c57e7088d9a5eebe0263f"
 dependencies = [
  "ctor",
  "version_check 0.9.3",
@@ -7199,9 +7339,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
+checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -77,6 +77,7 @@ config = "0.11.0"
 derivative = "2.2.0"
 # TODO the older versions of rand and rand_core are currently required to avoid mismatching version issue (https://github.com/dalek-cryptography/ed25519-dalek/pull/159)
 ed25519-dalek = {version = "1.0.1", default-features = false, features = ["rand", "u64_backend", "serde"]}
+ferveo = {git = "https://github.com/anoma/ferveo"}
 eyre = "0.6.5"
 futures = "0.3"
 hex = "0.4.3"

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -125,6 +125,9 @@ where
                     }
                     Event::new_tx_event(&processed_tx, height.0)
                 }
+                TxType::Protocol(protocol_tx) => {
+                    todo!()
+                }
                 TxType::Raw(_) => unreachable!(),
             };
 
@@ -189,6 +192,7 @@ where
 
         if new_epoch {
             self.update_epoch(&mut response);
+            self.update_dkg();
         }
 
         response.gas_used = self
@@ -289,6 +293,26 @@ where
             evidence: Some(evidence_params),
             ..response.consensus_param_updates.take().unwrap_or_default()
         });
+    }
+
+    fn update_dkg(&mut self) {
+        use tendermint::validator::Set;
+        let (current_epoch, _) = self.storage.get_current_epoch();
+        // TODO: The total weight should likely be a config, not hardcoded.
+        let params = DkgParams {
+            tau: current_epoch.0,
+            security_threshold: 2^12 / 3,
+            total_weight: 2^12,
+        };
+        // get the new validator for the next epoch
+        let validators = self.storage.read_validator_set();
+        let validators = validators
+            .get(current_epoch + 1)
+            .expect("Validators for the next epoch should be known");
+        self.dkg =  DkgStateMachine::new(
+
+        )
+
     }
 }
 

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -17,6 +17,7 @@ use tendermint_proto_abci::crypto::{
 use tendermint_stable::block::Header;
 
 use super::*;
+use crate::node::ledger::events::EventType;
 
 impl<D, H> Shell<D, H>
 where
@@ -52,55 +53,75 @@ where
         let (height, new_epoch) =
             self.update_state(req.header, req.hash, req.byzantine_validators);
 
-        for tx in &req.txs {
+        for processed_tx in &req.txs {
+            let tx = if let Ok(tx) = Tx::try_from(processed_tx.tx.as_ref()) {
+                tx
+            } else {
+                tracing::error!(
+                    "Internal logic error: FinalizeBlock received a tx that could not \
+                     be deserialized to a Tx type"
+                    );
+                continue
+            };
+            let tx_length = processed_tx.tx.len();
             if ErrorCodes::from_u32(tx.result.code).unwrap()
                 == ErrorCodes::InvalidSig
             {
-                let wrapper = if let Ok(TxType::Wrapper(wrapper)) =
-                    TxType::try_from(Tx::try_from(tx.tx.as_ref()).unwrap())
+
+                if let Ok(TxType::Wrapper(wrapper)) = TxType::try_from(inner_tx)
                 {
-                    wrapper
+                    let mut tx_result =
+                        Event::new_tx_event(&TxType::Wrapper(wrapper), height.0);
+                    tx_result["code"] = processed_tx.result.code.to_string();
+                    tx_result["info"] = format!("Tx rejected: {}", &processed_tx.result.info);
+                    tx_result["gas_used"] = "0".into();
+                    response.events.push(tx_result.into());
+                    continue;
                 } else {
-                    unreachable!()
-                };
-                let mut tx_result =
-                    Event::new_tx_event(&TxType::Wrapper(wrapper), height.0);
-                tx_result["code"] = tx.result.code.to_string();
-                tx_result["info"] = format!("Tx rejected: {}", &tx.result.info);
-                tx_result["gas_used"] = "0".into();
-                response.events.push(tx_result.into());
-                continue;
+                    tracing::error!(
+                        "Internal logic error: FinalizeBlock received a tx with an invalid \
+                        signature error code that could not be deserialized to a WrapperTx type"
+                    );
+                    continue
+                }
             }
-            let tx_length = tx.tx.len();
-            let processed_tx =
-                process_tx(Tx::try_from(&tx.tx as &[u8]).unwrap()).unwrap();
+
+            let tx_type = if let Ok(tx_type) = process_tx(tx) {
+                tx_type
+            } else {
+                tracing::error!(
+                    "Internal logic error: FinalizeBlock received tx that could not be \
+                    deserialized to a valid TxType"
+                );
+                continue
+            };
             // If [`process_proposal`] rejected a Tx, emit an event here and
             // move on to next tx
             // If we are rejecting all decrypted txs because they were submitted
             // in an incorrect order, we do that later.
-            if ErrorCodes::from_u32(tx.result.code).unwrap() != ErrorCodes::Ok
+            if ErrorCodes::from_u32(processed_tx.result.code).unwrap() != ErrorCodes::Ok
                 && !req.reject_all_decrypted
             {
                 let mut tx_result =
-                    Event::new_tx_event(&processed_tx, height.0);
-                tx_result["code"] = tx.result.code.to_string();
-                tx_result["info"] = format!("Tx rejected: {}", &tx.result.info);
+                    Event::new_tx_event(&tx_type, height.0);
+                tx_result["code"] = processed_tx.result.code.to_string();
+                tx_result["info"] = format!("Tx rejected: {}", &processed_tx.result.info);
                 tx_result["gas_used"] = "0".into();
                 response.events.push(tx_result.into());
                 // if the rejected tx was decrypted, remove it
                 // from the queue of txs to be processed
-                if let TxType::Decrypted(_) = &processed_tx {
+                if let TxType::Decrypted(_) = &tx_type {
                     self.tx_queue.pop();
                 }
                 continue;
             }
 
-            let mut tx_result = match &processed_tx {
+            let mut tx_result = match &tx_type {
                 TxType::Wrapper(_wrapper) => {
                     if !cfg!(feature = "ABCI") {
                         self.tx_queue.push(_wrapper.clone());
                     }
-                    Event::new_tx_event(&processed_tx, height.0)
+                    Event::new_tx_event(&tx_type, height.0)
                 }
                 TxType::Decrypted(_) => {
                     // If [`process_proposal`] detected that decrypted txs were
@@ -109,7 +130,7 @@ where
                     // be accepted.
                     if req.reject_all_decrypted {
                         let mut tx_result =
-                            Event::new_tx_event(&processed_tx, height.0);
+                            Event::new_tx_event(&tx_type, height.0);
                         tx_result["code"] = ErrorCodes::InvalidOrder.into();
                         tx_result["info"] = "All decrypted txs rejected as \
                                              they were not submitted in \
@@ -123,16 +144,21 @@ where
                     if !cfg!(feature = "ABCI") {
                         self.tx_queue.pop();
                     }
-                    Event::new_tx_event(&processed_tx, height.0)
+                    Event::new_tx_event(&tx_type, height.0)
                 }
                 TxType::Protocol(protocol_tx) => {
                     todo!()
                 }
-                TxType::Raw(_) => unreachable!(),
+                TxType::Raw(_) => {
+                    tracing::error!(
+                        "Internal logic error: FinalizeBlock received a TxType::Raw transaction"
+                    );
+                    continue
+                },
             };
 
             match protocol::apply_tx(
-                processed_tx,
+                tx_type,
                 tx_length,
                 &mut self.gas_meter,
                 &mut self.write_log,

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -56,9 +56,13 @@ where
             if ErrorCodes::from_u32(tx.result.code).unwrap()
                 == ErrorCodes::InvalidSig
             {
-                let wrapper =
-                    WrapperTx::try_from(&Tx::try_from(tx.tx.as_ref()).unwrap())
-                        .unwrap();
+                let wrapper = if let Ok(TxType::Wrapper(wrapper)) =
+                    TxType::try_from(Tx::try_from(tx.tx.as_ref()).unwrap())
+                {
+                    wrapper
+                } else {
+                    unreachable!()
+                };
                 let mut tx_result =
                     Event::new_tx_event(&TxType::Wrapper(wrapper), height.0);
                 tx_result["code"] = tx.result.code.to_string();

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -36,6 +36,7 @@ use anoma::types::transaction::{
 };
 use anoma::types::{address, key, token};
 use borsh::{BorshDeserialize, BorshSerialize};
+use ferveo::dkg::{DkgState, Params as DkgParams, PubliclyVerifiableAnnouncement, PubliclyVerifiableDkg};
 use num_derive::{FromPrimitive, ToPrimitive};
 use num_traits::{FromPrimitive, ToPrimitive};
 #[cfg(not(feature = "ABCI"))]
@@ -61,6 +62,8 @@ use crate::node::ledger::events::Event;
 use crate::node::ledger::shims::abcipp_shim_types::shim;
 use crate::node::ledger::shims::abcipp_shim_types::shim::response::TxResult;
 use crate::node::ledger::{protocol, storage, tendermint_node};
+
+type DkgStateMachine = PubliclyVerifiableDkg<anoma::types::transaction::EllipticCurve>;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -150,6 +153,8 @@ pub struct Shell<
     wasm_dir: PathBuf,
     /// Wrapper txs to be decrypted in the next block proposal
     tx_queue: TxQueue,
+    /// State machine for generating distributed public keys
+    dkg: DkgStateMachine,
 }
 
 #[derive(Default, Debug, Clone, BorshDeserialize, BorshSerialize)]

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -146,11 +146,14 @@ where
         ) {
             Ok(TxType::Wrapper(_)) => {}
             Ok(_) => {
-                return shim::response::TxResult {
+                let resp: shim::response::ProcessProposal = shim::response::TxResult {
                     code: ErrorCodes::InvalidSig.into(),
                     info: "The submitted transaction was not encrypted".into(),
                 }
                 .into();
+                // this ensures that emitted events are of the correct type
+                resp.tx = req.tx;
+                return resp;
             }
             Err(_) => {
                 // This will be caught later

--- a/apps/src/lib/node/ledger/shims/abcipp_shim.rs
+++ b/apps/src/lib/node/ledger/shims/abcipp_shim.rs
@@ -112,7 +112,8 @@ impl Service<Req> for AbcippShim {
                     self.service.reset_queue();
                 }
                 let begin_block_request =
-                    self.begin_block_request.take().unwrap();
+                    self.begin_block_request.take()
+                        .expect("Cannot process end block request without begin block request");
                 self.service
                     .call(Request::FinalizeBlock(request::FinalizeBlock {
                         hash: begin_block_request.hash,

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -13,6 +13,7 @@ default = ["ABCI"]
 # NOTE "dev" features that shouldn't be used in live networks are enabled by default for now
 dev = []
 ferveo-tpke = [
+  "ferveo",
   "tpke",
   "ark-bls12-381",
   "ark-ec",
@@ -66,8 +67,9 @@ bech32 = "0.8.0"
 borsh = "0.9.0"
 chrono = "0.4.19"
 ed25519-dalek = {version = "1.0.1", default-features = false, features = ["rand", "u64_backend", "serde"]}
+ferveo = {optional = true, git = "https://github.com/anoma/ferveo"}
 hex = "0.4.3"
-tpke = {package = "group-threshold-cryptography", optional = true, git = "https://github.com/anoma/ferveo", branch = "bat/workspace-cleanup"}
+tpke = {package = "group-threshold-cryptography", optional = true, git = "https://github.com/anoma/ferveo"}
 # TODO temp fork for https://github.com/informalsystems/ibc-rs/issues/1161
 # Also, using the same version of tendermint-rs as we do here.
 ibc = {git = "https://github.com/heliaxdev/ibc-rs", branch = "bat/abci++-integration", features = ["mocks", "borsh"], optional = true}
@@ -88,6 +90,7 @@ rand_core = {version = "0.5", optional = true}
 rand_new = {package = "rand", version = "0.8", optional = true}
 rust_decimal = "1.14.3"
 serde = {version = "1.0.125", features = ["derive"]}
+serde_json = "1.0.69"
 sha2 = "0.9.3"
 # We switch off "blake2b" because it cannot be compiled to wasm
 sparse-merkle-tree = {git = "https://github.com/heliaxdev/sparse-merkle-tree", branch = "yuji/ics23-proof", default-features = false, features = ["std", "borsh"]}

--- a/shared/src/types/transaction/decrypted.rs
+++ b/shared/src/types/transaction/decrypted.rs
@@ -69,21 +69,6 @@ pub mod decrypted_tx {
             )
         }
     }
-
-    // impl TryFrom<&Tx> for DecryptedTx {
-    //     type Error = crate::types::transaction::WrapperTxErr;
-    //
-    //     fn try_from(tx: &Tx) -> Result<Self, Self::Error> {
-    //         if let Some(data) = tx.data.as_ref() {
-    //             <Self as BorshDeserialize>::deserialize(&mut data.as_ref())
-    //                 .map_err(|_| {
-    //                     crate::types::transaction::WrapperTxErr::InvalidTx
-    //                 })
-    //         } else {
-    //             Err(crate::types::transaction::WrapperTxErr::InvalidTx)
-    //         }
-    //     }
-    // }
 }
 
 #[cfg(feature = "ferveo-tpke")]

--- a/shared/src/types/transaction/decrypted.rs
+++ b/shared/src/types/transaction/decrypted.rs
@@ -3,14 +3,13 @@
 /// *Not wasm compatible*
 #[cfg(feature = "ferveo-tpke")]
 pub mod decrypted_tx {
-    use std::convert::TryFrom;
 
     use ark_bls12_381::Bls12_381 as EllipticCurve;
     use ark_ec::PairingEngine;
     use borsh::{BorshDeserialize, BorshSerialize};
 
     use crate::proto::Tx;
-    use crate::types::transaction::{hash_tx, Hash, WrapperTx};
+    use crate::types::transaction::{hash_tx, Hash, TxType, WrapperTx};
 
     #[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
     #[allow(clippy::large_enum_variant)]
@@ -63,7 +62,7 @@ pub mod decrypted_tx {
             Tx::new(
                 vec![],
                 Some(
-                    decrypted
+                    TxType::Decrypted(decrypted)
                         .try_to_vec()
                         .expect("Encrypting transaction should not fail"),
                 ),
@@ -71,20 +70,20 @@ pub mod decrypted_tx {
         }
     }
 
-    impl TryFrom<&Tx> for DecryptedTx {
-        type Error = crate::types::transaction::WrapperTxErr;
-
-        fn try_from(tx: &Tx) -> Result<Self, Self::Error> {
-            if let Some(data) = tx.data.as_ref() {
-                <Self as BorshDeserialize>::deserialize(&mut data.as_ref())
-                    .map_err(|_| {
-                        crate::types::transaction::WrapperTxErr::InvalidTx
-                    })
-            } else {
-                Err(crate::types::transaction::WrapperTxErr::InvalidTx)
-            }
-        }
-    }
+    // impl TryFrom<&Tx> for DecryptedTx {
+    //     type Error = crate::types::transaction::WrapperTxErr;
+    //
+    //     fn try_from(tx: &Tx) -> Result<Self, Self::Error> {
+    //         if let Some(data) = tx.data.as_ref() {
+    //             <Self as BorshDeserialize>::deserialize(&mut data.as_ref())
+    //                 .map_err(|_| {
+    //                     crate::types::transaction::WrapperTxErr::InvalidTx
+    //                 })
+    //         } else {
+    //             Err(crate::types::transaction::WrapperTxErr::InvalidTx)
+    //         }
+    //     }
+    // }
 }
 
 #[cfg(feature = "ferveo-tpke")]

--- a/shared/src/types/transaction/encrypted.rs
+++ b/shared/src/types/transaction/encrypted.rs
@@ -60,8 +60,7 @@ pub mod encrypted_tx {
             BorshSerialize::serialize(
                 &(nonce_buffer, ciphertext, tag_buffer),
                 writer,
-            )?;
-            Ok(())
+            )
         }
     }
 

--- a/shared/src/types/transaction/protocol.rs
+++ b/shared/src/types/transaction/protocol.rs
@@ -1,0 +1,89 @@
+
+/// Types for sending and verifying txs
+/// used in Anoma protocols
+#[cfg(feature = "ferveo-tpke")]
+mod protocol_txs {
+    use std::io::{ErrorKind, Write};
+
+    use borsh::{BorshDeserialize, BorshSerialize};
+    use ferveo::dkg::pv::Message;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+
+    use crate::proto::Tx;
+    use crate::types::key::ed25519::{PublicKey, Keypair, Signature, verify_tx_sig};
+    use crate::types::transaction::{EllipticCurve, TxType, TxError};
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    /// Txs sent by validators as part of internal protocols
+    pub struct ProtocolTx {
+        /// we require ProtocolTxs be signed
+        pk: PublicKey,
+        /// The type of protocol message being sent
+        tx: ProtocolTxType,
+    }
+
+    impl ProtocolTx {
+        /// Validate the signature of a protocol tx
+        pub fn validate_sig(&self, tx: &Tx, sig: &Signature) -> Result<(), TxError> {
+            verify_tx_sig(&self.pk, &tx, sig).map_err(|err| {
+                TxError::SigError(format!("ProtocolTx signature verification failed: {}", err))
+            })
+        }
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    /// Types of protocol messages to be sent
+    pub enum ProtocolTxType {
+        /// Messages for the DKG protocol
+        DKG(Message<EllipticCurve>)
+    }
+
+    impl ProtocolTxType {
+        /// Sign a ProtocolTxType and wrap it up in a normal Tx
+        pub fn sign(self, keypair: &Keypair) -> Tx {
+            Tx::new(
+                vec![],
+                Some(TxType::Protocol(
+                    ProtocolTx {
+                        pk: keypair.public.clone(),
+                        tx: self,
+                    }
+                )
+                .try_to_vec()
+                .expect("Could not serialize ProtocolTx"))
+            ).sign(keypair)
+        }
+    }
+
+
+    impl borsh::ser::BorshSerialize for ProtocolTx {
+        fn serialize<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
+            let json = serde_json::to_string(&self)
+                .map_err(|err| std::io::Error::new(ErrorKind::InvalidData, err))?;
+            BorshSerialize::serialize(
+                &json,
+                writer,
+            )
+        }
+    }
+
+    impl borsh::de::BorshDeserialize for ProtocolTx {
+        fn deserialize(buf: &mut &[u8]) -> std::io::Result<Self> {
+            let json = <String as BorshDeserialize>::deserialize(buf)?;
+            serde_json::from_str(&json).map_err(
+                |err| std::io::Error::new(ErrorKind::InvalidData, err)
+            )
+        }
+    }
+
+    impl From<Message<EllipticCurve>> for ProtocolTxType {
+        fn from(msg: Message<EllipticCurve>) -> ProtocolTxType {
+            ProtocolTxType::DKG(msg)
+        }
+    }
+}
+
+
+#[cfg(feature = "ferveo-tpke")]
+pub use protocol_txs::*;


### PR DESCRIPTION
We support various kinds of tx types: Raw, Decrypted, and Wrapper. Previously, we would have to try and deserialize a Tx's data into each of these different types to figure out which type it was. With this PR, we wrap all transactions in TxType enum and serialize that instead. This way, we can always deserialize and immediately know the type.