### PR TITLE
[windows] apps/anoma/cli: fix some missing imports and error handling

### DIFF
--- a/apps/src/bin/anoma/cli.rs
+++ b/apps/src/bin/anoma/cli.rs
@@ -114,6 +114,7 @@ mod imp {
 mod imp {
     use std::process::Command;
 
+    use eyre::{eyre, Result, WrapErr};
     use winapi::shared::minwindef::{BOOL, DWORD, FALSE, TRUE};
     use winapi::um::consoleapi::SetConsoleCtrlHandler;
 
@@ -122,15 +123,10 @@ mod imp {
         TRUE
     }
 
-    pub fn exec_subcommand(program: &str, cmd: Command) -> Result<()> {
+    pub fn exec_subcommand(program: &str, mut cmd: Command) -> Result<()> {
         unsafe {
             if SetConsoleCtrlHandler(Some(ctrlc_handler), TRUE) == FALSE {
-                return Err(ProcessError::new(
-                    "Could not set Ctrl-C handler.",
-                    None,
-                    None,
-                )
-                .into());
+                return Err(eyre!("Could not set Ctrl-C handler."));
             }
         }
 


### PR DESCRIPTION
follow-up to #658 

This should fix build on Windows. I checked build with `cargo build --target=x86_64-pc-windows-gnu`, but I didn't try to run it on windows.

Together with #698 this should hopefully fix running ledger on windows.
