### PR TITLE
tx queue in storage

### DIFF
--- a/.changelog/unreleased/improvements/711-711.md
+++ b/.changelog/unreleased/improvements/711-711.md
@@ -1,0 +1,2 @@
+- Fix the `anoma client utils join-network` to respect `--base-dir` argument, if
+  specified ([#711](https://github.com/anoma/anoma/issues/711))

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,7 +17,7 @@ steps:
     pull: never
   - commands:
       - >-
-        echo "4665b6ec95b864d57f129d898488dd5c4cc5be29736b23782859a2a3cb446111 
+        echo "e004647807379d4ede37425b8e787531ee6e78605821dec9a16dbfaaf0025422 
         Makefile" | sha256sum -c -
       - >-
         echo "96f503edaeb65d5b75855c75ead35c6c3e394ee82ec6fd4aa15d0e7d9f1051d6 
@@ -188,7 +188,7 @@ steps:
     pull: never
   - commands:
       - >-
-        echo "4665b6ec95b864d57f129d898488dd5c4cc5be29736b23782859a2a3cb446111 
+        echo "e004647807379d4ede37425b8e787531ee6e78605821dec9a16dbfaaf0025422 
         Makefile" | sha256sum -c -
       - >-
         echo "96f503edaeb65d5b75855c75ead35c6c3e394ee82ec6fd4aa15d0e7d9f1051d6 
@@ -333,7 +333,7 @@ steps:
     pull: never
   - commands:
       - >-
-        echo "4665b6ec95b864d57f129d898488dd5c4cc5be29736b23782859a2a3cb446111 
+        echo "e004647807379d4ede37425b8e787531ee6e78605821dec9a16dbfaaf0025422 
         Makefile" | sha256sum -c -
       - >-
         echo "96f503edaeb65d5b75855c75ead35c6c3e394ee82ec6fd4aa15d0e7d9f1051d6 
@@ -479,7 +479,7 @@ steps:
     pull: never
   - commands:
       - >-
-        echo "4665b6ec95b864d57f129d898488dd5c4cc5be29736b23782859a2a3cb446111 
+        echo "e004647807379d4ede37425b8e787531ee6e78605821dec9a16dbfaaf0025422 
         Makefile" | sha256sum -c -
       - >-
         echo "96f503edaeb65d5b75855c75ead35c6c3e394ee82ec6fd4aa15d0e7d9f1051d6 
@@ -584,7 +584,7 @@ steps:
     pull: never
   - commands:
       - >-
-        echo "4665b6ec95b864d57f129d898488dd5c4cc5be29736b23782859a2a3cb446111 
+        echo "e004647807379d4ede37425b8e787531ee6e78605821dec9a16dbfaaf0025422 
         Makefile" | sha256sum -c -
       - >-
         echo "96f503edaeb65d5b75855c75ead35c6c3e394ee82ec6fd4aa15d0e7d9f1051d6 
@@ -676,7 +676,7 @@ steps:
     pull: never
   - commands:
       - >-
-        echo "4665b6ec95b864d57f129d898488dd5c4cc5be29736b23782859a2a3cb446111 
+        echo "e004647807379d4ede37425b8e787531ee6e78605821dec9a16dbfaaf0025422 
         Makefile" | sha256sum -c -
       - >-
         echo "96f503edaeb65d5b75855c75ead35c6c3e394ee82ec6fd4aa15d0e7d9f1051d6 
@@ -763,7 +763,7 @@ steps:
     pull: never
   - commands:
       - >-
-        echo "4665b6ec95b864d57f129d898488dd5c4cc5be29736b23782859a2a3cb446111 
+        echo "e004647807379d4ede37425b8e787531ee6e78605821dec9a16dbfaaf0025422 
         Makefile" | sha256sum -c -
       - >-
         echo "96f503edaeb65d5b75855c75ead35c6c3e394ee82ec6fd4aa15d0e7d9f1051d6 
@@ -873,7 +873,7 @@ steps:
     pull: never
   - commands:
       - >-
-        echo "4665b6ec95b864d57f129d898488dd5c4cc5be29736b23782859a2a3cb446111 
+        echo "e004647807379d4ede37425b8e787531ee6e78605821dec9a16dbfaaf0025422 
         Makefile" | sha256sum -c -
       - >-
         echo "96f503edaeb65d5b75855c75ead35c6c3e394ee82ec6fd4aa15d0e7d9f1051d6 
@@ -960,7 +960,7 @@ steps:
     pull: never
   - commands:
       - >-
-        echo "4665b6ec95b864d57f129d898488dd5c4cc5be29736b23782859a2a3cb446111 
+        echo "e004647807379d4ede37425b8e787531ee6e78605821dec9a16dbfaaf0025422 
         Makefile" | sha256sum -c -
       - >-
         echo "96f503edaeb65d5b75855c75ead35c6c3e394ee82ec6fd4aa15d0e7d9f1051d6 
@@ -1049,7 +1049,7 @@ steps:
     pull: never
   - commands:
       - >-
-        echo "4665b6ec95b864d57f129d898488dd5c4cc5be29736b23782859a2a3cb446111 
+        echo "e004647807379d4ede37425b8e787531ee6e78605821dec9a16dbfaaf0025422 
         Makefile" | sha256sum -c -
       - >-
         echo "96f503edaeb65d5b75855c75ead35c6c3e394ee82ec6fd4aa15d0e7d9f1051d6 
@@ -1195,7 +1195,7 @@ steps:
     pull: never
   - commands:
       - >-
-        echo "4665b6ec95b864d57f129d898488dd5c4cc5be29736b23782859a2a3cb446111 
+        echo "e004647807379d4ede37425b8e787531ee6e78605821dec9a16dbfaaf0025422 
         Makefile" | sha256sum -c -
       - >-
         echo "96f503edaeb65d5b75855c75ead35c6c3e394ee82ec6fd4aa15d0e7d9f1051d6 
@@ -1393,7 +1393,7 @@ steps:
     pull: never
   - commands:
       - >-
-        echo "4665b6ec95b864d57f129d898488dd5c4cc5be29736b23782859a2a3cb446111 
+        echo "e004647807379d4ede37425b8e787531ee6e78605821dec9a16dbfaaf0025422 
         Makefile" | sha256sum -c -
       - >-
         echo "96f503edaeb65d5b75855c75ead35c6c3e394ee82ec6fd4aa15d0e7d9f1051d6 
@@ -1487,6 +1487,6 @@ workspace:
   path: /usr/local/rust/anoma
 ---
 kind: signature
-hmac: db507944d1e46933ca985de1de98faba3253b94cad5d73a463bf89fcbc960b11
+hmac: 9d44042f4acc87e3bc942c92337d2a1675659ff60bb289f6ba6453f22f3e2792
 
 ...

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1811,9 +1811,9 @@ dependencies = [
 
 [[package]]
 name = "escargot"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ead7d8a70259beb627c1ffdd19b0372381f247f88e46a3bd52bb797182690b3"
+checksum = "f5584ba17d7ab26a8a7284f13e5bd196294dd2f2d79773cff29b9e9edef601a6"
 dependencies = [
  "log 0.4.14",
  "once_cell",

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -226,7 +226,7 @@ where
             .gas_meter
             .finalize_transaction()
             .map_err(|_| Error::GasOverflow)?;
-        self.reset_queue();
+        self.reset_tx_queue_iter();
         Ok(response)
     }
 

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -113,7 +113,7 @@ where
                 // if the rejected tx was decrypted, remove it
                 // from the queue of txs to be processed
                 if let TxType::Decrypted(_) = &tx_type {
-                    self.tx_queue.pop();
+                    self.storage.tx_queue.pop();
                 }
                 continue;
             }
@@ -121,7 +121,7 @@ where
             let mut tx_result = match &tx_type {
                 TxType::Wrapper(_wrapper) => {
                     if !cfg!(feature = "ABCI") {
-                        self.tx_queue.push(_wrapper.clone());
+                        self.storage.tx_queue.push(_wrapper.clone());
                     }
                     Event::new_tx_event(&tx_type, height.0)
                 }
@@ -144,7 +144,7 @@ where
                     }
                     // We remove the corresponding wrapper tx from the queue
                     if !cfg!(feature = "ABCI") {
-                        self.tx_queue.pop();
+                        self.storage.tx_queue.pop();
                     }
                     Event::new_tx_event(&tx_type, height.0)
                 }

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -12,7 +12,6 @@ mod prepare_proposal;
 mod process_proposal;
 mod queries;
 
-use std::collections::VecDeque;
 use std::convert::{TryFrom, TryInto};
 use std::mem;
 use std::path::{Path, PathBuf};
@@ -37,7 +36,7 @@ use anoma::types::transaction::{
 use anoma::types::{address, key, token};
 use anoma::vm::wasm::{TxCache, VpCache};
 use anoma::vm::WasmCacheRwAccess;
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::BorshSerialize;
 use num_derive::{FromPrimitive, ToPrimitive};
 use num_traits::{FromPrimitive, ToPrimitive};
 #[cfg(not(feature = "ABCI"))]
@@ -149,86 +148,14 @@ pub struct Shell<
     /// this field. They will be slashed when we finalize the block.
     byzantine_validators: Vec<Evidence>,
     /// Path to the base directory with DB data and configs
+    #[allow(dead_code)]
     base_dir: PathBuf,
     /// Path to the WASM directory for files used in the genesis block.
     wasm_dir: PathBuf,
-    /// Wrapper txs to be decrypted in the next block proposal
-    tx_queue: TxQueue,
     /// VP WASM compilation cache
     vp_wasm_cache: VpCache<WasmCacheRwAccess>,
     /// Tx WASM compilation cache
     tx_wasm_cache: TxCache<WasmCacheRwAccess>,
-}
-
-#[derive(Default, Debug, Clone, BorshDeserialize, BorshSerialize)]
-/// Wrapper txs to be decrypted in the next block proposal
-pub struct TxQueue {
-    /// Index of next wrapper_tx to fetch from storage
-    next_wrapper: usize,
-    /// The actual wrappers
-    queue: VecDeque<WrapperTx>,
-}
-
-impl TxQueue {
-    /// Add a new wrapper at the back of the queue
-    pub fn push(&mut self, wrapper: WrapperTx) {
-        self.queue.push_back(wrapper);
-    }
-
-    /// Remove the wrapper at the head of the queue
-    pub fn pop(&mut self) -> Option<WrapperTx> {
-        self.queue.pop_front()
-    }
-
-    /// Iterate lazily over the queue
-    #[allow(dead_code)]
-    fn next(&mut self) -> Option<&WrapperTx> {
-        let next = self.queue.get(self.next_wrapper);
-        if self.next_wrapper < self.queue.len() {
-            self.next_wrapper += 1;
-        }
-        next
-    }
-
-    /// Reset the iterator to the head of the queue
-    pub fn rewind(&mut self) {
-        self.next_wrapper = 0;
-    }
-
-    /// Get an iterator over the queue
-    #[allow(dead_code)]
-    pub fn iter(&self) -> impl std::iter::Iterator<Item = &WrapperTx> {
-        self.queue.iter()
-    }
-
-    /// Check if there are any txs in the queue
-    #[allow(dead_code)]
-    pub fn is_empty(&self) -> bool {
-        self.queue.is_empty()
-    }
-}
-
-impl<D, H> Drop for Shell<D, H>
-where
-    D: DB + for<'iter> DBIter<'iter> + Sync + 'static,
-    H: StorageHasher + Sync + 'static,
-{
-    fn drop(&mut self) {
-        tracing::info!("Storing a transaction queue...");
-        let cache_path = self.base_dir.clone().join(".tx_queue");
-        let _ = std::fs::File::create(&cache_path)
-            .expect("Creating the file for the tx_queue dump should not fail");
-        std::fs::write(
-            cache_path,
-            self.tx_queue
-                .try_to_vec()
-                .expect("Serializing tx queue to bytes should not fail"),
-        )
-        .expect(
-            "Failed to write tx queue to file. Good luck booting back up now",
-        );
-        tracing::info!("Transaction queue has been stored.");
-    }
 }
 
 impl<D, H> Shell<D, H>
@@ -258,24 +185,6 @@ where
                 tracing::error!("Cannot load the last state from the DB {}", e);
             })
             .expect("PersistentStorage cannot be initialized");
