### PR TITLE
Tx data contains tx type

### DIFF
--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -56,9 +56,13 @@ where
             if ErrorCodes::from_u32(tx.result.code).unwrap()
                 == ErrorCodes::InvalidSig
             {
-                let wrapper =
-                    WrapperTx::try_from(&Tx::try_from(tx.tx.as_ref()).unwrap())
-                        .unwrap();
+                let wrapper = if let Ok(TxType::Wrapper(wrapper)) =
+                    TxType::try_from(Tx::try_from(tx.tx.as_ref()).unwrap())
+                {
+                    wrapper
+                } else {
+                    unreachable!()
+                };
                 let mut tx_result =
                     Event::new_tx_event(&TxType::Wrapper(wrapper), height.0);
                 tx_result["code"] = tx.result.code.to_string();

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -37,11 +37,12 @@ mod prepare_block {
                 .block_data
                 .into_iter()
                 .take(number_of_new_txs)
-                .filter(|tx| {
-                    matches!(
-                        process_tx(Tx::try_from(tx.as_slice()).unwrap()),
-                        Ok(TxType::Wrapper(_))
-                    )
+                .filter(|tx_bytes| {
+                    if let Ok(tx) = Tx::try_from(tx_bytes.as_slice()) {
+                        matches!(process_tx(tx), Ok(TxType::Wrapper(_)))
+                    } else {
+                        false
+                    }
                 })
                 .collect();
 

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -167,17 +167,16 @@ where
         match process_tx(req_tx.clone()) {
             Ok(TxType::Wrapper(_)) => {}
             Ok(_) => {
-                let mut resp: shim::response::ProcessProposal =
-                    shim::response::TxResult {
+                return shim::response::ProcessProposal {
+                    result: shim::response::TxResult {
                         code: ErrorCodes::InvalidTx.into(),
                         info: "Transaction rejected: Non-encrypted \
                                transactions are not supported"
                             .into(),
-                    }
-                    .into();
-                // this ensures that emitted events are of the correct type
-                resp.tx = req.tx;
-                return resp;
+                    },
+                    // this ensures that emitted events are of the correct type
+                    resp.tx = req.tx,
+                }
             }
             Err(_) => {
                 // This will be caught later

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -146,11 +146,16 @@ where
         ) {
             Ok(TxType::Wrapper(_)) => {}
             Ok(_) => {
-                return shim::response::TxResult {
-                    code: ErrorCodes::InvalidSig.into(),
-                    info: "The submitted transaction was not encrypted".into(),
-                }
-                .into();
+                let mut resp: shim::response::ProcessProposal =
+                    shim::response::TxResult {
+                        code: ErrorCodes::InvalidTx.into(),
+                        info: "The submitted transaction was not encrypted"
+                            .into(),
+                    }
+                    .into();
+                // this ensures that emitted events are of the correct type
+                resp.tx = req.tx;
+                return resp;
             }
             Err(_) => {
                 // This will be caught later

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -152,18 +152,16 @@ where
         let req_tx = match Tx::try_from(req.tx.as_ref()) {
             Ok(tx) => tx,
             Err(_) => {
-                let mut resp: shim::response::ProcessProposal =
-                    shim::response::TxResult {
+                shim::response::ProcessProposal {
+                    result: shim::response::TxResult {
                         code: ErrorCodes::InvalidTx.into(),
                         info: "The submitted transaction was not \
                                deserializable"
                             .into(),
-                    }
-                    .into();
-
-                // this ensures that emitted events are of the correct type
-                resp.tx = req.tx;
-                return resp;
+                    },
+                    // this ensures that emitted events are of the correct type
+                    tx: req.tx
+                }
             }
         };
         match process_tx(req_tx.clone()) {

--- a/shared/src/types/transaction/decrypted.rs
+++ b/shared/src/types/transaction/decrypted.rs
@@ -69,21 +69,6 @@ pub mod decrypted_tx {
             )
         }
     }
-
-    // impl TryFrom<&Tx> for DecryptedTx {
-    //     type Error = crate::types::transaction::WrapperTxErr;
-    //
-    //     fn try_from(tx: &Tx) -> Result<Self, Self::Error> {
-    //         if let Some(data) = tx.data.as_ref() {
-    //             <Self as BorshDeserialize>::deserialize(&mut data.as_ref())
-    //                 .map_err(|_| {
-    //                     crate::types::transaction::WrapperTxErr::InvalidTx
-    //                 })
-    //         } else {
-    //             Err(crate::types::transaction::WrapperTxErr::InvalidTx)
-    //         }
-    //     }
-    // }
 }
 
 #[cfg(feature = "ferveo-tpke")]

--- a/shared/src/types/transaction/decrypted.rs
+++ b/shared/src/types/transaction/decrypted.rs
@@ -3,14 +3,13 @@
 /// *Not wasm compatible*
 #[cfg(feature = "ferveo-tpke")]
 pub mod decrypted_tx {
-    use std::convert::TryFrom;
 
     use ark_bls12_381::Bls12_381 as EllipticCurve;
     use ark_ec::PairingEngine;
     use borsh::{BorshDeserialize, BorshSerialize};
 
     use crate::proto::Tx;
-    use crate::types::transaction::{hash_tx, Hash, WrapperTx};
+    use crate::types::transaction::{hash_tx, Hash, TxType, WrapperTx};
 
     #[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
     #[allow(clippy::large_enum_variant)]
@@ -63,7 +62,7 @@ pub mod decrypted_tx {
             Tx::new(
                 vec![],
                 Some(
-                    decrypted
+                    TxType::Decrypted(decrypted)
                         .try_to_vec()
                         .expect("Encrypting transaction should not fail"),
                 ),
@@ -71,20 +70,20 @@ pub mod decrypted_tx {
         }
     }
 
-    impl TryFrom<&Tx> for DecryptedTx {
-        type Error = crate::types::transaction::WrapperTxErr;
-
-        fn try_from(tx: &Tx) -> Result<Self, Self::Error> {
-            if let Some(data) = tx.data.as_ref() {
-                <Self as BorshDeserialize>::deserialize(&mut data.as_ref())
-                    .map_err(|_| {
-                        crate::types::transaction::WrapperTxErr::InvalidTx
-                    })
-            } else {
-                Err(crate::types::transaction::WrapperTxErr::InvalidTx)
-            }
-        }
-    }
+    // impl TryFrom<&Tx> for DecryptedTx {
+    //     type Error = crate::types::transaction::WrapperTxErr;
+    //
+    //     fn try_from(tx: &Tx) -> Result<Self, Self::Error> {
+    //         if let Some(data) = tx.data.as_ref() {
+    //             <Self as BorshDeserialize>::deserialize(&mut data.as_ref())
+    //                 .map_err(|_| {
+    //                     crate::types::transaction::WrapperTxErr::InvalidTx
+    //                 })
+    //         } else {
+    //             Err(crate::types::transaction::WrapperTxErr::InvalidTx)
+    //         }
+    //     }
+    // }
 }
 
 #[cfg(feature = "ferveo-tpke")]


### PR DESCRIPTION
We support various kinds of tx types: Raw, Decrypted, and Wrapper. Previously, we would have to try and deserialize a Tx's data into each of these different types to figure out which type it was. With this PR, we wrap all transactions in TxType enum and serialize that instead. This way, we can always deserialize and immediately know the type.