### PR TITLE
Murisi/broadcast only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5766,7 +5766,7 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.23.0"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#a072e7da5acf4196febf8229cb20b5235aefcbf2"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#203fa2a7aac917d8b548bb1cb2d3c774ce090891"
 dependencies = [
  "async-trait",
  "bytes 1.1.0",
@@ -5822,7 +5822,7 @@ dependencies = [
 [[package]]
 name = "tendermint-config"
 version = "0.23.0"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#a072e7da5acf4196febf8229cb20b5235aefcbf2"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#203fa2a7aac917d8b548bb1cb2d3c774ce090891"
 dependencies = [
  "flex-error",
  "serde 1.0.132",
@@ -5848,7 +5848,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client"
 version = "0.23.0"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#a072e7da5acf4196febf8229cb20b5235aefcbf2"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#203fa2a7aac917d8b548bb1cb2d3c774ce090891"
 dependencies = [
  "chrono",
  "contracts",
@@ -5886,7 +5886,7 @@ dependencies = [
 [[package]]
 name = "tendermint-proto"
 version = "0.23.0"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#a072e7da5acf4196febf8229cb20b5235aefcbf2"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#203fa2a7aac917d8b548bb1cb2d3c774ce090891"
 dependencies = [
  "bytes 1.1.0",
  "chrono",
@@ -5920,7 +5920,7 @@ dependencies = [
 [[package]]
 name = "tendermint-rpc"
 version = "0.23.0"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#a072e7da5acf4196febf8229cb20b5235aefcbf2"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#203fa2a7aac917d8b548bb1cb2d3c774ce090891"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -5986,7 +5986,7 @@ dependencies = [
 [[package]]
 name = "tendermint-testgen"
 version = "0.23.0"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#a072e7da5acf4196febf8229cb20b5235aefcbf2"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.0#203fa2a7aac917d8b548bb1cb2d3c774ce090891"
 dependencies = [
  "chrono",
  "ed25519-dalek",

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -1112,6 +1112,7 @@ pub mod args {
             Err(_) => config::DEFAULT_BASE_DIR.into(),
         }),
     );
+    const BROADCAST_ONLY: ArgFlag = flag("broadcast-only");
     const CHAIN_ID: Arg<ChainId> = arg("chain-id");
     const CHAIN_ID_OPT: ArgOpt<ChainId> = CHAIN_ID.opt();
     const CHAIN_ID_PREFIX: Arg<ChainIdPrefix> = arg("chain-prefix");
@@ -1998,6 +1999,8 @@ pub mod args {
         pub dry_run: bool,
         /// Submit the transaction even if it doesn't pass client checks
         pub force: bool,
+        /// Do not wait for the transaction to be added to the blockchain
+        pub broadcast_only: bool,
         /// The address of the ledger node as host:port
         pub ledger_address: TendermintAddress,
         /// If any new account is initialized by the tx, use the given alias to
@@ -2024,6 +2027,10 @@ pub mod args {
             )
             .arg(FORCE.def().about(
                 "Submit the transaction even if it doesn't pass client checks.",
+            ))
+            .arg(BROADCAST_ONLY.def().about(
+                "Do not wait for the transaction to be added to the \
+                 blockchain.",
             ))
             .arg(LEDGER_ADDRESS_DEFAULT.def().about(LEDGER_ADDRESS_ABOUT))
             .arg(ALIAS_OPT.def().about(
@@ -2065,6 +2072,7 @@ pub mod args {
         fn parse(matches: &ArgMatches) -> Self {
             let dry_run = DRY_RUN_TX.parse(matches);
             let force = FORCE.parse(matches);
+            let broadcast_only = BROADCAST_ONLY.parse(matches);
             let ledger_address = LEDGER_ADDRESS_DEFAULT.parse(matches);
             let initialized_account_alias = ALIAS_OPT.parse(matches);
             let fee_amount = FEE_AMOUNT.parse(matches);
@@ -2076,6 +2084,7 @@ pub mod args {
             Self {
                 dry_run,
                 force,
+                broadcast_only,
                 ledger_address,
                 initialized_account_alias,
                 fee_amount,

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -2029,8 +2029,8 @@ pub mod args {
                 "Submit the transaction even if it doesn't pass client checks.",
             ))
             .arg(BROADCAST_ONLY.def().about(
-                "Do not wait for the transaction to be added to the \
-                 blockchain.",
+                "Do not wait for the transaction to be applied. This will \
+                 return once the transaction is added to the mempool.",
             ))
             .arg(LEDGER_ADDRESS_DEFAULT.def().about(LEDGER_ADDRESS_ABOUT))
             .arg(ALIAS_OPT.def().about(

--- a/apps/src/lib/client/tendermint_websocket_client.rs
+++ b/apps/src/lib/client/tendermint_websocket_client.rs
@@ -486,6 +486,8 @@ mod test_tendermint_websocket_client {
     use anoma::types::transaction::hash_tx as hash_tx_bytes;
     use serde::{Deserialize, Serialize};
     #[cfg(not(feature = "ABCI"))]
+    use tendermint::abci::transaction;
+    #[cfg(not(feature = "ABCI"))]
     use tendermint_rpc::endpoint::abci_info::AbciInfo;
     #[cfg(not(feature = "ABCI"))]
     use tendermint_rpc::query::{EventType, Query};

--- a/apps/src/lib/client/tendermint_websocket_client.rs
+++ b/apps/src/lib/client/tendermint_websocket_client.rs
@@ -5,6 +5,7 @@ use std::net::TcpStream;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+#[cfg(not(feature = "ABCI"))]
 use anoma::types::transaction::{hash_tx as hash_tx_bytes, Hash};
 use async_trait::async_trait;
 #[cfg(not(feature = "ABCI"))]
@@ -25,8 +26,6 @@ use tendermint_rpc_abci::query::Query;
 use tendermint_rpc_abci::{
     Client, Error as RpcError, Request, Response, SimpleRequest,
 };
-#[cfg(feature = "ABCI")]
-use tendermint_stable::abci::transaction;
 use thiserror::Error;
 use tokio::time::Instant;
 use websocket::result::WebSocketError;
@@ -457,6 +456,7 @@ impl Client for TendermintWebsocketClient {
     }
 }
 
+#[cfg(not(feature = "ABCI"))]
 pub fn hash_tx(tx_bytes: &[u8]) -> transaction::Hash {
     let Hash(hash_bytes) = hash_tx_bytes(tx_bytes);
     transaction::Hash::new(hash_bytes)
@@ -483,6 +483,7 @@ fn get_id(req_json: &str) -> Result<String, Error> {
 mod test_tendermint_websocket_client {
     use std::time::Duration;
 
+    use anoma::types::transaction::hash_tx as hash_tx_bytes;
     use serde::{Deserialize, Serialize};
     #[cfg(not(feature = "ABCI"))]
     use tendermint_rpc::endpoint::abci_info::AbciInfo;
@@ -496,6 +497,8 @@ mod test_tendermint_websocket_client {
     use tendermint_rpc_abci::query::{EventType, Query};
     #[cfg(feature = "ABCI")]
     use tendermint_rpc_abci::Client;
+    #[cfg(feature = "ABCI")]
+    use tendermint_stable::abci::transaction;
     use websocket::sync::Server;
     use websocket::{Message, OwnedMessage};
 
@@ -567,8 +570,8 @@ mod test_tendermint_websocket_client {
                     // Mock a subscription result returning on the wire before
                     // the simple request result
                     let info = AbciInfo {
-                        last_block_app_hash: super::hash_tx(
-                            "Testing".as_bytes(),
+                        last_block_app_hash: transaction::Hash::new(
+                            hash_tx_bytes("Testing".as_bytes()).0,
                         )
                         .as_ref()
                         .into(),

--- a/apps/src/lib/client/tx.rs
+++ b/apps/src/lib/client/tx.rs
@@ -691,14 +691,27 @@ async fn process_tx(
             args.gas_limit.clone(),
             tx,
         );
-        match submit_tx(args.ledger_address.clone(), tx, keypair).await {
-            Ok(result) => (ctx, result.initialized_accounts),
-            Err(err) => {
-                eprintln!(
-                    "Encountered error while broadcasting transaction: {}",
-                    err
-                );
-                safe_exit(1)
+        if args.broadcast_only {
+            match broadcast_tx(args.ledger_address.clone(), tx, keypair).await {
+                Ok(_result) => (ctx, Vec::default()),
+                Err(err) => {
+                    eprintln!(
+                        "Encountered error while broadcasting transaction: {}",
+                        err
+                    );
+                    safe_exit(1)
+                }
+            }
+        } else {
+            match submit_tx(args.ledger_address.clone(), tx, keypair).await {
+                Ok(result) => (ctx, result.initialized_accounts),
+                Err(err) => {
+                    eprintln!(
+                        "Encountered error while broadcasting transaction: {}",
+                        err
+                    );
+                    safe_exit(1)
+                }
             }
         }
     }

--- a/apps/src/lib/client/tx.rs
+++ b/apps/src/lib/client/tx.rs
@@ -860,11 +860,10 @@ pub async fn submit_tx(
     //
     // Note that the `applied.hash` key comes from a custom event
     // created by the shell
-    let query_key = if !cfg!(feature = "ABCI") {
-        "accepted.hash"
-    } else {
-        "applied.hash"
-    };
+    #[cfg(not(feature = "ABCI"))]
+    let query_key = "accepted.hash";
+    #[cfg(feature = "ABCI")]
+    let query_key = "applied.hash";
     let query = Query::from(EventType::NewBlock)
         .and_eq(query_key, wrapper_tx_hash.as_str());
     wrapper_tx_subscription.subscribe(query)?;

--- a/apps/src/lib/client/tx.rs
+++ b/apps/src/lib/client/tx.rs
@@ -778,7 +778,6 @@ async fn save_initialized_accounts(
 /// Extract the wrapper transaction's hash and, if in ABCI++ mode, the inner
 /// transaction's hash. Useful for determining when parts of the given
 /// tranasaction make it on-chain.
-
 pub fn tx_hashes(tx: &WrapperTx) -> (String, String) {
     let tx_hash = tx.tx_hash.to_string();
     #[cfg(not(feature = "ABCI"))]

--- a/apps/src/lib/client/tx.rs
+++ b/apps/src/lib/client/tx.rs
@@ -874,20 +874,12 @@ pub async fn submit_tx(
     // Broadcast the supplied transaction
     broadcast_tx(address, tx, keypair).await?;
 
-    let parsed = if !cfg!(feature = "ABCI") {
-        parse(
-            wrapper_tx_subscription.receive_response()?,
-            TmEventType::Accepted,
-            &wrapper_tx_hash.to_string(),
-        )
-    } else {
-        TxResponse::find_tx(
-            wrapper_tx_subscription.receive_response()?,
-            wrapper_tx_hash,
-        )
-    };
     #[cfg(feature = "ABCI")]
     let parsed = {
+        let parsed = TxResponse::find_tx(
+            wrapper_tx_subscription.receive_response()?,
+            wrapper_tx_hash,
+        );
         println!(
             "Transaction applied with result: {}",
             serde_json::to_string_pretty(&parsed).unwrap()
@@ -896,6 +888,11 @@ pub async fn submit_tx(
     };
     #[cfg(not(feature = "ABCI"))]
     let parsed = {
+        let parsed = parse(
+            wrapper_tx_subscription.receive_response()?,
+            TmEventType::Accepted,
+            &wrapper_tx_hash.to_string(),
+        );
         println!(
             "Transaction accepted with result: {}",
             serde_json::to_string_pretty(&parsed).unwrap()

--- a/apps/src/lib/client/tx.rs
+++ b/apps/src/lib/client/tx.rs
@@ -12,9 +12,9 @@ use anoma::types::{address, token};
 use anoma::{ledger, vm};
 use async_std::io::{self, WriteExt};
 use borsh::BorshSerialize;
+use itertools::Either::*;
 use jsonpath_lib as jsonpath;
 use serde::Serialize;
-use itertools::Either::*;
 #[cfg(not(feature = "ABCI"))]
 use tendermint_config::net::Address as TendermintAddress;
 #[cfg(feature = "ABCI")]

--- a/apps/src/lib/node/gossip/intent_gossiper/matchmaker.rs
+++ b/apps/src/lib/node/gossip/intent_gossiper/matchmaker.rs
@@ -27,7 +27,7 @@ use super::filter::Filter;
 use super::mempool::{self, IntentMempool};
 use crate::cli::args;
 use crate::client::rpc;
-use crate::client::tx::broadcast_tx;
+use crate::client::tx::submit_tx;
 use crate::{config, wasm_loader};
 
 /// A matchmaker receive intents and tries to find a match with previously
@@ -224,7 +224,7 @@ impl Matchmaker {
         );
 
         let response =
-            broadcast_tx(self.ledger_address.clone(), tx, &self.tx_signing_key)
+            submit_tx(self.ledger_address.clone(), tx, &self.tx_signing_key)
                 .await;
         match response {
             Ok(tx_response) => {


### PR DESCRIPTION
Implemented a feature to allow client to exit as soon as a transaction is in the mempool. See #403 . This change only makes sense if there is a way to later extract transaction results. See the pull request at #634 . The specific changes made are as follows:
* Added a flag `--broadcast-only` to allow user to indicate that client should exit once the transaction is in mempool
* Factored out the waiting/blocking code in `broadcast_tx` so that the client can effect early exits
* Added code to print transaction hashes even if the transactions have not been accepted/applied to the blockchain