### PR TITLE
Don't package wasm/checksums.json

### DIFF
--- a/.changelog/unreleased/miscellaneous/731-dont-package-wasm.md
+++ b/.changelog/unreleased/miscellaneous/731-dont-package-wasm.md
@@ -1,0 +1,2 @@
+- Don't include wasm checksums in the package, since the network configuration
+  mechanisms now handle this. ([#731](https://github.com/anoma/anoma/pull/731))

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,9 @@ check-release:
 	$(cargo) check --release --package anoma_apps
 
 package: build-release
-	mkdir -p $(package-name)/wasm && \
+	mkdir -p $(package-name) && \
 	cd target/release && ln $(bin) ../../$(package-name) && \
 	cd ../.. && \
-	ln wasm/checksums.json $(package-name)/wasm && \
 	tar -c -z -f $(package-name).tar.gz $(package-name) && \
 	rm -rf $(package-name)
 


### PR DESCRIPTION
Avoid packaging wasm/checksums.json, because this is handled by
join-network and related functionality. It is the responsibility of
init-network users to know what wasm hashes they want to include in
their genesis.