### PR TITLE
docs/user-guide: update the testnet's chain ID (v0.3.0)

### DIFF
--- a/v0.3.0/user-guide/getting-started.html
+++ b/v0.3.0/user-guide/getting-started.html
@@ -161,7 +161,7 @@
 </ul>
 <p>To explore the command-line interface, add <code>--help</code> argument at any sub-command level to find out any possible sub-commands and/or arguments.</p>
 <p>To configure your node to join the Feigenbaum public testnet, run:</p>
-<pre><code class="language-bash">anoma client utils join-network --chain-id=anoma-feigenbaum-0.ebb9e9f9013
+<pre><code class="language-bash">anoma client utils join-network --chain-id=anoma-testnet-0.0.a1d4bbfafa49
 </code></pre>
 
                     </main>


### PR DESCRIPTION
manually backported from #766