### PR TITLE
release: allow cargo-release maintenance releases

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,4 +1,4 @@
-allow-branch               = ["master"]
+allow-branch               = ["master", "maint-*"]
 consolidate-commits        = true
 disable-push               = true
 disable-publish            = true


### PR DESCRIPTION
cargo-release was configured to release only from 'master'. Change this
to 'master' and 'maint-*'.

on 0.3.1 already; forward-port