### PR TITLE
Murisi/tx result extraction

### DIFF
--- a/.changelog/unreleased/features/634-tx-result-extraction.md
+++ b/.changelog/unreleased/features/634-tx-result-extraction.md
@@ -1,0 +1,2 @@
+- Add `anomac tx-result` command to query the result of a transaction given a
+  transaction hash. ([#634](https://github.com/anoma/anoma/issues/634))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5660,7 +5660,7 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.23.0"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#a072e7da5acf4196febf8229cb20b5235aefcbf2"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#203fa2a7aac917d8b548bb1cb2d3c774ce090891"
 dependencies = [
  "async-trait",
  "bytes 1.1.0",
@@ -5716,7 +5716,7 @@ dependencies = [
 [[package]]
 name = "tendermint-config"
 version = "0.23.0"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#a072e7da5acf4196febf8229cb20b5235aefcbf2"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#203fa2a7aac917d8b548bb1cb2d3c774ce090891"
 dependencies = [
  "flex-error",
  "serde 1.0.130",
@@ -5742,7 +5742,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client"
 version = "0.23.0"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#a072e7da5acf4196febf8229cb20b5235aefcbf2"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#203fa2a7aac917d8b548bb1cb2d3c774ce090891"
 dependencies = [
  "chrono",
  "contracts",
@@ -5780,7 +5780,7 @@ dependencies = [
 [[package]]
 name = "tendermint-proto"
 version = "0.23.0"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#a072e7da5acf4196febf8229cb20b5235aefcbf2"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#203fa2a7aac917d8b548bb1cb2d3c774ce090891"
 dependencies = [
  "bytes 1.1.0",
  "chrono",
@@ -5814,7 +5814,7 @@ dependencies = [
 [[package]]
 name = "tendermint-rpc"
 version = "0.23.0"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#a072e7da5acf4196febf8229cb20b5235aefcbf2"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#203fa2a7aac917d8b548bb1cb2d3c774ce090891"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -5880,7 +5880,7 @@ dependencies = [
 [[package]]
 name = "tendermint-testgen"
 version = "0.23.0"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#a072e7da5acf4196febf8229cb20b5235aefcbf2"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#203fa2a7aac917d8b548bb1cb2d3c774ce090891"
 dependencies = [
  "chrono",
  "ed25519-dalek",

--- a/apps/src/bin/anoma-client/cli.rs
+++ b/apps/src/bin/anoma-client/cli.rs
@@ -18,9 +18,6 @@ pub async fn main() -> Result<()> {
                 Sub::TxTransfer(TxTransfer(args)) => {
                     tx::submit_transfer(ctx, args).await;
                 }
-                Sub::TxResult(TxResult(args)) => {
-                    tx::lookup_result(ctx, args).await;
-                }
                 Sub::TxUpdateVp(TxUpdateVp(args)) => {
                     tx::submit_update_vp(ctx, args).await;
                 }
@@ -54,6 +51,9 @@ pub async fn main() -> Result<()> {
                 }
                 Sub::QuerySlashes(QuerySlashes(args)) => {
                     rpc::query_slashes(ctx, args).await;
+                }
+                Sub::QueryResult(QueryResult(args)) => {
+                    rpc::query_result(ctx, args).await;
                 }
                 // Gossip cmds
                 Sub::Intent(Intent(args)) => {

--- a/apps/src/bin/anoma-client/cli.rs
+++ b/apps/src/bin/anoma-client/cli.rs
@@ -18,6 +18,9 @@ pub async fn main() -> Result<()> {
                 Sub::TxTransfer(TxTransfer(args)) => {
                     tx::submit_transfer(ctx, args).await;
                 }
+                Sub::TxResult(TxResult(args)) => {
+                    tx::lookup_result(ctx, args).await;
+                }
                 Sub::TxUpdateVp(TxUpdateVp(args)) => {
                     tx::submit_update_vp(ctx, args).await;
                 }

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -142,7 +142,6 @@ pub mod cmds {
                 .subcommand(TxUpdateVp::def().display_order(1))
                 .subcommand(TxInitAccount::def().display_order(1))
                 .subcommand(TxInitValidator::def().display_order(1))
-                .subcommand(TxResult::def().display_order(1))
                 // PoS transactions
                 .subcommand(Bond::def().display_order(2))
                 .subcommand(Unbond::def().display_order(2))
@@ -153,6 +152,7 @@ pub mod cmds {
                 .subcommand(QueryBonds::def().display_order(3))
                 .subcommand(QueryVotingPower::def().display_order(3))
                 .subcommand(QuerySlashes::def().display_order(3))
+                .subcommand(QueryResult::def().display_order(3))
                 // Intents
                 .subcommand(Intent::def().display_order(4))
                 .subcommand(SubscribeTopic::def().display_order(4))
@@ -166,7 +166,6 @@ pub mod cmds {
             let tx_transfer = Self::parse_with_ctx(matches, TxTransfer);
             let tx_update_vp = Self::parse_with_ctx(matches, TxUpdateVp);
             let tx_init_account = Self::parse_with_ctx(matches, TxInitAccount);
-            let tx_result = Self::parse_with_ctx(matches, TxResult);
             let tx_init_validator =
                 Self::parse_with_ctx(matches, TxInitValidator);
             let bond = Self::parse_with_ctx(matches, Bond);
@@ -178,6 +177,7 @@ pub mod cmds {
             let query_voting_power =
                 Self::parse_with_ctx(matches, QueryVotingPower);
             let query_slashes = Self::parse_with_ctx(matches, QuerySlashes);
+            let query_result = Self::parse_with_ctx(matches, QueryResult);
             let intent = Self::parse_with_ctx(matches, Intent);
             let subscribe_topic = Self::parse_with_ctx(matches, SubscribeTopic);
             let utils = SubCmd::parse(matches).map(Self::WithoutContext);
@@ -186,7 +186,6 @@ pub mod cmds {
                 .or(tx_update_vp)
                 .or(tx_init_account)
                 .or(tx_init_validator)
-                .or(tx_result)
                 .or(bond)
                 .or(unbond)
                 .or(withdraw)
@@ -195,6 +194,7 @@ pub mod cmds {
                 .or(query_bonds)
                 .or(query_voting_power)
                 .or(query_slashes)
+                .or(query_result)
                 .or(intent)
                 .or(subscribe_topic)
                 .or(utils)
@@ -235,7 +235,7 @@ pub mod cmds {
         // Ledger cmds
         TxCustom(TxCustom),
         TxTransfer(TxTransfer),
-        TxResult(TxResult),
+        QueryResult(QueryResult),
         TxUpdateVp(TxUpdateVp),
         TxInitAccount(TxInitAccount),
         TxInitValidator(TxInitValidator),
@@ -678,21 +678,21 @@ pub mod cmds {
     }
 
     #[derive(Clone, Debug)]
-    pub struct TxResult(pub args::TxResult);
+    pub struct QueryResult(pub args::QueryResult);
 
-    impl SubCmd for TxResult {
+    impl SubCmd for QueryResult {
         const CMD: &'static str = "tx-result";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
             matches
                 .subcommand_matches(Self::CMD)
-                .map(|matches| TxResult(args::TxResult::parse(matches)))
+                .map(|matches| QueryResult(args::QueryResult::parse(matches)))
         }
 
         fn def() -> App {
             App::new(Self::CMD)
                 .about("Query the result of a transaction.")
-                .add_args::<args::TxResult>()
+                .add_args::<args::QueryResult>()
         }
     }
 
@@ -1261,14 +1261,14 @@ pub mod args {
 
     /// Transaction associated results arguments
     #[derive(Clone, Debug)]
-    pub struct TxResult {
+    pub struct QueryResult {
         /// Common query args
         pub query: Query,
         /// Hash of transaction to lookup
         pub tx_hash: String,
     }
 
-    impl Args for TxResult {
+    impl Args for QueryResult {
         fn parse(matches: &ArgMatches) -> Self {
             let query = Query::parse(matches);
             let tx_hash = TX_HASH.parse(matches);

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -691,7 +691,7 @@ pub mod cmds {
 
         fn def() -> App {
             App::new(Self::CMD)
-                .about("Get the result associated with a transaction.")
+                .about("Query the result of a transaction.")
                 .add_args::<args::TxResult>()
         }
     }

--- a/apps/src/lib/client/rpc.rs
+++ b/apps/src/lib/client/rpc.rs
@@ -23,32 +23,27 @@ use tendermint_config::net::Address as TendermintAddress;
 #[cfg(feature = "ABCI")]
 use tendermint_config_abci::net::Address as TendermintAddress;
 #[cfg(not(feature = "ABCI"))]
-use tendermint_rpc::{Client, HttpClient};
-#[cfg(feature = "ABCI")]
-use tendermint_rpc_abci::{Client, HttpClient};
-#[cfg(feature = "ABCI")]
-use tendermint_stable::abci::Code;
-
-#[cfg(not(feature = "ABCI"))]
 use tendermint_rpc::error::Error as TError;
 #[cfg(not(feature = "ABCI"))]
 use tendermint_rpc::query::Query;
 #[cfg(not(feature = "ABCI"))]
-use tendermint_rpc::{
-    Order, SubscriptionClient, WebSocketClient,
-};
+use tendermint_rpc::{Client, HttpClient};
+#[cfg(not(feature = "ABCI"))]
+use tendermint_rpc::{Order, SubscriptionClient, WebSocketClient};
 #[cfg(feature = "ABCI")]
 use tendermint_rpc_abci::error::Error as TError;
 #[cfg(feature = "ABCI")]
 use tendermint_rpc_abci::query::Query;
 #[cfg(feature = "ABCI")]
-use tendermint_rpc_abci::{
-    Order, SubscriptionClient, WebSocketClient,
-};
+use tendermint_rpc_abci::{Client, HttpClient};
+#[cfg(feature = "ABCI")]
+use tendermint_rpc_abci::{Order, SubscriptionClient, WebSocketClient};
+#[cfg(feature = "ABCI")]
+use tendermint_stable::abci::Code;
 
 use crate::cli::{self, args, Context};
-use crate::node::ledger::rpc::{Path, PrefixValue};
 use crate::client::tx::TxResponse;
+use crate::node::ledger::rpc::{Path, PrefixValue};
 
 /// Query the epoch of the last committed block
 pub async fn query_epoch(args: args::Query) -> Epoch {
@@ -1132,8 +1127,10 @@ pub async fn query_result(_ctx: Context, args: args::QueryResult) {
     .await;
     match tx_response {
         Ok(result) => {
-            println!("Transaction was applied with result: {}",
-                     serde_json::to_string_pretty(&result).unwrap())
+            println!(
+                "Transaction was applied with result: {}",
+                serde_json::to_string_pretty(&result).unwrap()
+            )
         }
         Err(err1) => {
             // If this fails then instead look for an acceptance event.

--- a/apps/src/lib/client/rpc.rs
+++ b/apps/src/lib/client/rpc.rs
@@ -29,8 +29,26 @@ use tendermint_rpc_abci::{Client, HttpClient};
 #[cfg(feature = "ABCI")]
 use tendermint_stable::abci::Code;
 
+#[cfg(not(feature = "ABCI"))]
+use tendermint_rpc::error::Error as TError;
+#[cfg(not(feature = "ABCI"))]
+use tendermint_rpc::query::Query;
+#[cfg(not(feature = "ABCI"))]
+use tendermint_rpc::{
+    Order, SubscriptionClient, WebSocketClient,
+};
+#[cfg(feature = "ABCI")]
+use tendermint_rpc_abci::error::Error as TError;
+#[cfg(feature = "ABCI")]
+use tendermint_rpc_abci::query::Query;
+#[cfg(feature = "ABCI")]
+use tendermint_rpc_abci::{
+    Order, SubscriptionClient, WebSocketClient,
+};
+
 use crate::cli::{self, args, Context};
 use crate::node::ledger::rpc::{Path, PrefixValue};
+use crate::client::tx::TxResponse;
 
 /// Query the epoch of the last committed block
 pub async fn query_epoch(args: args::Query) -> Epoch {
@@ -979,4 +997,162 @@ pub async fn query_has_storage_key(
         }
     }
     cli::safe_exit(1)
+}
+
+/// Represents a query for an event pertaining to the specified transaction
+
+#[derive(Debug, Clone)]
+pub enum TxEventQuery {
+    Accepted(String),
+    Applied(String),
+}
+
+impl TxEventQuery {
+    /// The event type to which this event query pertains
+    fn event_type(&self) -> &'static str {
+        match self {
+            TxEventQuery::Accepted(_tx_hash) => "accepted",
+            TxEventQuery::Applied(_tx_hash) => "applied",
+        }
+    }
+
+    /// The transaction to which this event query pertains
+    fn tx_hash(&self) -> &String {
+        match self {
+            TxEventQuery::Accepted(tx_hash) => tx_hash,
+            TxEventQuery::Applied(tx_hash) => tx_hash,
+        }
+    }
+}
+
+/// Transaction event queries are semantically a subset of general queries
+
+impl From<TxEventQuery> for Query {
+    fn from(tx_query: TxEventQuery) -> Self {
+        match tx_query {
+            TxEventQuery::Accepted(tx_hash) => {
+                Query::default().and_eq("accepted.hash", tx_hash)
+            }
+            TxEventQuery::Applied(tx_hash) => {
+                Query::default().and_eq("applied.hash", tx_hash)
+            }
+        }
+    }
+}
+
+/// Lookup the full response accompanying the specified transaction event
+
+pub async fn query_tx_response(
+    ledger_address: &TendermintAddress,
+    tx_query: TxEventQuery,
+) -> Result<TxResponse, TError> {
+    // Connect to the Tendermint server holding the transactions
+    let (client, driver) = WebSocketClient::new(ledger_address.clone()).await?;
+    let driver_handle = tokio::spawn(async move { driver.run().await });
+    // Find all blocks that apply a transaction with the specified hash
+    let blocks = &client
+        .block_search(Query::from(tx_query.clone()), 1, 255, Order::Ascending)
+        .await
+        .expect("Unable to query for transaction with given hash")
+        .blocks;
+    // Get the block results corresponding to a block to which
+    // the specified transaction belongs
+    let block = &blocks
+        .get(0)
+        .ok_or_else(|| {
+            TError::server(
+                "Unable to find a block applying the given transaction"
+                    .to_string(),
+            )
+        })?
+        .block;
+    let response_block_results = client
+        .block_results(block.header.height)
+        .await
+        .expect("Unable to retrieve block containing transaction");
+    // Search for the event where the specified transaction is
+    // applied to the blockchain
+    let query_event_opt =
+        response_block_results.end_block_events.and_then(|events| {
+            (&events)
+                .iter()
+                .find(|event| {
+                    event.type_str == tx_query.event_type()
+                        && (&event.attributes).iter().any(|tag| {
+                            tag.key.as_ref() == "hash"
+                                && tag.value.as_ref() == tx_query.tx_hash()
+                        })
+                })
+                .cloned()
+        });
+    let query_event = query_event_opt.ok_or_else(|| {
+        TError::server(
+            "Unable to find the event corresponding to the specified \
+             transaction"
+                .to_string(),
+        )
+    })?;
+    // Reformat the event attributes so as to ease value extraction
+    let event_map: std::collections::HashMap<&str, &str> = (&query_event
+        .attributes)
+        .iter()
+        .map(|tag| (tag.key.as_ref(), tag.value.as_ref()))
+        .collect();
+    // Summarize the transaction results that we were searching for
+    let result = TxResponse {
+        info: event_map["info"].to_string(),
+        height: event_map["height"].to_string(),
+        hash: event_map["hash"].to_string(),
+        code: event_map["code"].to_string(),
+        gas_used: event_map["gas_used"].to_string(),
+        initialized_accounts: serde_json::from_str(
+            event_map["initialized_accounts"],
+        )
+        .unwrap_or_default(),
+    };
+    // Signal to the driver to terminate.
+    client.close()?;
+    // Await the driver's termination to ensure proper connection closure.
+    let _ = driver_handle.await.unwrap_or_else(|x| {
+        eprintln!("{}", x);
+        cli::safe_exit(1)
+    });
+    Ok(result)
+}
+
+/// Lookup the results of applying the specified transaction to the
+/// blockchain.
+
+pub async fn query_result(_ctx: Context, args: args::QueryResult) {
+    // First try looking up application event pertaining to given hash.
+    let tx_response = query_tx_response(
+        &args.query.ledger_address,
+        TxEventQuery::Applied(args.tx_hash.clone()),
+    )
+    .await;
+    match tx_response {
+        Ok(result) => {
+            println!("Transaction was applied with result: {}",
+                     serde_json::to_string_pretty(&result).unwrap())
+        }
+        Err(err1) => {
+            // If this fails then instead look for an acceptance event.
+            let tx_response = query_tx_response(
+                &args.query.ledger_address,
+                TxEventQuery::Accepted(args.tx_hash),
+            )
+            .await;
+            match tx_response {
+                Ok(result) => println!(
+                    "Transaction was accepted with result: {}",
+                    serde_json::to_string_pretty(&result).unwrap()
+                ),
+                Err(err2) => {
+                    // Print the errors that caused the lookups to fail
+                    eprintln!("{}\n{}", err1, err2);
+                    cli::safe_exit(1)
+                }
+            }
+        }
+    }
 }

--- a/apps/src/lib/client/tx.rs
+++ b/apps/src/lib/client/tx.rs
@@ -19,20 +19,16 @@ use tendermint_config::net::Address as TendermintAddress;
 #[cfg(feature = "ABCI")]
 use tendermint_config_abci::net::Address as TendermintAddress;
 #[cfg(not(feature = "ABCI"))]
-use tendermint_rpc::error::Error as TError;
-#[cfg(not(feature = "ABCI"))]
 use tendermint_rpc::query::{EventType, Query};
 #[cfg(not(feature = "ABCI"))]
 use tendermint_rpc::{
-    Client, HttpClient, Order, SubscriptionClient, WebSocketClient,
+    Client, HttpClient,
 };
-#[cfg(feature = "ABCI")]
-use tendermint_rpc_abci::error::Error as TError;
 #[cfg(feature = "ABCI")]
 use tendermint_rpc_abci::query::{EventType, Query};
 #[cfg(feature = "ABCI")]
 use tendermint_rpc_abci::{
-    Client, HttpClient, Order, SubscriptionClient, WebSocketClient,
+    Client, HttpClient,
 };
 
 use super::{rpc, signing};
@@ -341,163 +337,6 @@ pub async fn submit_init_validator(
         );
     } else {
         println!("Transaction dry run. No addresses have been saved.")
-    }
-}
-
-/// Represents a query for an event pertaining to the specified transaction
-
-#[derive(Debug, Clone)]
-pub enum TxEventQuery {
-    Accepted(String),
-    Applied(String),
-}
-
-impl TxEventQuery {
-    /// The event type to which this event query pertains
-    fn event_type(&self) -> &'static str {
-        match self {
-            TxEventQuery::Accepted(_tx_hash) => "accepted",
-            TxEventQuery::Applied(_tx_hash) => "applied",
-        }
-    }
-
-    /// The transaction to which this event query pertains
-    fn tx_hash(&self) -> &String {
-        match self {
-            TxEventQuery::Accepted(tx_hash) => tx_hash,
-            TxEventQuery::Applied(tx_hash) => tx_hash,
-        }
-    }
-}
-
-/// Transaction event queries are semantically a subset of general queries
-
-impl From<TxEventQuery> for Query {
-    fn from(tx_query: TxEventQuery) -> Self {
-        match tx_query {
-            TxEventQuery::Accepted(tx_hash) => {
-                Query::default().and_eq("accepted.hash", tx_hash)
-            }
-            TxEventQuery::Applied(tx_hash) => {
-                Query::default().and_eq("applied.hash", tx_hash)
-            }
-        }
-    }
-}
-
-/// Lookup the full response accompanying the specified transaction event
-
-pub async fn lookup_tx_response(
-    ledger_address: &TendermintAddress,
-    tx_query: TxEventQuery,
-) -> Result<TxResponse, TError> {
-    // Connect to the Tendermint server holding the transactions
-    let (client, driver) = WebSocketClient::new(ledger_address.clone()).await?;
-    let driver_handle = tokio::spawn(async move { driver.run().await });
-    // Find all blocks that apply a transaction with the specified hash
-    let blocks = &client
-        .block_search(Query::from(tx_query.clone()), 1, 255, Order::Ascending)
-        .await
-        .expect("Unable to query for transaction with given hash")
-        .blocks;
-    // Get the block results corresponding to a block to which
-    // the specified transaction belongs
-    let block = &blocks
-        .get(0)
-        .ok_or_else(|| {
-            TError::server(
-                "Unable to find a block applying the given transaction"
-                    .to_string(),
-            )
-        })?
-        .block;
-    let response_block_results = client
-        .block_results(block.header.height)
-        .await
-        .expect("Unable to retrieve block containing transaction");
-    // Search for the event where the specified transaction is
-    // applied to the blockchain
-    let query_event_opt =
-        response_block_results.end_block_events.and_then(|events| {
-            (&events)
-                .iter()
-                .find(|event| {
-                    event.type_str == tx_query.event_type()
-                        && (&event.attributes).iter().any(|tag| {
-                            tag.key.as_ref() == "hash"
-                                && tag.value.as_ref() == tx_query.tx_hash()
-                        })
-                })
-                .cloned()
-        });
-    let query_event = query_event_opt.ok_or_else(|| {
-        TError::server(
-            "Unable to find the event corresponding to the specified \
-             transaction"
-                .to_string(),
-        )
-    })?;
-    // Reformat the event attributes so as to ease value extraction
-    let event_map: std::collections::HashMap<&str, &str> = (&query_event
-        .attributes)
-        .iter()
-        .map(|tag| (tag.key.as_ref(), tag.value.as_ref()))
-        .collect();
-    // Summarize the transaction results that we were searching for
-    let result = TxResponse {
-        info: event_map["info"].to_string(),
-        height: event_map["height"].to_string(),
-        hash: event_map["hash"].to_string(),
-        code: event_map["code"].to_string(),
-        gas_used: event_map["gas_used"].to_string(),
-        initialized_accounts: serde_json::from_str(
-            event_map["initialized_accounts"],
-        )
-        .unwrap_or_default(),
-    };
-    // Signal to the driver to terminate.
-    client.close()?;
-    // Await the driver's termination to ensure proper connection closure.
-    let _ = driver_handle.await.unwrap_or_else(|x| {
-        eprintln!("{}", x);
-        safe_exit(1)
-    });
-    Ok(result)
-}
-
-/// Lookup the results of applying the specified transaction to the
-/// blockchain.
-
-pub async fn lookup_result(_ctx: Context, args: args::TxResult) {
-    // First try looking up application event pertaining to given hash.
-    let tx_response = lookup_tx_response(
-        &args.query.ledger_address,
-        TxEventQuery::Applied(args.tx_hash.clone()),
-    )
-    .await;
-    match tx_response {
-        Ok(result) => {
-            println!("Transaction was applied with result: {:?}", result)
-        }
-        Err(err1) => {
-            // If this fails then instead look for an acceptance event.
-            let tx_response = lookup_tx_response(
-                &args.query.ledger_address,
-                TxEventQuery::Accepted(args.tx_hash),
-            )
-            .await;
-            match tx_response {
-                Ok(result) => println!(
-                    "Transaction was accepted with result: {:?}",
-                    result
-                ),
-                Err(err2) => {
-                    // Print the errors that caused the lookups to fail
-                    eprintln!("{}\n{}", err1, err2);
-                    safe_exit(1)
-                }
-            }
-        }
     }
 }
 
@@ -1058,12 +897,12 @@ pub async fn broadcast_tx(
 
 #[derive(Debug, Serialize)]
 pub struct TxResponse {
-    info: String,
-    height: String,
-    hash: String,
-    code: String,
-    gas_used: String,
-    initialized_accounts: Vec<Address>,
+    pub info: String,
+    pub height: String,
+    pub hash: String,
+    pub code: String,
+    pub gas_used: String,
+    pub initialized_accounts: Vec<Address>,
 }
 
 /// Parse the JSON payload received from a subscription

--- a/apps/src/lib/client/tx.rs
+++ b/apps/src/lib/client/tx.rs
@@ -21,15 +21,11 @@ use tendermint_config_abci::net::Address as TendermintAddress;
 #[cfg(not(feature = "ABCI"))]
 use tendermint_rpc::query::{EventType, Query};
 #[cfg(not(feature = "ABCI"))]
-use tendermint_rpc::{
-    Client, HttpClient,
-};
+use tendermint_rpc::{Client, HttpClient};
 #[cfg(feature = "ABCI")]
 use tendermint_rpc_abci::query::{EventType, Query};
 #[cfg(feature = "ABCI")]
-use tendermint_rpc_abci::{
-    Client, HttpClient,
-};
+use tendermint_rpc_abci::{Client, HttpClient};
 
 use super::{rpc, signing};
 use crate::cli::context::WalletAddress;


### PR DESCRIPTION
An attempt to resolve issue #634 . An implementation of a command line option `tx-result` to extract the results of a transaction from its hash. More precisely a transaction result comprises its `info`, `height`, `hash`, `code`, `gas_used`, and `initialized_accounts`. Note also that the hash can either be an application or an acceptance hash.

The following changes were made:
* Add CLI option `tx-result` to allow user to request result
* Made function that uses ABCI/++ query mechanisms to extract results
* A correction to `find_tx` to prevent it from crashing on ABCI++

Note that currently for this patch to work with ABCI++, heliaxdev/tendermint-rs#2 needs to be applied to `tendermint-rs`.