### PR TITLE
More flexible ledger/intent gossip configuration

### DIFF
--- a/.changelog/unreleased/improvements/774-774.md
+++ b/.changelog/unreleased/improvements/774-774.md
@@ -1,0 +1,4 @@
+- Config: Enable setting config values via environment variables, add
+  variables for configuring Tendermint instrumentation and allow missing
+  values in the config file (filled in with defaults defined in the code)
+  ([#774](https://github.com/anoma/anoma/pull/774))

--- a/apps/src/lib/config/mod.rs
+++ b/apps/src/lib/config/mod.rs
@@ -116,6 +116,9 @@ pub struct Tendermint {
     /// height
     pub consensus_timeout_commit: Timeout,
     pub tendermint_mode: TendermintMode,
+    pub instrumentation_prometheus: bool,
+    pub instrumentation_prometheus_listen_addr: SocketAddr,
+    pub instrumentation_namespace: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -163,6 +166,12 @@ impl Ledger {
                 p2p_allow_duplicate_ip: false,
                 consensus_timeout_commit: Timeout::from_str("1s").unwrap(),
                 tendermint_mode: mode,
+                instrumentation_prometheus: false,
+                instrumentation_prometheus_listen_addr: SocketAddr::new(
+                    IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                    26661,
+                ),
+                instrumentation_namespace: "anoman_tm".to_string(),
             },
         }
     }

--- a/apps/src/lib/config/mod.rs
+++ b/apps/src/lib/config/mod.rs
@@ -339,6 +339,7 @@ impl Config {
         config
             .merge(defaults)
             .and_then(|c| c.merge(config::File::with_name(file_name)))
+            .and_then(|c| c.merge(config::Environment::with_prefix("anoma").separator("__")))
             .map_err(Error::ReadError)?;
         config.try_into().map_err(Error::DeserializationError)
     }

--- a/apps/src/lib/config/mod.rs
+++ b/apps/src/lib/config/mod.rs
@@ -339,7 +339,11 @@ impl Config {
         config
             .merge(defaults)
             .and_then(|c| c.merge(config::File::with_name(file_name)))
-            .and_then(|c| c.merge(config::Environment::with_prefix("anoma").separator("__")))
+            .and_then(|c| {
+                c.merge(
+                    config::Environment::with_prefix("anoma").separator("__"),
+                )
+            })
             .map_err(Error::ReadError)?;
         config.try_into().map_err(Error::DeserializationError)
     }

--- a/apps/src/lib/node/ledger/tendermint_node.rs
+++ b/apps/src/lib/node/ledger/tendermint_node.rs
@@ -350,6 +350,14 @@ async fn update_tendermint_config(
     // quite large
     config.rpc.max_body_bytes = 2_000_000;
 
+    config.instrumentation.prometheus =
+        tendermint_config.instrumentation_prometheus;
+    config.instrumentation.prometheus_listen_addr = tendermint_config
+        .instrumentation_prometheus_listen_addr
+        .to_string();
+    config.instrumentation.namespace =
+        tendermint_config.instrumentation_namespace;
+
     let mut file = OpenOptions::new()
         .write(true)
         .truncate(true)

--- a/docs/src/user-guide/ledger.md
+++ b/docs/src/user-guide/ledger.md
@@ -6,13 +6,25 @@ To start a local Anoma ledger node, run:
 anoma ledger
 ```
 
+Note that you need to have [joined a network](./getting-started.md) before you start the ledger. It throws an error if no network has been configured.
+
 The node will attempt to connect to the persistent validator nodes and other peers in the network, and synchronize to the latest block.
 
 By default, the ledger will store its configuration and state in the `.anoma` directory relative to the current working directory. You can use the `--base-dir` CLI global argument or `ANOMA_BASE_DIR` environment variable to change it.
 
-If not found on start up, the ledger will generate a configuration file at `.anoma/config.toml`.
-
 The ledger also needs access to the built WASM files that are used in the genesis block. These files are included in release and shouldn't be modified, otherwise your node will fail with a consensus error on the genesis block. By default, these are expected to be in the `wasm` directory, relative to the current working directory. This can also be set with the `--wasm-dir` CLI global argument, `ANOMA_WASM_DIR` environment variable or the configuration file.
+
+The ledger configuration is stored in `.anoma/{chain_id}/config.toml` (with
+default `--base-dir`). It is created when you join the network. You can modify
+that file to change the configuration of your node. All values can also be set
+via environment variables. Names of the recognized environment variables are
+derived from the configuration keys by: uppercase every letter of the key,
+insert `.` or `__` for each nested value and prepend `ANOMA_`. For example,
+option `p2p_pex` in `[ledger.tendermint]` can be set by
+`ANOMA_LEDGER__TENDERMINT__P2P_PEX=true|false` or
+`ANOMA_LEDGER.TENDERMINT.P2P_PEX=true|false` in the environment (Note: only the
+double underscore form can be used in Bash, because Bash doesn't allow dots in
+environment variable names).
 
 ## 📝 Initialize an account
 


### PR DESCRIPTION
Operations improvements, because I really don't enjoy patching TOML with sed all the time.

- Enable setting config values via environment variables
- Add variables for configuring Tendermint instrumentation
- Allow missing values in the config file (filled in with defaults defined in the code)