-        // If we are not starting the chain for the first time, the file
-        // containing the tx queue should exist
-        let tx_queue = if storage.last_height.0 > 0u64 {
-            BorshDeserialize::deserialize(
-                &mut std::fs::read(base_dir.join(".tx_queue"))
-                    .expect(
-                        "Anoma ledger failed to start: Failed to open file \
-                         containing the transaction queue",
-                    )
-                    .as_ref(),
-            )
-            .expect(
-                "Anoma ledger failed to start: Failed to read file containing \
-                 the transaction queue",
-            )
-        } else {
-            Default::default()
-        };
 
         let vp_wasm_cache_dir =
             base_dir.join(chain_id.as_str()).join("vp_wasm_cache");
@@ -288,7 +197,6 @@ where
             byzantine_validators: vec![],
             base_dir,
             wasm_dir,
-            tx_queue,
             vp_wasm_cache: VpCache::new(
                 vp_wasm_cache_dir,
                 vp_wasm_compilation_cache as usize,
@@ -303,19 +211,19 @@ where
     /// Iterate lazily over the wrapper txs in order
     #[cfg(not(feature = "ABCI"))]
     fn next_wrapper(&mut self) -> Option<&WrapperTx> {
-        self.tx_queue.next()
+        self.storage.tx_queue.next()
     }
 
     /// Iterate lazily over the wrapper txs in order
     #[cfg(feature = "ABCI")]
     fn next_wrapper(&mut self) -> Option<WrapperTx> {
-        self.tx_queue.pop()
+        self.storage.tx_queue.pop()
     }
 
     /// If we reject the decrypted txs because they were out of
     /// order, reset the iterator.
     pub fn reset_queue(&mut self) {
-        self.tx_queue.rewind()
+        self.storage.tx_queue.rewind()
     }
 
     /// Load the Merkle root hash and the height of the last committed block, if
@@ -687,7 +595,7 @@ mod test_utils {
         /// Add a wrapper tx to the queue of txs to be decrypted
         /// in the current block proposal
         pub fn enqueue_tx(&mut self, wrapper: WrapperTx) {
-            self.shell.tx_queue.push(wrapper);
+            self.shell.storage.tx_queue.push(wrapper);
             self.shell.reset_queue();
         }
 
@@ -718,9 +626,8 @@ mod test_utils {
         test
     }
 
-    /// We test that on shell shutdown, the tx queue gets
-    /// persisted in a file, and on startup it is read
-    /// successfully
+    /// We test that on shell shutdown, the tx queue gets persisted in a DB, and
+    /// on startup it is read successfully
     #[test]
     fn test_tx_queue_persistence() {
         let base_dir = tempdir().unwrap().as_ref().canonicalize().unwrap();
@@ -752,9 +659,9 @@ mod test_utils {
             0.into(),
             tx,
         );
-        shell.tx_queue.push(wrapper);
+        shell.storage.tx_queue.push(wrapper);
         // Artificially increase the block height so that chain
-        // will read the ".tx_queue" file when restarted
+        // will read the new block when restarted
         let store = Default::default();
         let hash = BlockHash([0; 32]);
         let pred_epochs = Default::default();
@@ -772,14 +679,14 @@ mod test_utils {
                 next_epoch_min_start_height: BlockHeight(3),
                 next_epoch_min_start_time: DateTimeUtc::now(),
                 address_gen: &address_gen,
+                tx_queue: &shell.storage.tx_queue,
             })
             .expect("Test failed");
 
-        // Drop the shell and check that the ".tx_queue" file was created
+        // Drop the shell
         std::mem::drop(shell);
-        assert!(base_dir.join(".tx_queue").exists());
 
-        // Reboot the shell and check that the queue was restored from disk
+        // Reboot the shell and check that the queue was restored from DB
         let shell = Shell::<PersistentDB, PersistentStorageHasher>::new(
             base_dir.clone(),
             base_dir.join("db").join("anoma-devchain-00000"),
@@ -789,80 +696,6 @@ mod test_utils {
             vp_wasm_compilation_cache,
             tx_wasm_compilation_cache,
         );
-        assert!(!shell.tx_queue.is_empty());
-    }
-
-    /// We test that on shell bootup, if the last height > 0
-    /// and  the tx queue file is missing, bootup fails
-    #[test]
-    #[should_panic]
-    fn test_tx_queue_must_exist() {
-        let base_dir = tempdir().unwrap().as_ref().canonicalize().unwrap();
-        // we have to use RocksDB for this test
-        let vp_wasm_compilation_cache = 50 * 1024 * 1024; // 50 kiB
-        let tx_wasm_compilation_cache = 50 * 1024 * 1024; // 50 kiB
-        let mut shell = Shell::<PersistentDB, PersistentStorageHasher>::new(
-            base_dir.clone(),
-            base_dir.join("db").join("anoma-devchain-00000"),
-            Default::default(),
-            top_level_directory().join("wasm"),
-            None,
-            vp_wasm_compilation_cache,
-            tx_wasm_compilation_cache,
-        );
-        let keypair = gen_keypair();
-        // enqueue a wrapper tx
-        let tx = Tx::new(
-            "wasm_code".as_bytes().to_owned(),
-            Some("transaction data".as_bytes().to_owned()),
-        );
-        let wrapper = WrapperTx::new(
-            Fee {
-                amount: 0.into(),
-                token: xan(),
-            },
-            &keypair,
-            Epoch(0),
-            0.into(),
-            tx,
-        );
-        shell.tx_queue.push(wrapper);
-        // Artificially increase the block height so that chain
-        // will read the ".tx_queue" file when restarted
-        let store = Default::default();
-        let hash = BlockHash([0; 32]);
-        let pred_epochs = Default::default();
-        let address_gen = EstablishedAddressGen::new("test");
-        shell
-            .storage
-            .db
-            .write_block(BlockStateWrite {
-                root: [0; 32].into(),
-                store: &store,
-                hash: &hash,
-                height: BlockHeight(1),
-                epoch: Epoch(0),
-                pred_epochs: &pred_epochs,
-                next_epoch_min_start_height: BlockHeight(3),
-                next_epoch_min_start_time: DateTimeUtc::now(),
-                address_gen: &address_gen,
-            })
-            .expect("Test failed");
-
-        // Drop the shell and check that the ".tx_queue" file was created
-        std::mem::drop(shell);
-        std::fs::remove_file(base_dir.join(".tx_queue")).expect("Test failed");
-        assert!(!base_dir.join(".tx_queue").exists());
-
-        // Reboot the shell and check that the queue was restored from disk
-        let _ = Shell::<PersistentDB, PersistentStorageHasher>::new(
-            base_dir.clone(),
-            base_dir.join("db").join("anoma-devchain-00000"),
-            Default::default(),
-            top_level_directory().join("wasm"),
-            None,
-            vp_wasm_compilation_cache,
-            tx_wasm_compilation_cache,
-        );
+        assert!(!shell.storage.tx_queue.is_empty());
     }
 }

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -211,7 +211,7 @@ where
     /// Iterate lazily over the wrapper txs in order
     #[cfg(not(feature = "ABCI"))]
     fn next_wrapper(&mut self) -> Option<&WrapperTx> {
-        self.storage.tx_queue.next()
+        self.storage.tx_queue.lazy_next()
     }
 
     /// Iterate lazily over the wrapper txs in order
@@ -222,7 +222,7 @@ where
 
     /// If we reject the decrypted txs because they were out of
     /// order, reset the iterator.
-    pub fn reset_queue(&mut self) {
+    pub fn reset_tx_queue_iter(&mut self) {
         self.storage.tx_queue.rewind()
     }
 
@@ -594,9 +594,10 @@ mod test_utils {
 
         /// Add a wrapper tx to the queue of txs to be decrypted
         /// in the current block proposal
+        #[cfg(test)]
         pub fn enqueue_tx(&mut self, wrapper: WrapperTx) {
             self.shell.storage.tx_queue.push(wrapper);
-            self.shell.reset_queue();
+            self.shell.reset_tx_queue_iter();
         }
 
         #[cfg(not(feature = "ABCI"))]

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -48,6 +48,7 @@ mod prepare_block {
 
             // decrypt the wrapper txs included in the previous block
             let mut decrypted_txs = self
+                .storage
                 .tx_queue
                 .iter()
                 .map(|tx| {

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -194,7 +194,7 @@ where
                 })
                 .to_bytes();
                 // we are not checking that txs are out of order
-                self.tx_queue.push(wrapper);
+                self.storage.tx_queue.push(wrapper);
                 // check the decoded tx
                 let mut decoded_resp =
                     self.process_proposal(shim::request::ProcessProposal {
@@ -287,7 +287,7 @@ mod test_process_proposal {
         #[cfg(feature = "ABCI")]
         {
             assert_eq!(response.tx, tx);
-            assert!(shell.shell.tx_queue.is_empty())
+            assert!(shell.shell.storage.tx_queue.is_empty())
         }
     }
 
@@ -365,7 +365,7 @@ mod test_process_proposal {
         #[cfg(feature = "ABCI")]
         {
             assert_eq!(response.tx, new_tx.to_bytes());
-            assert!(shell.shell.tx_queue.is_empty())
+            assert!(shell.shell.storage.tx_queue.is_empty())
         }
     }
 
@@ -404,7 +404,7 @@ mod test_process_proposal {
         #[cfg(feature = "ABCI")]
         {
             assert_eq!(response.tx, wrapper.to_bytes());
-            assert!(shell.shell.tx_queue.is_empty())
+            assert!(shell.shell.storage.tx_queue.is_empty())
         }
     }
 
@@ -456,7 +456,7 @@ mod test_process_proposal {
         #[cfg(feature = "ABCI")]
         {
             assert_eq!(response.tx, wrapper.to_bytes());
-            assert!(shell.shell.tx_queue.is_empty())
+            assert!(shell.shell.storage.tx_queue.is_empty())
         }
     }
 
@@ -603,7 +603,7 @@ mod test_process_proposal {
                         hash_tx(inner.try_to_vec().unwrap().as_ref()),
                         hash_tx(wrapper.try_to_vec().unwrap().as_ref())
                     );
-                    assert!(shell.shell.tx_queue.is_empty())
+                    assert!(shell.shell.storage.tx_queue.is_empty())
                 }
                 _ => panic!("Test failed"),
             }

--- a/apps/src/lib/node/ledger/shims/abcipp_shim.rs
+++ b/apps/src/lib/node/ledger/shims/abcipp_shim.rs
@@ -121,7 +121,7 @@ impl AbcippShim {
                     if out_of_order {
                         // The wrapper txs will need to be decrypted again
                         // and included in the proposed block after the current
-                        self.service.reset_queue();
+                        self.service.reset_tx_queue_iter();
                     }
                     let begin_block_request =
                         self.begin_block_request.take().unwrap();

--- a/apps/src/lib/node/ledger/storage/rocksdb.rs
+++ b/apps/src/lib/node/ledger/storage/rocksdb.rs
@@ -5,6 +5,9 @@
 //! - `height`: the last committed block height
 //! - `epoch_start_height`: block height at which the current epoch started
 //! - `epoch_start_time`: block time at which the current epoch started
+//! - `tx_queue`: txs to be decrypted in the next block
+//! - `pred`: predecessor values of the top-level keys of the same name
+//!   - `tx_queue`
 //! - `subspace`: any byte data associated with accounts
 //! - `history/subspace`: list of block heights at which any given subspace key
 //!   has changed
@@ -28,7 +31,9 @@ use anoma::ledger::storage::{
     types, BlockStateRead, BlockStateWrite, DBIter, DBWriteBatch, Error,
     Result, DB,
 };
-use anoma::types::storage::{BlockHeight, Key, KeySeg, KEY_SEGMENT_SEPARATOR};
+use anoma::types::storage::{
+    BlockHeight, Key, KeySeg, TxQueue, KEY_SEGMENT_SEPARATOR,
+};
 use anoma::types::time::DateTimeUtc;
 use rocksdb::{
     BlockBasedOptions, Direction, FlushOptions, IteratorMode, Options,
@@ -293,6 +298,17 @@ impl DB for RocksDB {
                 return Ok(None);
             }
         };
+        let tx_queue: TxQueue = match self
+            .0
+            .get("tx_queue")
+            .map_err(|e| Error::DBError(e.into_string()))?
+        {
+            Some(bytes) => types::decode(bytes).map_err(Error::CodingError)?,
+            None => {
+                tracing::error!("Couldn't load tx queue from the DB");
+                return Ok(None);
+            }
+        };
 
         // Load data at the height
         let prefix = format!("{}/", height.raw());
@@ -383,6 +399,7 @@ impl DB for RocksDB {
                 next_epoch_min_start_height,
                 next_epoch_min_start_time,
                 address_gen,
+                tx_queue,
             })),
             _ => Err(Error::Temporary {
                 error: "Essential data couldn't be read from the DB"
@@ -403,6 +420,7 @@ impl DB for RocksDB {
             next_epoch_min_start_height,
             next_epoch_min_start_time,
             address_gen,
+            tx_queue,
         }: BlockStateWrite = state;
 
         // Epoch start height and time
@@ -414,6 +432,16 @@ impl DB for RocksDB {
             "next_epoch_min_start_time",
             types::encode(&next_epoch_min_start_time),
         );
+        // Tx queue
+        if let Some(pred_tx_queue) = self
+            .0
+            .get("tx_queue")
+            .map_err(|e| Error::DBError(e.into_string()))?
+        {
+            // Write the predecessor value for rollback
+            batch.put("pred/tx_queue", pred_tx_queue);
+        }
+        batch.put("tx_queue", types::encode(&tx_queue));
 
         let prefix_key = Key::from(height.to_db_key());
         // Merkle tree

--- a/shared/src/types/storage.rs
+++ b/shared/src/types/storage.rs
@@ -570,9 +570,10 @@ impl TxQueue {
         self.queue.pop_front()
     }
 
-    /// Iterate lazily over the queue
+    /// Iterate lazily over the queue. Finds the next value and advances the
+    /// lazy iterator.
     #[allow(dead_code)]
-    pub fn next(&mut self) -> Option<&WrapperTx> {
+    pub fn lazy_next(&mut self) -> Option<&WrapperTx> {
         let next = self.queue.get(self.next_wrapper);
         if self.next_wrapper < self.queue.len() {
             self.next_wrapper += 1;

--- a/shared/src/types/storage.rs
+++ b/shared/src/types/storage.rs
@@ -9,6 +9,8 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+#[cfg(feature = "ferveo-tpke")]
+use super::transaction::WrapperTx;
 use crate::bytes::ByteBuf;
 use crate::types::address::{self, Address};
 
@@ -543,6 +545,56 @@ impl Epochs {
             return Some(epoch);
         }
         None
+    }
+}
+
+#[cfg(feature = "ferveo-tpke")]
+#[derive(Default, Debug, Clone, BorshDeserialize, BorshSerialize)]
+/// Wrapper txs to be decrypted in the next block proposal
+pub struct TxQueue {
+    /// Index of next wrapper_tx to fetch from storage
+    next_wrapper: usize,
+    /// The actual wrappers
+    queue: std::collections::VecDeque<WrapperTx>,
+}
+
+#[cfg(feature = "ferveo-tpke")]
+impl TxQueue {
+    /// Add a new wrapper at the back of the queue
+    pub fn push(&mut self, wrapper: WrapperTx) {
+        self.queue.push_back(wrapper);
+    }
+
+    /// Remove the wrapper at the head of the queue
+    pub fn pop(&mut self) -> Option<WrapperTx> {
+        self.queue.pop_front()
+    }
+
+    /// Iterate lazily over the queue
+    #[allow(dead_code)]
+    pub fn next(&mut self) -> Option<&WrapperTx> {
+        let next = self.queue.get(self.next_wrapper);
+        if self.next_wrapper < self.queue.len() {
+            self.next_wrapper += 1;
+        }
+        next
+    }
+
+    /// Reset the iterator to the head of the queue
+    pub fn rewind(&mut self) {
+        self.next_wrapper = 0;
+    }
+
+    /// Get an iterator over the queue
+    #[allow(dead_code)]
+    pub fn iter(&self) -> impl std::iter::Iterator<Item = &WrapperTx> {
+        self.queue.iter()
+    }
+
+    /// Check if there are any txs in the queue
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
     }
 }
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -54,7 +54,8 @@ anoma_apps = {path = "../apps", default-features = false, features = ["testing"]
 assert_cmd = "1.0.7"
 borsh = "0.9.1"
 color-eyre = "0.5.11"
-escargot = "0.5.2"
+# NOTE: enable "print" feature to see output from builds ran by e2e tests
+escargot = {version = "0.5.7"} # , features = ["print"]}
 eyre = "0.6.5"
 itertools = "0.10.0"
 libp2p = "0.38.0"

--- a/tests/src/e2e/gossip_tests.rs
+++ b/tests/src/e2e/gossip_tests.rs
@@ -29,14 +29,14 @@ fn run_gossip() -> Result<()> {
         setup::network(|genesis| setup::add_validators(1, genesis), None)?;
 
     let mut cmd =
-        run_as!(test, Who::Validator(0), Bin::Node, &["gossip"], Some(20),)?;
+        run_as!(test, Who::Validator(0), Bin::Node, &["gossip"], Some(40))?;
     // Node without peers
     cmd.exp_regex(r"Peer id: PeerId\(.*\)")?;
 
     drop(cmd);
 
     let mut first_node =
-        run_as!(test, Who::Validator(0), Bin::Node, &["gossip"], Some(20),)?;
+        run_as!(test, Who::Validator(0), Bin::Node, &["gossip"], Some(40))?;
     let (_unread, matched) = first_node.exp_regex(r"Peer id: PeerId\(.*\)")?;
     let first_node_peer_id = matched
         .trim()
@@ -48,7 +48,7 @@ fn run_gossip() -> Result<()> {
         .1;
 
     let mut second_node =
-        run_as!(test, Who::Validator(1), Bin::Node, &["gossip"], Some(20),)?;
+        run_as!(test, Who::Validator(1), Bin::Node, &["gossip"], Some(40))?;
 
     second_node.exp_regex(r"Peer id: PeerId\(.*\)")?;
     second_node.exp_string(&format!(
@@ -67,7 +67,7 @@ fn match_intents() -> Result<()> {
     let test = setup::single_node_net()?;
 
     let mut ledger =
-        run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(20),)?;
+        run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(40))?;
     ledger.exp_string("Anoma ledger node started")?;
     ledger.exp_string("No state could be found")?;
     // Wait to commit a block
@@ -134,7 +134,7 @@ fn match_intents() -> Result<()> {
             "--signing-key",
             "matchmaker-key",
         ],
-        Some(20),
+        Some(40)
     )?;
 
     // Wait gossip to start

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -118,7 +118,6 @@ fn run_ledger_load_state_and_reset() -> Result<()> {
     // Wait for the node to stop running to finish writing the state and tx
     // queue
     ledger.exp_string("Anoma ledger node has shut down.")?;
-    ledger.exp_string("Transaction queue has been stored.")?;
     ledger.exp_eof()?;
     drop(ledger);
 
@@ -368,7 +367,6 @@ fn invalid_transactions() -> Result<()> {
     // Wait for the node to stop running to finish writing the state and tx
     // queue
     ledger.exp_string("Anoma ledger node has shut down.")?;
-    ledger.exp_string("Transaction queue has been stored.")?;
     ledger.exp_eof()?;
     drop(ledger);
 

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -36,7 +36,7 @@ fn run_ledger() -> Result<()> {
     // Start the ledger as a validator
     for args in &cmd_combinations {
         let mut ledger =
-            run_as!(test, Who::Validator(0), Bin::Node, args, Some(20))?;
+            run_as!(test, Who::Validator(0), Bin::Node, args, Some(40))?;
         ledger.exp_string("Anoma ledger node started")?;
         ledger.exp_string("This node is a validator")?;
     }
@@ -44,7 +44,7 @@ fn run_ledger() -> Result<()> {
     // Start the ledger as a non-validator
     for args in &cmd_combinations {
         let mut ledger =
-            run_as!(test, Who::NonValidator, Bin::Node, args, Some(20))?;
+            run_as!(test, Who::NonValidator, Bin::Node, args, Some(40))?;
         ledger.exp_string("Anoma ledger node started")?;
         if !cfg!(feature = "ABCI") {
             ledger.exp_string(
@@ -69,7 +69,7 @@ fn test_anoma_shuts_down_if_tendermint_dies() -> Result<()> {
 
     // 1. Run the ledger node
     let mut ledger =
-        run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(20))?;
+        run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(40))?;
 
     ledger.exp_string("Anoma ledger node started")?;
 
@@ -105,7 +105,7 @@ fn run_ledger_load_state_and_reset() -> Result<()> {
 
     // 1. Run the ledger node
     let mut ledger =
-        run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(20))?;
+        run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(40))?;
 
     ledger.exp_string("Anoma ledger node started")?;
     // There should be no previous state
@@ -123,7 +123,7 @@ fn run_ledger_load_state_and_reset() -> Result<()> {
 
     // 3. Run the ledger again, it should load its previous state
     let mut ledger =
-        run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(20))?;
+        run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(40))?;
 
     ledger.exp_string("Anoma ledger node started")?;
 
@@ -148,7 +148,7 @@ fn run_ledger_load_state_and_reset() -> Result<()> {
 
     // 6. Run the ledger again, it should start from fresh state
     let mut session =
-        run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(20))?;
+        run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(40))?;
 
     session.exp_string("Anoma ledger node started")?;
 
@@ -171,7 +171,7 @@ fn ledger_txs_and_queries() -> Result<()> {
 
     // 1. Run the ledger node
     let mut ledger =
-        run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(20))?;
+        run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(40))?;
 
     ledger.exp_string("Anoma ledger node started")?;
     if !cfg!(feature = "ABCI") {
@@ -262,7 +262,7 @@ fn ledger_txs_and_queries() -> Result<()> {
             } else {
                 tx_args.clone()
             };
-            let mut client = run!(test, Bin::Client, tx_args, Some(20))?;
+            let mut client = run!(test, Bin::Client, tx_args, Some(40))?;
 
             if !dry_run {
                 if !cfg!(feature = "ABCI") {
@@ -284,7 +284,7 @@ fn ledger_txs_and_queries() -> Result<()> {
         ),
     ];
     for (query_args, expected) in &query_args_and_expected_response {
-        let mut client = run!(test, Bin::Client, query_args, Some(20))?;
+        let mut client = run!(test, Bin::Client, query_args, Some(40))?;
         client.exp_regex(expected)?;
 
         client.assert_success();
@@ -305,7 +305,7 @@ fn invalid_transactions() -> Result<()> {
 
     // 1. Run the ledger node
     let mut ledger =
-        run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(20))?;
+        run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(40))?;
     ledger.exp_string("Anoma ledger node started")?;
     if !cfg!(feature = "ABCI") {
         ledger.exp_string("started node")?;
@@ -348,7 +348,7 @@ fn invalid_transactions() -> Result<()> {
         XAN,
     ];
 
-    let mut client = run!(test, Bin::Client, tx_args, Some(20))?;
+    let mut client = run!(test, Bin::Client, tx_args, Some(40))?;
     if !cfg!(feature = "ABCI") {
         client.exp_string("Transaction accepted")?;
     }
@@ -372,7 +372,7 @@ fn invalid_transactions() -> Result<()> {
 
     // 4. Restart the ledger
     let mut ledger =
-        run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(20))?;
+        run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(40))?;
 
     ledger.exp_string("Anoma ledger node started")?;
 
@@ -403,7 +403,7 @@ fn invalid_transactions() -> Result<()> {
         "--force",
     ];
 
-    let mut client = run!(test, Bin::Client, tx_args, Some(20))?;
+    let mut client = run!(test, Bin::Client, tx_args, Some(40))?;
     if !cfg!(feature = "ABCI") {
         client.exp_string("Transaction accepted")?;
     }
@@ -452,7 +452,7 @@ fn pos_bonds() -> Result<()> {
 
     // 1. Run the ledger node
     let mut ledger =
-        run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(20))?;
+        run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(40))?;
 
     ledger.exp_string("Anoma ledger node started")?;
     if !cfg!(feature = "ABCI") {
@@ -475,7 +475,7 @@ fn pos_bonds() -> Result<()> {
         XAN,
     ];
     let mut client =
-        run_as!(test, Who::Validator(0), Bin::Client, tx_args, Some(20))?;
+        run_as!(test, Who::Validator(0), Bin::Client, tx_args, Some(40))?;
     client.exp_string("Transaction is valid.")?;
     client.assert_success();
 
@@ -495,7 +495,7 @@ fn pos_bonds() -> Result<()> {
         "--fee-token",
         XAN,
     ];
-    let mut client = run!(test, Bin::Client, tx_args, Some(20))?;
+    let mut client = run!(test, Bin::Client, tx_args, Some(40))?;
     client.exp_string("Transaction is valid.")?;
     client.assert_success();
 
@@ -514,7 +514,7 @@ fn pos_bonds() -> Result<()> {
         XAN,
     ];
     let mut client =
-        run_as!(test, Who::Validator(0), Bin::Client, tx_args, Some(20))?;
+        run_as!(test, Who::Validator(0), Bin::Client, tx_args, Some(40))?;
     client.exp_string("Transaction is valid.")?;
     client.assert_success();
 
@@ -534,7 +534,7 @@ fn pos_bonds() -> Result<()> {
         "--fee-token",
         XAN,
     ];
-    let mut client = run!(test, Bin::Client, tx_args, Some(20))?;
+    let mut client = run!(test, Bin::Client, tx_args, Some(40))?;
     client.exp_string("Transaction is valid.")?;
     client.assert_success();
 
@@ -573,7 +573,7 @@ fn pos_bonds() -> Result<()> {
         XAN,
     ];
     let mut client =
-        run_as!(test, Who::Validator(0), Bin::Client, tx_args, Some(20))?;
+        run_as!(test, Who::Validator(0), Bin::Client, tx_args, Some(40))?;
     client.exp_string("Transaction is valid.")?;
     client.assert_success();
 
@@ -591,7 +591,7 @@ fn pos_bonds() -> Result<()> {
         "--fee-token",
         XAN,
     ];
-    let mut client = run!(test, Bin::Client, tx_args, Some(20))?;
+    let mut client = run!(test, Bin::Client, tx_args, Some(40))?;
     client.exp_string("Transaction is valid.")?;
     client.assert_success();
 
@@ -632,7 +632,7 @@ fn pos_init_validator() -> Result<()> {
 
     // 1. Run the ledger node
     let mut ledger =
-        run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(20))?;
+        run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(40))?;
 
     ledger.exp_string("Anoma ledger node started")?;
     if !cfg!(feature = "ABCI") {
@@ -658,7 +658,7 @@ fn pos_init_validator() -> Result<()> {
         "--fee-token",
         XAN,
     ];
-    let mut client = run!(test, Bin::Client, tx_args, Some(20))?;
+    let mut client = run!(test, Bin::Client, tx_args, Some(40))?;
     client.exp_string("Transaction is valid.")?;
     client.assert_success();
 
@@ -681,7 +681,7 @@ fn pos_init_validator() -> Result<()> {
         "--fee-token",
         XAN,
     ];
-    let mut client = run!(test, Bin::Client, tx_args, Some(20))?;
+    let mut client = run!(test, Bin::Client, tx_args, Some(40))?;
     client.exp_string("Transaction is valid.")?;
     client.assert_success();
     //     Then self-bond the tokens:
@@ -700,7 +700,7 @@ fn pos_init_validator() -> Result<()> {
         "--fee-token",
         XAN,
     ];
-    let mut client = run!(test, Bin::Client, tx_args, Some(20))?;
+    let mut client = run!(test, Bin::Client, tx_args, Some(40))?;
     client.exp_string("Transaction is valid.")?;
     client.assert_success();
 
@@ -722,7 +722,7 @@ fn pos_init_validator() -> Result<()> {
         "--fee-token",
         XAN,
     ];
-    let mut client = run!(test, Bin::Client, tx_args, Some(20))?;
+    let mut client = run!(test, Bin::Client, tx_args, Some(40))?;
     client.exp_string("Transaction is valid.")?;
     client.assert_success();
 
@@ -740,7 +740,7 @@ fn pos_init_validator() -> Result<()> {
         "--fee-token",
         XAN,
     ];
-    let mut client = run!(test, Bin::Client, tx_args, Some(20))?;
+    let mut client = run!(test, Bin::Client, tx_args, Some(40))?;
     client.exp_string("Transaction is valid.")?;
     client.assert_success();
 
@@ -785,7 +785,7 @@ fn ledger_many_txs_in_a_block() -> Result<()> {
 
     // 1. Run the ledger node
     let mut ledger =
-        run_as!(*test, Who::Validator(0), Bin::Node, &["ledger"], Some(20))?;
+        run_as!(*test, Who::Validator(0), Bin::Node, &["ledger"], Some(40))?;
 
     ledger.exp_string("Anoma ledger node started")?;
     if !cfg!(feature = "ABCI") {
@@ -825,7 +825,7 @@ fn ledger_many_txs_in_a_block() -> Result<()> {
             let test = Arc::clone(&test);
             let tx_args = Arc::clone(&tx_args);
             std::thread::spawn(move || {
-                let mut client = run!(*test, Bin::Client, &*tx_args, Some(30))?;
+                let mut client = run!(*test, Bin::Client, &*tx_args, Some(40))?;
                 if !cfg!(feature = "ABCI") {
                     client.exp_string("Transaction accepted")?;
                 }


### PR DESCRIPTION
closes #711 

I've also modified the `make clippy(-abci-plus-plus)` recipes to explicitly set `ANOMA_DEV=false`, so that if you enable it in your shell, you can still run clippy on the same build that the CI uses.

This is a semi-breaking change from v0.3.0. Syncing an existing chain from scratch will work, but loading a state written by v0.3.0 will not work.