### PR TITLE
[nix] improved nix integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ After installation, the main `anoma` executable will be available on path.
 
 To find how to use it, check out the [User Guide section of the docs](https://docs.anoma.network/master/user-guide/).
 
+If you are running NixOS or at least the Nix package manager, you may opt to
+install Anoma as a Nix derivation like so:
+
+```shell
+nix-shell --run "crate2nix generate --no-default-features --features 'std ABCI'"
+nix-build -A anoma
+nix-env -i ./result
+```
+
 ## ⚙️ Development
 
 ```shell
@@ -43,10 +52,12 @@ ANOMA_DEV=true make
 
 ### Using Nix
 
+If you are running NixOS or at least the Nix package manager, you may opt in to
+all the dependencies via Nix by simply entering the Nix shell environment:
+
 ```shell
-nix-shell -p crate2nix --command "crate2nix generate"
-nix-build -A apps
-nix-env -i ./result
+nix-shell
+make
 ```
 
 ### Before submitting a PR, pls make sure to run the following:

--- a/default.nix
+++ b/default.nix
@@ -1,81 +1,30 @@
-{ rust_overlay ? import (builtins.fetchTarball "https://github.com/oxalica/rust-overlay/archive/master.tar.gz")
-, pkgs ? import <nixpkgs> {
-    overlays = [
-      rust_overlay
-
-      (self: super: {
-        rustc = pkgs.rust-bin.stable.latest.minimal.override {
-          targets = [ "x86_64-unknown-linux-gnu" "wasm32-unknown-unknown" ];
-        };
-        inherit (super.rust-bin.stable.latest) rustfmt;
-      })
-    ];
-  }
-, lib ? pkgs.lib
-, stdenv ? pkgs.stdenv
-, xcbuild ? pkgs.xcbuild
-}:
+{ pkgs ? import ./nix { }
+# Allows specifying Rust features for anoma crates.
+, features ? ["std" "ABCI"]
+# Allows overriding Tendermint derivation.
+, tendermint ? pkgs.tendermint
+, ... }:
 let
-  crateOverrides = pkgs: with pkgs; {
-      prost-build = attrs: { buildInputs = [ protobuf ]; };
-      libp2p-core = attrs: { buildInputs = [ protobuf ]; PROTOC = "${protobuf}/bin/protoc"; };
-      libp2p-plaintext = attrs: { buildInputs = [ protobuf ]; PROTOC = "${protobuf}/bin/protoc"; };
-      libp2p-floodsub = attrs: { buildInputs = [ protobuf ]; PROTOC = "${protobuf}/bin/protoc"; };
-      libp2p-gossipsub = attrs: { buildInputs = [ protobuf ]; PROTOC = "${protobuf}/bin/protoc"; };
-      libp2p-identify = attrs: { buildInputs = [ protobuf ]; PROTOC = "${protobuf}/bin/protoc"; };
-      libp2p-kad = attrs: { buildInputs = [ protobuf ]; PROTOC = "${protobuf}/bin/protoc"; };
-      libp2p-relay = attrs: { buildInputs = [ protobuf ]; PROTOC = "${protobuf}/bin/protoc"; };
-      libp2p-noise = attrs: { buildInputs = [ protobuf ]; PROTOC = "${protobuf}/bin/protoc"; };
+  packages = rec {
+    apps = pkgs.cargoNix.workspaceMembers.anoma_apps.build.override { inherit features; };
 
-      # Additional build inputs are needed on OSX (they're using `xcrun`)
-      blake2b-rs = attrs: { buildInputs = lib.optionals stdenv.isDarwin [ xcbuild ]; };
-      wasmer-vm = attrs: { buildInputs = lib.optionals stdenv.isDarwin [ xcbuild ]; };
+    # By default we want to have executables that have the correct "tendermint" and
+    # "anoma*" executables available in PATH no matter how the user calls anoma etc.
+    anoma = pkgs.runCommandNoCC "anoma" {
+      nativeBuildInputs = [ pkgs.makeWrapper ];
+    } ''
+      mkdir -p $out/bin
+      for exe in ${apps}/bin/* ${tendermint}/bin/*; do
+        makeWrapper $exe $out/bin/$(basename $exe) \
+          --prefix PATH : ${apps}/bin:${tendermint}/bin
+      done
+    '';
 
-      librocksdb-sys = attrs: {
-        buildInputs = [ clang rustfmt snappy lz4 zstd zlib bzip2 ]
-          ++ lib.optionals stdenv.isDarwin [ xcbuild ];
-        LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
-        # rust-rocksdb uses {}_LIB_DIR to determine whether it embeds compression libs in itself.
-        # We need to tell it to use libs from the nix store so that we don't get linker errors later on.
-        SNAPPY_LIB_DIR = "${snappy}/lib";
-        LZ4_LIB_DIR = "${lz4}/lib";
-        ZSTD_LIB_DIR = "${zstd}/lib";
-        Z_LIB_DIR = "${zlib}/lib";
-        BZ2_LIB_DIR = "${bzip2}/lib";
-        # rust-rocksdb relies on CARGO_CFG_TARGET_FEATURE env variable
-        # which is set by cargo. We are using rustc directly here, so
-        # we need to set that variable.
-        #
-        # See: https://github.com/rust-rocksdb/rust-rocksdb/commit/81a9edea83473012378e808606cdd92c1212c076#diff-7377ccc9f5cb3386318bd8afcd84814e7dd6d9b40efa909fb2dc218ecb779499
-        #
-        # XXX empty string is the most portable, but it can't take
-        # advantage of fast vectorization instructions on newer CPUs.
-        CARGO_CFG_TARGET_FEATURE = "";
-      };
+    docs = pkgs.callPackage ./docs { };
 
-      anoma = attrs: {
-        buildInputs = [ rustfmt ];
-        patchPhase = ''
-          substituteInPlace build.rs --replace ./proto ${./proto}
-        '';
-      };
-
-      anoma_apps = attrs: {
-        buildInputs = [ rustfmt lz4 zstd zlib bzip2 ];
-        patchPhase = ''
-          substituteInPlace build.rs --replace ./proto ${./proto}
-        '';
-      };
-    };
-
-  # Generate Cargo.nix with: crate2nix generate
-  cargo_nix = import ./Cargo.nix {
-    inherit pkgs;
-    buildRustCrateForPkgs = pkgs: pkgs.buildRustCrate.override {
-      defaultCrateOverrides = pkgs.defaultCrateOverrides // crateOverrides pkgs;
-    };
+    wasm = pkgs.runCommand "anoma-wasm" { } ''
+      mkdir -p $out/wasm
+      cp ${./wasm/checksums.json} $out/wasm/checksums.json
+    '';
   };
-
-in {
-  apps = cargo_nix.workspaceMembers.anoma_apps;
-}
+in packages

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,3 +3,9 @@ See the [Introduction](./src/).
 In short:
 - `make dev-deps` install dependencies
 - `make serve` open the rendered mdBook in your default browser
+
+Using Nix:
+
+```bash
+nix-shell --run "make serve"
+```

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -1,0 +1,24 @@
+{ pkgs ? import ../nix { }
+}:
+
+with pkgs;
+
+stdenv.mkDerivation {
+  name = "anoma-docs";
+  src = nix-gitignore.gitignoreSource [] ./.;
+  buildInputs = [ mdbook mdbook-mermaid mdbook-linkcheck ];
+
+  patchPhase = ''
+    substituteInPlace src/specs/encoding.md \
+      --replace ../../../proto ${../proto}
+  '';
+
+  buildPhase = ''
+    make build
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    mv book/html $out/
+  '';
+}

--- a/nix/crate-overrides.nix
+++ b/nix/crate-overrides.nix
@@ -1,0 +1,74 @@
+{ defaultCrateOverrides
+, lib
+, stdenv
+, protobuf
+, clang
+, rustfmt
+, snappy
+, lz4
+, zstd
+, zlib
+, bzip2
+, xcbuild
+, llvmPackages
+}:
+
+#with pkgs;
+
+let
+  # XXX by default the host platform is conservative so this does nothing without overriding in config.
+  mkCargoTargetFeatures = platform: lib.concatStringsSep "," (
+    lib.optional (platform.sse3Support) "sse2"
+    ++ lib.optional (platform.sse4_1Support) "sse4.1"
+    ++ lib.optional (platform.sse4_2Support) "sse4.2"
+  );
+in
+
+defaultCrateOverrides // {
+  prost-build = attrs: { buildInputs = [ protobuf ]; };
+  libp2p-core = attrs: { buildInputs = [ protobuf ]; PROTOC = "${protobuf}/bin/protoc"; };
+  libp2p-plaintext = attrs: { buildInputs = [ protobuf ]; PROTOC = "${protobuf}/bin/protoc"; };
+  libp2p-floodsub = attrs: { buildInputs = [ protobuf ]; PROTOC = "${protobuf}/bin/protoc"; };
+  libp2p-gossipsub = attrs: { buildInputs = [ protobuf ]; PROTOC = "${protobuf}/bin/protoc"; };
+  libp2p-identify = attrs: { buildInputs = [ protobuf ]; PROTOC = "${protobuf}/bin/protoc"; };
+  libp2p-kad = attrs: { buildInputs = [ protobuf ]; PROTOC = "${protobuf}/bin/protoc"; };
+  libp2p-relay = attrs: { buildInputs = [ protobuf ]; PROTOC = "${protobuf}/bin/protoc"; };
+  libp2p-noise = attrs: { buildInputs = [ protobuf ]; PROTOC = "${protobuf}/bin/protoc"; };
+
+  # Additional build inputs are needed on OSX (they're using `xcrun`)
+  blake2b-rs = attrs: { buildInputs = lib.optionals stdenv.isDarwin [ xcbuild ]; };
+  wasmer-vm = attrs: { buildInputs = lib.optionals stdenv.isDarwin [ xcbuild ]; };
+
+  librocksdb-sys = attrs: {
+    buildInputs = [ clang rustfmt snappy lz4 zstd zlib bzip2 ]
+      ++ lib.optionals stdenv.isDarwin [ xcbuild ];
+    LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+    # rust-rocksdb uses {}_LIB_DIR to determine whether it embeds compression libs in itself.
+    # We need to tell it to use libs from the nix store so that we don't get linker errors later on.
+    SNAPPY_LIB_DIR = "${snappy}/lib";
+    LZ4_LIB_DIR = "${lz4}/lib";
+    ZSTD_LIB_DIR = "${zstd}/lib";
+    Z_LIB_DIR = "${zlib}/lib";
+    BZ2_LIB_DIR = "${bzip2}/lib";
+    # rust-rocksdb relies on CARGO_CFG_TARGET_FEATURE env variable
+    # which is set by cargo. We are using rustc directly here, so
+    # we need to set that variable.
+    #
+    # See: https://github.com/rust-rocksdb/rust-rocksdb/commit/81a9edea83473012378e808606cdd92c1212c076#diff-7377ccc9f5cb3386318bd8afcd84814e7dd6d9b40efa909fb2dc218ecb779499
+    CARGO_CFG_TARGET_FEATURE = mkCargoTargetFeatures stdenv.hostPlatform;
+  };
+
+  anoma = attrs: {
+    buildInputs = [ rustfmt ];
+    patchPhase = ''
+      substituteInPlace build.rs --replace ./proto ${../proto}
+    '';
+  };
+
+  anoma_apps = attrs: {
+    buildInputs = [ rustfmt lz4 zstd zlib bzip2 ];
+    patchPhase = ''
+      substituteInPlace build.rs --replace ./proto ${../proto}
+    '';
+  };
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,50 @@
+{ config ? {}
+, _cargoNix ? ../Cargo.nix
+,
+}:
+let
+  rustOverlay = import (builtins.fetchTarball "https://github.com/oxalica/rust-overlay/archive/master.tar.gz");
+  # rustc from rust-toolchain.toml
+  rustChannel = (builtins.fromTOML (builtins.readFile ../rust-toolchain.toml)).toolchain.channel;
+  # rustfmt, clippy, miri from nightly
+  rustNightlyVersion = builtins.substring 8 10 (builtins.readFile ../rust-nightly-version);
+  # nixpkgs-unstable 01-12-2021
+  nixpkgs = let hash = "af21d41260846fb9c9840a75e310e56dfe97d6a3";
+    in builtins.fetchTarball { url = "https://github.com/nixos/nixpkgs/archive/${hash}.tar.gz"; };
+  overlays =
+    [
+      rustOverlay
+      (self: super: {
+        # Rust toolchains
+        rustc = self.rust-bin.stable.${rustChannel}.minimal.override {
+          targets = [ "x86_64-unknown-linux-gnu" "wasm32-unknown-unknown" ];
+        };
+        rustNightly = self.rust-bin.nightly.${rustNightlyVersion};
+        # Wrapper which runs the pinned nightly version of cargo
+        cargo-nightly = self.runCommandNoCC "cargo-nightly" { buildInputs = [ self.makeWrapper ]; } ''
+          mkdir -p $out/bin
+          makeWrapper ${self.rustNightly.cargo}/bin/cargo $out/bin/cargo-nightly \
+            --prefix PATH : ${self.lib.makeBinPath [
+              (self.rustNightly.default.override {
+                targets = [ "x86_64-unknown-linux-gnu" "wasm32-unknown-unknown" ];
+              })
+            ]}
+        '';
+        # docs build needs this
+        mdbook-linkcheck = self.callPackage ./mdbook-linkcheck.nix { };
+
+        # you should generate Cargo.nix with "crate2nix generate" since it is not checked in to the repo
+        cargoNix = import _cargoNix {
+          pkgs = self;
+          buildRustCrateForPkgs = pkgs: pkgs.buildRustCrate.override {
+            defaultCrateOverrides = pkgs.callPackage ./crate-overrides.nix {};
+          };
+        };
+      })
+    ];
+
+  pkgs = import nixpkgs {
+    inherit overlays config;
+  };
+
+in pkgs

--- a/nix/mdbook-linkcheck.nix
+++ b/nix/mdbook-linkcheck.nix
@@ -1,0 +1,22 @@
+{ rustPlatform, fetchFromGitHub, pkg-config, openssl }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "mdbook-linkcheck";
+  version = "0.7.5";
+
+  src = fetchFromGitHub {
+    owner = "Michael-F-Bryan";
+    repo = "mdbook-linkcheck";
+    rev = "5c6b338966250f1bed8539ef4b1e9c2d831d6ac0";
+    sha256 = "0kvgcnh9hra2yzbqr93bcbahldy8l9vpclq9ki9mvk8pssngzrr8";
+  };
+
+  cargoSha256 = "0ia2dshh6kw3lihg2mqsa88f8gr8ig54khv1hsxpymizwgdnsrjm";
+
+  dontCargoCheck = 1;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  OPENSSL_NO_VENDOR=1;
+}


### PR DESCRIPTION
Make it so that `nix-shell` drops you in a shell with the same toolchains available as what is used in the `crate2nix`-based derivation (when doing `nix-build`).