### PR TITLE
enabling intent gossiper p2p connections

### DIFF
--- a/.changelog/unreleased/improvements/775-775.md
+++ b/.changelog/unreleased/improvements/775-775.md
@@ -1,0 +1,3 @@
+- Gossip: Enable peer discovery with libp2p Kademlia and Identify
+  protocol and allow to keep the established peer connections open.
+  ([#775](https://github.com/anoma/anoma/pull/775))

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -258,7 +258,7 @@ pub fn init_network(
             &config.matchmaker_tx,
         ) {
             (Some(account), Some(mm_code), Some(tx_code)) => {
-                if config.intent_gossip_bootstrap.unwrap_or_default() {
+                if config.intent_gossip_seed.unwrap_or_default() {
                     eprintln!("A bootstrap node cannot run matchmakers");
                     cli::safe_exit(1)
                 }
@@ -310,7 +310,7 @@ pub fn init_network(
 
         // Store the gossip config
         gossiper_configs.insert(name.clone(), gossiper_config);
-        if config.intent_gossip_bootstrap.unwrap_or_default() {
+        if config.intent_gossip_seed.unwrap_or_default() {
             seed_peers.insert(intent_peer);
         }
 
@@ -319,9 +319,8 @@ pub fn init_network(
 
     if seed_peers.is_empty() && config.validator.len() > 1 {
         tracing::warn!(
-            "At least 1 validator with `intent_gossip_bootstrap = true` is \
-             needed to established connection between the intent gossiper \
-             nodes"
+            "At least 1 validator with `intent_gossip_seed = true` is needed \
+             to established connection between the intent gossiper nodes"
         );
     }
 

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -196,6 +196,10 @@ pub fn init_network(
             )
             .unwrap()
         };
+        if let Some(discover) = gossiper_config.discover_peer.as_mut() {
+            // Disable mDNS local network peer discovery on the validator nodes
+            discover.mdns = false;
+        }
         let intent_peer = PeerAddress {
             address: intent_peer_address,
             peer_id,

--- a/apps/src/lib/config/genesis.rs
+++ b/apps/src/lib/config/genesis.rs
@@ -137,10 +137,10 @@ pub mod genesis_config {
         pub matchmaker_code: Option<String>,
         /// Path to a transaction WASM code used by the matchmaker, if any
         pub matchmaker_tx: Option<String>,
-        /// Is this validator running a bootstrap intent gossip node? A
-        /// bootstrap node is not part of the gossipsub where intents are being
-        /// propagated and hence cannot run matchmakers
-        pub intent_gossip_bootstrap: Option<bool>,
+        /// Is this validator running a seed intent gossip node? A seed node is
+        /// not part of the gossipsub where intents are being propagated and
+        /// hence cannot run matchmakers
+        pub intent_gossip_seed: Option<bool>,
     }
 
     #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/apps/src/lib/config/genesis.rs
+++ b/apps/src/lib/config/genesis.rs
@@ -137,6 +137,10 @@ pub mod genesis_config {
         pub matchmaker_code: Option<String>,
         /// Path to a transaction WASM code used by the matchmaker, if any
         pub matchmaker_tx: Option<String>,
+        /// Is this validator running a bootstrap intent gossip node? A
+        /// bootstrap node is not part of the gossipsub where intents are being
+        /// propagated and hence cannot run matchmakers
+        pub intent_gossip_bootstrap: Option<bool>,
     }
 
     #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/apps/src/lib/config/mod.rs
+++ b/apps/src/lib/config/mod.rs
@@ -123,6 +123,7 @@ pub struct IntentGossiper {
     pub address: Multiaddr,
     pub topics: HashSet<String>,
     pub subscription_filter: SubscriptionFilter,
+    pub seed_peers: HashSet<PeerAddress>,
     pub rpc: Option<RpcServer>,
     pub discover_peer: Option<DiscoverPeer>,
     pub matchmaker: Option<Matchmaker>,
@@ -233,7 +234,6 @@ pub struct DiscoverPeer {
     pub max_discovery_peers: u64,
     pub kademlia: bool,
     pub mdns: bool,
-    pub bootstrap_peers: HashSet<PeerAddress>,
 }
 
 #[derive(Error, Debug)]
@@ -377,14 +377,14 @@ impl Default for IntentGossiper {
     fn default() -> Self {
         Self {
             address: Multiaddr::from_str("/ip4/0.0.0.0/tcp/26659").unwrap(),
-            rpc: None,
+            topics: vec!["asset_v0"].into_iter().map(String::from).collect(),
             subscription_filter: SubscriptionFilter::RegexFilter(
                 Regex::new("asset_v\\d{1,2}").unwrap(),
             ),
-
-            topics: vec!["asset_v0"].into_iter().map(String::from).collect(),
-            matchmaker: None,
+            seed_peers: HashSet::default(),
+            rpc: None,
             discover_peer: Some(DiscoverPeer::default()),
+            matchmaker: None,
         }
     }
 }
@@ -510,7 +510,6 @@ impl Default for DiscoverPeer {
             max_discovery_peers: 16,
             kademlia: true,
             mdns: true,
-            bootstrap_peers: HashSet::new(),
         }
     }
 }

--- a/apps/src/lib/config/mod.rs
+++ b/apps/src/lib/config/mod.rs
@@ -232,7 +232,9 @@ pub struct PeerAddress {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DiscoverPeer {
     pub max_discovery_peers: u64,
+    /// Toggle Kademlia remote peer discovery, on by default
     pub kademlia: bool,
+    /// Toggle local network mDNS peer discovery, off by default
     pub mdns: bool,
 }
 
@@ -501,15 +503,11 @@ impl<'de> Deserialize<'de> for PeerAddress {
 }
 
 impl Default for DiscoverPeer {
-    /// default configuration for discovering peer.
-    /// max_discovery_peers: 16,
-    /// kademlia: true,
-    /// mdns: true,
     fn default() -> Self {
         Self {
             max_discovery_peers: 16,
             kademlia: true,
-            mdns: true,
+            mdns: false,
         }
     }
 }

--- a/apps/src/lib/node/gossip/behaviour/discovery.rs
+++ b/apps/src/lib/node/gossip/behaviour/discovery.rs
@@ -319,7 +319,12 @@ impl NetworkBehaviour for DiscoveryBehaviour {
         conn: &ConnectionId,
         endpoint: &ConnectedPoint,
     ) {
-        tracing::debug!("Injecting connection established for peer ID {}", peer_id);
+        tracing::debug!(
+            "Injecting connection established for peer ID {} with endpoint \
+             {:#?}",
+            peer_id,
+            endpoint
+        );
         self.num_connections += 1;
 
         self.kademlia
@@ -433,7 +438,10 @@ impl NetworkBehaviour for DiscoveryBehaviour {
         // TODO: explain a bit more the logic happening here
         if let Some(next_kad_random_query) = self.next_kad_random_query.as_mut()
         {
-            tracing::debug!("Kademlia random query {:#?}", next_kad_random_query);
+            tracing::debug!(
+                "Kademlia random query {:#?}",
+                next_kad_random_query
+            );
             while next_kad_random_query.poll_next_unpin(cx).is_ready() {
                 if self.num_connections < self.discovery_max {
                     let random_peer_id = PeerId::random();

--- a/apps/src/lib/node/gossip/behaviour/discovery.rs
+++ b/apps/src/lib/node/gossip/behaviour/discovery.rs
@@ -141,7 +141,7 @@ pub struct DiscoveryBehaviour {
     /// bootstrap nodes and reserved nodes.
     user_defined: Vec<PeerAddress>,
     /// Kademlia discovery.
-    kademlia: Toggle<Kademlia<MemoryStore>>,
+    pub kademlia: Toggle<Kademlia<MemoryStore>>,
     /// Discovers nodes on the local network.
     mdns: Toggle<Mdns>,
     /// Stream that fires when we need to perform the next random Kademlia

--- a/apps/src/lib/node/gossip/behaviour/discovery.rs
+++ b/apps/src/lib/node/gossip/behaviour/discovery.rs
@@ -296,6 +296,7 @@ impl NetworkBehaviour for DiscoveryBehaviour {
     }
 
     fn inject_connected(&mut self, peer_id: &PeerId) {
+        tracing::debug!("Injecting connected peer {}", peer_id);
         self.peers.insert(*peer_id);
         self.pending_events
             .push_back(DiscoveryEvent::Connected(*peer_id));
@@ -304,6 +305,7 @@ impl NetworkBehaviour for DiscoveryBehaviour {
     }
 
     fn inject_disconnected(&mut self, peer_id: &PeerId) {
+        tracing::debug!("Injecting disconnected peer {}", peer_id);
         self.peers.remove(peer_id);
         self.pending_events
             .push_back(DiscoveryEvent::Disconnected(*peer_id));
@@ -317,6 +319,7 @@ impl NetworkBehaviour for DiscoveryBehaviour {
         conn: &ConnectionId,
         endpoint: &ConnectedPoint,
     ) {
+        tracing::debug!("Injecting connection established for peer ID {}", peer_id);
         self.num_connections += 1;
 
         self.kademlia
@@ -329,6 +332,7 @@ impl NetworkBehaviour for DiscoveryBehaviour {
         conn: &ConnectionId,
         endpoint: &ConnectedPoint,
     ) {
+        tracing::debug!("Injecting connection closed for peer ID {}", peer_id);
         self.num_connections -= 1;
 
         self.kademlia
@@ -416,6 +420,7 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 
         // Poll Kademlia return every other event except kad event
         while let Poll::Ready(ev) = self.kademlia.poll(cx, params) {
+            tracing::debug!("Kademlia event {:#?}", ev);
             if let NetworkBehaviourAction::GenerateEvent(_kad_ev) = ev {
             } else {
                 return Poll::Ready(ev.map_out(DiscoveryEvent::KademliaEvent));
@@ -428,6 +433,7 @@ impl NetworkBehaviour for DiscoveryBehaviour {
         // TODO: explain a bit more the logic happening here
         if let Some(next_kad_random_query) = self.next_kad_random_query.as_mut()
         {
+            tracing::debug!("Kademlia random query {:#?}", next_kad_random_query);
             while next_kad_random_query.poll_next_unpin(cx).is_ready() {
                 if self.num_connections < self.discovery_max {
                     let random_peer_id = PeerId::random();

--- a/apps/src/lib/node/gossip/behaviour/discovery.rs
+++ b/apps/src/lib/node/gossip/behaviour/discovery.rs
@@ -202,7 +202,7 @@ impl DiscoveryBehaviour {
             kademlia_disjoint_query_paths,
         } = config;
 
-        let mut peers = HashSet::new();
+        let mut peers = HashSet::with_capacity(user_defined.len());
 
         // Kademlia config
         let kademlia_opt = if enable_kademlia {

--- a/apps/src/lib/node/gossip/behaviour/mod.rs
+++ b/apps/src/lib/node/gossip/behaviour/mod.rs
@@ -170,6 +170,8 @@ impl Behaviour {
             .max_transmit_size(16 * 1024 * 1024)
             .validate_messages()
             .mesh_outbound_min(1)
+            // TODO bootstrap peers should not be part of the mesh, so all the
+            // `.mesh` args should be set to 0 https://github.com/libp2p/specs/blob/70d7fda47dda88d828b4db72775c1602de57e91b/pubsub/gossipsub/gossipsub-v1.1.md#recommendations-for-network-operators
             .mesh_n_low(2)
             .mesh_n(3)
             .mesh_n_high(6)

--- a/apps/src/lib/node/gossip/behaviour/mod.rs
+++ b/apps/src/lib/node/gossip/behaviour/mod.rs
@@ -223,20 +223,19 @@ impl Behaviour {
         let discover_behaviour = {
             // TODO: check that bootstrap_peers are in multiaddr (otherwise it
             // fails silently)
-            let discover_config = if let Some(discover_config) =
-                &config.discover_peer
-            {
-                DiscoveryConfigBuilder::default()
-                    .with_user_defined(discover_config.bootstrap_peers.clone())
-                    .discovery_limit(discover_config.max_discovery_peers)
-                    .with_kademlia(discover_config.kademlia)
-                    .with_mdns(discover_config.mdns)
-                    .use_kademlia_disjoint_query_paths(true)
-                    .build()
-                    .unwrap()
-            } else {
-                DiscoveryConfigBuilder::default().build().unwrap()
-            };
+            let discover_config =
+                if let Some(discover_config) = &config.discover_peer {
+                    DiscoveryConfigBuilder::default()
+                        .with_user_defined(config.seed_peers.clone())
+                        .discovery_limit(discover_config.max_discovery_peers)
+                        .with_kademlia(discover_config.kademlia)
+                        .with_mdns(discover_config.mdns)
+                        .use_kademlia_disjoint_query_paths(true)
+                        .build()
+                        .unwrap()
+                } else {
+                    DiscoveryConfigBuilder::default().build().unwrap()
+                };
             DiscoveryBehaviour::new(peer_id, discover_config).unwrap()
         };
         Self {

--- a/apps/src/lib/node/gossip/behaviour/mod.rs
+++ b/apps/src/lib/node/gossip/behaviour/mod.rs
@@ -14,6 +14,7 @@ use libp2p::gossipsub::{
     MessageAcceptance, MessageAuthenticity, MessageId, TopicHash,
     ValidationMode,
 };
+use libp2p::identify::{Identify, IdentifyConfig, IdentifyEvent};
 use libp2p::identity::Keypair;
 use libp2p::swarm::NetworkBehaviourEventProcess;
 use libp2p::{NetworkBehaviour, PeerId};
@@ -27,6 +28,19 @@ use super::intent_gossiper::matchmaker::MatchmakerMessage;
 use crate::node::gossip::behaviour::discovery::{
     DiscoveryBehaviour, DiscoveryConfigBuilder,
 };
+
+/// Behaviour is composed of a `DiscoveryBehaviour` and an GossipsubBehaviour`.
+/// It automatically connect to newly discovered peer, except specified
+/// otherwise, and propagates intents to other peers.
+#[derive(NetworkBehaviour)]
+pub struct Behaviour {
+    pub intent_gossip_behaviour: Gossipsub,
+    pub discover_behaviour: DiscoveryBehaviour,
+    /// The identify protocol allows establishing P2P connections via Kademlia
+    identify: Identify,
+    #[behaviour(ignore)]
+    pub mm_sender: Option<Sender<MatchmakerMessage>>,
+}
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -124,17 +138,6 @@ impl TopicSubscriptionFilter for IntentGossipSubscriptionFilter {
     }
 }
 
-/// Behaviour is composed of a `DiscoveryBehaviour` and an GossipsubBehaviour`.
-/// It automatically connect to newly discovered peer, except specified
-/// otherwise, and propagates intents to other peers.
-#[derive(NetworkBehaviour)]
-pub struct Behaviour {
-    pub intent_gossip_behaviour: Gossipsub,
-    pub discover_behaviour: DiscoveryBehaviour,
-    #[behaviour(ignore)]
-    pub mm_sender: Option<Sender<MatchmakerMessage>>,
-}
-
 /// [message_id] use the hash of the message data as an id
 pub fn message_id(message: &GossipsubMessage) -> MessageId {
     let mut hasher = DefaultHasher::new();
@@ -149,7 +152,8 @@ impl Behaviour {
         config: &crate::config::IntentGossiper,
         mm_sender: Option<Sender<MatchmakerMessage>>,
     ) -> Self {
-        let peer_id = PeerId::from_public_key(key.public());
+        let public_key = key.public();
+        let peer_id = PeerId::from_public_key(public_key.clone());
 
         // TODO remove hardcoded value and add them to the config Except
         // validation_mode, protocol_id_prefix, message_id_fn and
@@ -233,6 +237,10 @@ impl Behaviour {
         Self {
             intent_gossip_behaviour,
             discover_behaviour,
+            identify: Identify::new(IdentifyConfig::new(
+                "anoma/id/anoma/id/1.0.0".into(),
+                public_key,
+            )),
             mm_sender,
         }
     }
@@ -347,6 +355,31 @@ impl NetworkBehaviourEventProcess<DiscoveryEvent> for Behaviour {
                 tracing::info!("Peer disconnected: {:?}", peer)
             }
             _ => {}
+        }
+    }
+}
+
+impl NetworkBehaviourEventProcess<IdentifyEvent> for Behaviour {
+    fn inject_event(&mut self, event: IdentifyEvent) {
+        match event {
+            IdentifyEvent::Received { peer_id, info } => {
+                tracing::debug!("Identified Peer {}", peer_id);
+                tracing::debug!("protocol_version {}", info.protocol_version);
+                tracing::debug!("agent_version {}", info.agent_version);
+                tracing::debug!("listening_ addresses {:?}", info.listen_addrs);
+                tracing::debug!("observed_address {}", info.observed_addr);
+                tracing::debug!("protocols {:?}", info.protocols);
+            }
+            IdentifyEvent::Sent { .. } => (),
+            IdentifyEvent::Pushed { .. } => (),
+            IdentifyEvent::Error { peer_id, error } => {
+                tracing::error!(
+                    "Error while attempting to identify the remote peer {}: \
+                     {},",
+                    peer_id,
+                    error
+                );
+            }
         }
     }
 }

--- a/apps/src/lib/node/gossip/intent_gossiper/matchmaker.rs
+++ b/apps/src/lib/node/gossip/intent_gossiper/matchmaker.rs
@@ -21,7 +21,6 @@ use tendermint_config::net;
 use tendermint_config_abci::net;
 use thiserror::Error;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
-use tokio::sync::oneshot;
 
 use super::filter::Filter;
 use super::mempool::{self, IntentMempool};
@@ -72,7 +71,7 @@ struct MatchmakerState(Arc<*mut c_void>);
 #[derive(Debug)]
 pub enum MatchmakerMessage {
     /// Run the matchmaker with the given intent
-    ApplyIntent(Intent, oneshot::Sender<bool>),
+    ApplyIntent(Intent, std::sync::mpsc::Sender<bool>),
 }
 
 #[derive(Error, Debug)]

--- a/tests/src/e2e/gossip_tests.rs
+++ b/tests/src/e2e/gossip_tests.rs
@@ -26,22 +26,27 @@ use crate::{run, run_as};
 /// Test that when we "run-gossip" a peer with no seeds should fail
 /// bootstrapping kademlia. A peer with a seed should be able to
 /// bootstrap kademia and connect to the other peer.
+/// In this test we:
+/// 1. Check that a gossip node can start and stop cleanly
+/// 2. Check that two peers connected to the same seed node discover each other
 #[test]
 fn run_gossip() -> Result<()> {
     let test =
-        setup::network(|genesis| setup::add_validators(1, genesis), None)?;
+        setup::network(|genesis| setup::add_validators(2, genesis), None)?;
 
-    let mut cmd =
-        run_as!(test, Who::Validator(0), Bin::Node, &["gossip"], Some(20),)?;
-    // Node without peers
-    cmd.exp_regex(r"Peer id: PeerId\(.*\)")?;
+    // 1. Start the first gossip node and then stop it
+    let mut node_0 =
+        run_as!(test, Who::Validator(0), Bin::Node, &["gossip"], Some(20))?;
+    node_0.send_control('c')?;
+    node_0.exp_eof()?;
+    drop(node_0);
 
-    drop(cmd);
-
-    let mut first_node =
-        run_as!(test, Who::Validator(0), Bin::Node, &["gossip"], Some(20),)?;
-    let (_unread, matched) = first_node.exp_regex(r"Peer id: PeerId\(.*\)")?;
-    let first_node_peer_id = matched
+    // 2. Check that two peers connected to the same seed node discover each
+    // other. Start the first gossip node again (the seed node).
+    let mut node_0 =
+        run_as!(test, Who::Validator(0), Bin::Node, &["gossip"], Some(20))?;
+    let (_unread, matched) = node_0.exp_regex(r"Peer id: PeerId\(.*\)")?;
+    let node_0_peer_id = matched
         .trim()
         .rsplit_once("\"")
         .unwrap()
@@ -50,14 +55,36 @@ fn run_gossip() -> Result<()> {
         .unwrap()
         .1;
 
-    let mut second_node =
-        run_as!(test, Who::Validator(1), Bin::Node, &["gossip"], Some(20),)?;
+    // Start the second gossip node (a peer node)
+    let mut node_1 =
+        run_as!(test, Who::Validator(1), Bin::Node, &["gossip"], Some(20))?;
 
-    second_node.exp_regex(r"Peer id: PeerId\(.*\)")?;
-    second_node.exp_string(&format!(
+    let (_unread, matched) = node_1.exp_regex(r"Peer id: PeerId\(.*\)")?;
+    let node_1_peer_id = matched
+        .trim()
+        .rsplit_once("\"")
+        .unwrap()
+        .0
+        .rsplit_once("\"")
+        .unwrap()
+        .1;
+    node_1.exp_string(&format!(
         "Connect to a new peer: PeerId(\"{}\")",
-        first_node_peer_id
+        node_0_peer_id
     ))?;
+
+    // Start the third gossip node (another peer node)
+    let mut node_2 =
+        run_as!(test, Who::Validator(2), Bin::Node, &["gossip"], Some(20))?;
+    // The third node should connect to node 1 via Identify and Kademlia peer
+    // discovery protocol
+    node_2.exp_string(&format!(
+        "Connect to a new peer: PeerId(\"{}\")",
+        node_1_peer_id
+    ))?;
+    node_2.exp_string(&format!("Identified Peer {}", node_1_peer_id))?;
+    node_2
+        .exp_string(&format!("Routing updated peer ID: {}", node_1_peer_id))?;
 
     Ok(())
 }
@@ -98,7 +125,7 @@ fn match_intents() -> Result<()> {
     println!("Done building the matchmaker.");
 
     let mut ledger =
-        run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(20),)?;
+        run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(20))?;
     ledger.exp_string("Anoma ledger node started")?;
     ledger.exp_string("No state could be found")?;
     // Wait to commit a block

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -53,7 +53,7 @@ pub fn add_validators(num: u8, mut genesis: GenesisConfig) -> GenesisConfig {
     // Clone the first validator before modifying it
     let other_validators = validator_0.clone();
     // Set the first validator to be a bootstrap node to enable P2P connectivity
-    validator_0.intent_gossip_bootstrap = Some(true);
+    validator_0.intent_gossip_seed = Some(true);
     // A bootstrap node doesn't participate in the gossipsub protocol for
     // gossiping intents, so we remove its matchmaker
     validator_0.matchmaker_account = None;
@@ -66,7 +66,7 @@ pub fn add_validators(num: u8, mut genesis: GenesisConfig) -> GenesisConfig {
     for ix in 0..num {
         let mut validator = other_validators.clone();
         // Only the first validator is bootstrap
-        validator.intent_gossip_bootstrap = None;
+        validator.intent_gossip_seed = None;
         let mut net_address = net_address_0;
         // 5 ports for each validator
         net_address.set_port(net_address_port_0 + 5 * (ix as u16 + 1));

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -42,16 +42,31 @@ pub struct Network {
     chain_id: ChainId,
 }
 
-/// Add `num` validators to the genesis config.
+/// Add `num` validators to the genesis config. Note that called from inside
+/// the [`network`]'s first argument's closure, there is 1 validator already
+/// present to begin with, so e.g. `add_validators(1, _)` will configure a
+/// network with 2 validators.
+///
 /// INVARIANT: Do not call this function more than once on the same config.
 pub fn add_validators(num: u8, mut genesis: GenesisConfig) -> GenesisConfig {
-    let validator_0 = genesis.validator.get("validator-0").unwrap().clone();
+    let validator_0 = genesis.validator.get_mut("validator-0").unwrap();
+    // Clone the first validator before modifying it
+    let other_validators = validator_0.clone();
+    // Set the first validator to be a bootstrap node to enable P2P connectivity
+    validator_0.intent_gossip_bootstrap = Some(true);
+    // A bootstrap node doesn't participate in the gossipsub protocol for
+    // gossiping intents, so we remove its matchmaker
+    validator_0.matchmaker_account = None;
+    validator_0.matchmaker_code = None;
+    validator_0.matchmaker_tx = None;
     let net_address_0 =
         SocketAddr::from_str(validator_0.net_address.as_ref().unwrap())
             .unwrap();
     let net_address_port_0 = net_address_0.port();
     for ix in 0..num {
-        let mut validator = validator_0.clone();
+        let mut validator = other_validators.clone();
+        // Only the first validator is bootstrap
+        validator.intent_gossip_bootstrap = None;
         let mut net_address = net_address_0;
         // 5 ports for each validator
         net_address.set_port(net_address_port_0 + 5 * (ix as u16 + 1));


### PR DESCRIPTION
This PR enables remote peer discovery for the intent gossiper node.

We've added libp2p Identify (to automatically identify nodes periodically, return information about them, and answers identify queries from other nodes) and Ping protocol (to keep established connections live).

The updated `e2e::gossip_tests::run_gossip` now tests that two peers that don't know about each other can establish direct connection via a common seed node that gossips their info.

For convenience we can set one of the validator nodes in testnets to be a seed node (anoma-network-config change for devnet https://github.com/heliaxdev/anoma-network-config/commit/0945bcbc22669a0ac8352f4dfaf991b2cf97dc7d - note that the field `intent_gossip_bootstrap` has been later renamed to `intent_gossip_seed` in here 43c32da).