### PR TITLE
[nix] adds missing nix-shell dependency

### DIFF
--- a/.changelog/unreleased/miscellaneous/694-nix.md
+++ b/.changelog/unreleased/miscellaneous/694-nix.md
@@ -1,0 +1,2 @@
+- Adds missing nix-shell openssl dependency.
+  ([#694](https://github.com/anoma/anoma/pull/694))

--- a/shell.nix
+++ b/shell.nix
@@ -9,6 +9,7 @@ mkShell {
     llvmPackages.libclang
     protobuf
     crate2nix
+    openssl
     # Needed at runtime
     tendermint
   ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];


### PR DESCRIPTION
`make build` was failing when I tried to run it inside `nix-shell`, with the following message:
```sh
  = note: /nix/store/js66s0xwjnzg0ggi2lq9bcvlk6x2za13-binutils-2.35.2/bin/ld: cannot find -lssl
          /nix/store/js66s0xwjnzg0ggi2lq9bcvlk6x2za13-binutils-2.35.2/bin/ld: cannot find -lcrypto
          collect2: error: ld returned 1 exit status
```

Adding `openssl` to `buildInputs` solved it.