### PR TITLE
apps: include `git describe` version string

### DIFF
--- a/.changelog/unreleased/improvements/733-git-describe-version.md
+++ b/.changelog/unreleased/improvements/733-git-describe-version.md
@@ -1,0 +1,2 @@
+- Include a more accurate build version from git describe in help output version
+  strings. ([#733](https://github.com/anoma/anoma/pull/733))

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ anoma-*.tar.gz
 
 # wasm artifacts
 wasm/*.wasm
+
+# app version string file
+apps/version.rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,7 @@ dependencies = [
  "eyre",
  "flate2",
  "futures 0.3.18",
+ "git2",
  "hex",
  "itertools 0.10.1",
  "jsonpath_lib",
@@ -2176,6 +2177,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
+name = "git2"
+version = "0.13.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log 0.4.14",
+ "openssl-probe",
+ "openssl-sys",
+ "url 2.2.2",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2903,6 +2919,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.12.26+1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3385,12 +3415,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "libssh2-sys"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
 dependencies = [
  "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -146,4 +146,5 @@ tempfile = "3.2.0"
 tokio-test = "0.4.2"
 
 [build-dependencies]
+git2 = "0.13.25"
 tonic-build = "0.6.0"

--- a/apps/build.rs
+++ b/apps/build.rs
@@ -1,6 +1,9 @@
-use std::fs::read_to_string;
+use std::fs::{read_to_string, File};
+use std::io::Write;
 use std::process::Command;
 use std::{env, str};
+
+use git2::{DescribeFormatOptions, DescribeOptions, Repository};
 
 /// Path to the .proto source files, relative to `apps` directory
 const PROTO_SRC: &str = "./proto";
@@ -13,6 +16,50 @@ fn main() {
     compile_error!(
         "`ABCI` and `ABCI-plus-plus` may not be used at the same time"
     );
+
+    // Discover the repository version, if it exists
+    println!("cargo:rerun-if-changed=../.git");
+    let describe_opts = DescribeOptions::new();
+    let mut describe_format = DescribeFormatOptions::new();
+    describe_format.dirty_suffix("-dirty");
+    let repo = Repository::discover(".").ok();
+    let describe = match &repo {
+        Some(repo) => repo.describe(&describe_opts).ok(),
+        None => None,
+    };
+    let version_string = match describe {
+        Some(describe) => describe.format(Some(&describe_format)).ok(),
+        None => None,
+    };
+    let mut version_rs =
+        File::create("./version.rs").expect("cannot write version");
+    let pre = "pub fn anoma_version() -> &'static str { \"";
+    let post = "\" }";
+    let _result = match version_string {
+        Some(version_string) => {
+            version_rs
+                .write_all(pre.as_bytes())
+                .expect("cannot write version");
+            version_rs
+                .write_all(version_string.as_bytes())
+                .expect("cannot write version");
+            version_rs
+                .write_all(post.as_bytes())
+                .expect("cannot write version");
+        }
+        None => {
+            version_rs
+                .write_all(pre.as_bytes())
+                .expect("cannot write version");
+            version_rs
+                .write_all(env!("CARGO_PKG_VERSION").as_bytes())
+                .expect("cannot write version");
+            version_rs
+                .write_all(post.as_bytes())
+                .expect("cannot write version");
+        }
+    };
+
     // Tell Cargo that if the given file changes, to rerun this build script.
     println!("cargo:rerun-if-changed={}", PROTO_SRC);
 

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -9,11 +9,13 @@
 pub mod context;
 mod utils;
 
-use clap::{crate_authors, crate_version, AppSettings, ArgMatches};
+use clap::{crate_authors, AppSettings, ArgMatches};
 pub use utils::safe_exit;
 use utils::*;
 
 pub use self::context::Context;
+
+include!("../../version.rs");
 
 const APP_NAME: &str = "Anoma";
 
@@ -2457,7 +2459,7 @@ pub fn anoma_wallet_cli() -> (cmds::AnomaWallet, Context) {
 
 fn anoma_app() -> App {
     let app = App::new(APP_NAME)
-        .version(crate_version!())
+        .version(anoma_version())
         .author(crate_authors!("\n"))
         .about("Anoma command line interface.")
         .setting(AppSettings::SubcommandRequiredElseHelp);
@@ -2466,7 +2468,7 @@ fn anoma_app() -> App {
 
 fn anoma_node_app() -> App {
     let app = App::new(APP_NAME)
-        .version(crate_version!())
+        .version(anoma_version())
         .author(crate_authors!("\n"))
         .about("Anoma node command line interface.")
         .setting(AppSettings::SubcommandRequiredElseHelp);
@@ -2475,7 +2477,7 @@ fn anoma_node_app() -> App {
 
 fn anoma_client_app() -> App {
     let app = App::new(APP_NAME)
-        .version(crate_version!())
+        .version(anoma_version())
         .author(crate_authors!("\n"))
         .about("Anoma client command line interface.")
         .setting(AppSettings::SubcommandRequiredElseHelp);
@@ -2484,7 +2486,7 @@ fn anoma_client_app() -> App {
 
 fn anoma_wallet_app() -> App {
     let app = App::new(APP_NAME)
-        .version(crate_version!())
+        .version(anoma_version())
         .author(crate_authors!("\n"))
         .about("Anoma wallet command line interface.")
         .setting(AppSettings::SubcommandRequiredElseHelp);


### PR DESCRIPTION
Include a version string from `git describe` to use in --version
output, falling back on the crate version if no git repository is
found.

This doesn't actually work, because Cargo is bad and there's no way to force build.rs to rerun. Forcing it to rerun on .git changes might seem to work, but it doesn't - we may be in a worktree and .git may be a file pointing to the main repository. Better approaches welcome.