### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The default is set to `info` for all the modules, expect for Tendermint ABCI, wh
 
 For more fine-grained logging levels settings, please refer to the [tracing subscriber docs](https://docs.rs/tracing-subscriber/0.2.18/tracing_subscriber/struct.EnvFilter.html#directives) for more information.
 
-To switch on logging in tests that use `#[test]` macro from `test_env_log::test`, use `RUST_LOG` with e.g. `RUST_LOG=info cargo test -- --nocapture`.
+To switch on logging in tests that use `#[test]` macro from `test_log::test`, use `RUST_LOG` with e.g. `RUST_LOG=info cargo test -- --nocapture`.
 
 ## How to contribute
 

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -358,7 +358,10 @@ mod test_process_proposal {
         assert_eq!(response.result.code, u32::from(ErrorCodes::InvalidSig));
         assert_eq!(
             response.result.info,
-            String::from("Signature verification failed: signature error")
+            String::from(
+                "Signature verification failed: signature error: Verification \
+                 equation was not satisfied"
+            )
         );
         #[cfg(feature = "ABCI")]
         {

--- a/shared/src/types/transaction/mod.rs
+++ b/shared/src/types/transaction/mod.rs
@@ -210,9 +210,8 @@ pub mod tx_types {
             {
                 // verify signature and extract signed data
                 TxType::Wrapper(wrapper) => {
-                    verify_tx_sig(&wrapper.pk, &tx, sig).map_err(|err| {
-                        WrapperTxErr::SigError(err.to_string())
-                    })?;
+                    verify_tx_sig(&wrapper.pk, &tx, sig)
+                        .map_err(WrapperTxErr::SigError)?;
                     Ok(TxType::Wrapper(wrapper))
                 }
                 // we extract the signed data, but don't check the signature
@@ -369,7 +368,7 @@ pub mod tx_types {
                 ),
             );
             let result = process_tx(tx).expect_err("Test failed");
-            assert_eq!(result, WrapperTxErr::Unsigned);
+            assert_matches!(result, WrapperTxErr::Unsigned);
         }
     }
 

--- a/shared/src/types/transaction/wrapper.rs
+++ b/shared/src/types/transaction/wrapper.rs
@@ -14,7 +14,7 @@ pub mod wrapper_tx {
 
     use crate::proto::Tx;
     use crate::types::address::Address;
-    use crate::types::key::ed25519::{Keypair, PublicKey};
+    use crate::types::key::ed25519::{Keypair, PublicKey, VerifySigError};
     use crate::types::storage::Epoch;
     use crate::types::token::Amount;
     use crate::types::transaction::encrypted::EncryptedTx;
@@ -26,7 +26,7 @@ pub mod wrapper_tx {
     /// Errors relating to decrypting a wrapper tx and its
     /// encrypted payload from a Tx type
     #[allow(missing_docs)]
-    #[derive(Error, Debug, PartialEq)]
+    #[derive(Error, Debug)]
     pub enum WrapperTxErr {
         #[error(
             "The hash of the decrypted tx does not match the hash commitment"
@@ -39,7 +39,7 @@ pub mod wrapper_tx {
         #[error("Expected signed WrapperTx data")]
         Unsigned,
         #[error("{0}")]
-        SigError(String),
+        SigError(VerifySigError),
         #[error("Unable to deserialize the Tx data: {0}")]
         Deserialization(String),
         #[error(
@@ -382,7 +382,7 @@ pub mod wrapper_tx {
             assert!(wrapper.validate_ciphertext());
             let privkey = <EllipticCurve as PairingEngine>::G2Affine::prime_subgroup_generator();
             let err = wrapper.decrypt(privkey).expect_err("Test failed");
-            assert_eq!(err, WrapperTxErr::DecryptedHash);
+            assert_matches!(err, WrapperTxErr::DecryptedHash);
         }
 
         /// We check that even if the encrypted payload and has of its
@@ -457,12 +457,7 @@ pub mod wrapper_tx {
             // check that the try from method also fails
             let err = crate::types::transaction::process_tx(tx)
                 .expect_err("Test failed");
-            assert_eq!(
-                err,
-                WrapperTxErr::SigError(
-                    "Signature verification failed: signature error".into()
-                )
-            );
+            assert_matches!(err, WrapperTxErr::SigError(_));
         }
     }
 }


### PR DESCRIPTION
just a tiny follow-up to #664 to reflect dep name change from `test_env_log` to `test_log`