### PR TITLE
fix matchmaker state ptr

### DIFF
--- a/.changelog/unreleased/bug-fixes/806-806.md
+++ b/.changelog/unreleased/bug-fixes/806-806.md
@@ -1,0 +1,3 @@
+- Matchmaker: Fix a matchmaker's state management via a raw pointer
+  that was causing segfaults in the matchmaker in release build.
+  ([#806](https://github.com/anoma/anoma/pull/806))

--- a/.changelog/unreleased/improvements/717-717.md
+++ b/.changelog/unreleased/improvements/717-717.md
@@ -1,0 +1,3 @@
+- Testing: Increments network configuration ports used for E2E
+  tests and ABCI++ enabled E2E tests to avoid sharing resources.
+  ([#717](https://github.com/anoma/anoma/issues/717))

--- a/apps/src/lib/client/gossip.rs
+++ b/apps/src/lib/client/gossip.rs
@@ -72,16 +72,24 @@ pub async fn gossip_intent(
         let topic = topic.expect(
             "The topic must be defined to submit the intent to a gossip node.",
         );
-        let mut client = RpcServiceClient::connect(node_addr).await.unwrap();
 
-        let intent = anoma::proto::Intent::new(data_bytes);
-        let message: services::RpcMessage =
-            RpcMessage::new_intent(intent, topic).into();
-        let response = client
-            .send_message(message)
-            .await
-            .expect("failed to send message and/or receive rpc response");
-        println!("{:#?}", response);
+        match RpcServiceClient::connect(node_addr.clone()).await {
+            Ok(mut client) => {
+                let intent = anoma::proto::Intent::new(data_bytes);
+                let message: services::RpcMessage =
+                    RpcMessage::new_intent(intent, topic).into();
+                let response = client.send_message(message).await.expect(
+                    "Failed to send message and/or receive rpc response",
+                );
+                println!("{:#?}", response);
+            }
+            Err(e) => {
+                eprintln!(
+                    "Error connecting RPC client to {}: {}",
+                    node_addr, e
+                );
+            }
+        };
     }
 }
 

--- a/apps/src/lib/node/gossip/intent_gossiper/matchmaker.rs
+++ b/apps/src/lib/node/gossip/intent_gossiper/matchmaker.rs
@@ -125,14 +125,15 @@ impl Matchmaker {
             )
         }
         let matchmaker_code =
-            unsafe { Library::new(matchmaker_dylib).unwrap() };
+            unsafe { Library::new(matchmaker_dylib) }.unwrap();
 
         // Instantiate the matchmaker
         let new_matchmaker: libloading::Symbol<
             unsafe extern "C" fn() -> *mut c_void,
-        > = unsafe { matchmaker_code.get(b"_new_matchmaker").unwrap() };
+        > = unsafe { matchmaker_code.get(b"_new_matchmaker") }.unwrap();
 
-        let state = MatchmakerState(Arc::new(unsafe { new_matchmaker() }));
+        let new_state = unsafe { new_matchmaker() };
+        let state = MatchmakerState(Arc::new(new_state));
 
         let tx_code = wasm_loader::read_wasm(&wasm_dir, &config.tx_code);
         let filter = Some(Filter);
@@ -183,9 +184,9 @@ impl Matchmaker {
                 ) -> AddIntentResult,
             > = unsafe { self.r#impl.library.get(b"_add_intent").unwrap() };
 
-            let result = unsafe {
-                add_intent(*self.r#impl.state.0, &intent.id().0, &intent.data)
-            };
+            let state = *self.r#impl.state.0;
+            let result =
+                unsafe { add_intent(state, &intent.id().0, &intent.data) };
 
             if let Some(tx) = result.tx {
                 self.submit_tx(tx).await

--- a/genesis/e2e-tests-single-node.toml
+++ b/genesis/e2e-tests-single-node.toml
@@ -15,9 +15,9 @@ validator_vp = "vp_user"
 # VP for the staking reward account
 staking_reward_vp = "vp_user"
 # Public IP:port address.
-# We set the port to be the default+10, so that if a local node was running at 
+# We set the port to be the default+1000, so that if a local node was running at 
 # the same time as the E2E tests, it wouldn't affect them.
-net_address = "127.0.0.1:26666"
+net_address = "127.0.0.1:27656"
 # This has to be an alias of one of the established accounts
 matchmaker_account = "matchmaker"
 # A matchmaker dylib program's name (the platform specific extension 

--- a/genesis/e2e-tests-single-node.toml
+++ b/genesis/e2e-tests-single-node.toml
@@ -14,8 +14,10 @@ non_staked_balance = 1000000000000
 validator_vp = "vp_user"
 # VP for the staking reward account
 staking_reward_vp = "vp_user"
-# Public IP:port address
-net_address = "127.0.0.1:26656"
+# Public IP:port address.
+# We set the port to be the default+10, so that if a local node was running at 
+# the same time as the E2E tests, it wouldn't affect them.
+net_address = "127.0.0.1:26666"
 # This has to be an alias of one of the established accounts
 matchmaker_account = "matchmaker"
 # A matchmaker dylib program's name (the platform specific extension 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -148,9 +148,8 @@ pub fn matchmaker(input: TokenStream) -> TokenStream {
         #[no_mangle]
         #[automatically_derived]
         fn _new_matchmaker() -> *mut std::ffi::c_void {
-            let mut state = #ident::default();
-            let state_ptr = &mut state as *mut #ident as *mut std::ffi::c_void;
-            std::mem::forget(state);
+            let state = Box::new(#ident::default());
+            let state_ptr = Box::into_raw(state) as *mut std::ffi::c_void;
             state_ptr
         }
 
@@ -159,8 +158,7 @@ pub fn matchmaker(input: TokenStream) -> TokenStream {
         #[automatically_derived]
         fn _drop_matchmaker(state_ptr: *mut std::ffi::c_void) {
             // The state will be dropped on going out of scope
-            let _state: #ident =
-                unsafe { std::ptr::read(state_ptr as *mut #ident) };
+            let _state = unsafe { Box::from_raw(state_ptr as *mut #ident) };
         }
 
         /// Ask the matchmaker to process a new intent

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -124,12 +124,24 @@ pub fn validity_predicate(
     TokenStream::from(gen)
 }
 
-/// Generate WASM binding for matchmaker main entrypoint function.
+/// Derive dynamic library binding for a matchmaker implementation.
 ///
-/// This macro expects a function with signature:
+/// This macro requires that the data structure implements
+/// [`std::default::Default`] that is used to instantiate the matchmaker and
+/// `anoma::types::matchmaker::AddIntent` to implement a custom matchmaker
+/// algorithm.
+///
+/// # Examples
 ///
 /// ```compiler_fail
-/// fn match_intent(matchmaker_data:Vec<u8>, intent_id: Vec<u8>, intent: Vec<u8>) -> bool
+/// use anoma::types::matchmaker::AddIntent;
+/// use anoma_macros::Matchmaker;
+///
+/// #[derive(Default, Matchmaker)]
+/// struct Matchmaker;
+///
+/// impl AddIntent for Matchmaker {
+/// }
 /// ```
 #[proc_macro_derive(Matchmaker)]
 pub fn matchmaker(input: TokenStream) -> TokenStream {

--- a/tests/src/e2e/gossip_tests.rs
+++ b/tests/src/e2e/gossip_tests.rs
@@ -107,16 +107,7 @@ fn match_intents() -> Result<()> {
         .join("matchmaker")
         .join("mm_token_exch")
         .join("Cargo.toml");
-    let cmd = if !cfg!(feature = "ABCI") {
-        CargoBuild::new()
-            .manifest_path(manifest_path)
-            .no_default_features()
-            .features("ABCI-plus-plus")
-    } else {
-        CargoBuild::new()
-            .manifest_path(manifest_path)
-            .features("ABCI")
-    };
+    let cmd = CargoBuild::new().manifest_path(manifest_path);
     let cmd = if run_debug { cmd } else { cmd.release() };
     let msgs = cmd.exec().unwrap();
     for msg in msgs {

--- a/tests/src/e2e/gossip_tests.rs
+++ b/tests/src/e2e/gossip_tests.rs
@@ -195,9 +195,19 @@ fn match_intents() -> Result<()> {
         Some(40)
     )?;
 
-    // Wait gossip to start
-    session_gossip.exp_string("RPC started at 127.0.0.1:26660")?;
+    // The RPC port is either 26660 for ABCI or 26670 for ABCI++ (see
+    // `setup::network`)
+    let rpc_port = if cfg!(feature = "ABCI") {
+        "26660"
+    } else {
+        "26670"
+    };
+    let rpc_address = format!("127.0.0.1:{}", rpc_port);
 
+    // Wait gossip to start
+    session_gossip.exp_string(&format!("RPC started at {}", rpc_address))?;
+
+    let rpc_address = format!("http://{}", rpc_address);
     // cargo run --bin anomac -- intent --node "http://127.0.0.1:26660" --data-path intent.A --topic "asset_v1"
     // cargo run --bin anomac -- intent --node "http://127.0.0.1:26660" --data-path intent.B --topic "asset_v1"
     // cargo run --bin anomac -- intent --node "http://127.0.0.1:26660" --data-path intent.C --topic "asset_v1"
@@ -208,7 +218,7 @@ fn match_intents() -> Result<()> {
         &[
             "intent",
             "--node",
-            "http://127.0.0.1:26660",
+            &rpc_address,
             "--data-path",
             intent_a_path_input.to_str().unwrap(),
             "--topic",
@@ -235,7 +245,7 @@ fn match_intents() -> Result<()> {
         &[
             "intent",
             "--node",
-            "http://127.0.0.1:26660",
+            &rpc_address,
             "--data-path",
             intent_b_path_input.to_str().unwrap(),
             "--topic",
@@ -262,7 +272,7 @@ fn match_intents() -> Result<()> {
         &[
             "intent",
             "--node",
-            "http://127.0.0.1:26660",
+            &rpc_address,
             "--data-path",
             intent_c_path_input.to_str().unwrap(),
             "--topic",

--- a/tests/src/e2e/gossip_tests.rs
+++ b/tests/src/e2e/gossip_tests.rs
@@ -173,13 +173,15 @@ fn match_intents() -> Result<()> {
 
     let validator_one_rpc = get_actor_rpc(&test, &Who::Validator(0));
 
-    // The RPC port is either 26660 for ABCI or 26670 for ABCI++ (see
+    // The RPC port is either 27660 for ABCI or 28660 for ABCI++ (see
     // `setup::network`)
-    let rpc_port = if cfg!(feature = "ABCI") {
-        "26660"
-    } else {
-        "26670"
-    };
+    let rpc_port = (27660
+        + if cfg!(feature = "ABCI") {
+            0
+        } else {
+            setup::ABCI_PLUS_PLUS_PORT_OFFSET
+        })
+    .to_string();
     let rpc_address = format!("127.0.0.1:{}", rpc_port);
 
     // Start gossip
@@ -205,9 +207,6 @@ fn match_intents() -> Result<()> {
     session_gossip.exp_string(&format!("RPC started at {}", rpc_address))?;
 
     let rpc_address = format!("http://{}", rpc_address);
-    // cargo run --bin anomac -- intent --node "http://127.0.0.1:26660" --data-path intent.A --topic "asset_v1" --ledger-address ...
-    // cargo run --bin anomac -- intent --node "http://127.0.0.1:26660" --data-path intent.B --topic "asset_v1" --ledger-address ...
-    // cargo run --bin anomac -- intent --node "http://127.0.0.1:26660" --data-path intent.C --topic "asset_v1" --ledger-address ...
     //  Send intent A
     let mut session_send_intent_a = run!(
         test,

--- a/tests/src/e2e/helpers.rs
+++ b/tests/src/e2e/helpers.rs
@@ -5,11 +5,12 @@ use std::str::FromStr;
 use anoma::types::address::Address;
 use anoma::types::key::ed25519::Keypair;
 use anoma::types::storage::Epoch;
+use anoma_apps::config::{Config, TendermintMode};
 use color_eyre::eyre::Result;
 use eyre::eyre;
 
 use super::setup::Test;
-use crate::e2e::setup::Bin;
+use crate::e2e::setup::{Bin, Who};
 use crate::run;
 
 /// Find the address of an account by its alias from the wallet
@@ -30,6 +31,16 @@ pub fn find_address(test: &Test, alias: impl AsRef<str>) -> Result<Address> {
     })?;
     println!("Found {}", address);
     Ok(address)
+}
+
+pub fn get_actor_rpc(test: &Test, who: &Who) -> String {
+    let base_dir = test.get_base_dir(who);
+    let tendermint_mode = match who {
+        Who::NonValidator => TendermintMode::Full,
+        Who::Validator(_) => TendermintMode::Validator,
+    };
+    let config = Config::load(&base_dir, &test.net.chain_id, tendermint_mode);
+    config.ledger.tendermint.rpc_address.to_string()
 }
 
 /// Find the address of an account by its alias from the wallet
@@ -61,11 +72,21 @@ pub fn find_keypair(test: &Test, alias: impl AsRef<str>) -> Result<Keypair> {
 }
 
 /// Find the address of an account by its alias from the wallet
-pub fn find_voting_power(test: &Test, alias: impl AsRef<str>) -> Result<u64> {
+pub fn find_voting_power(
+    test: &Test,
+    alias: impl AsRef<str>,
+    ledger_address: &str,
+) -> Result<u64> {
     let mut find = run!(
         test,
         Bin::Client,
-        &["voting-power", "--validator", alias.as_ref()],
+        &[
+            "voting-power",
+            "--validator",
+            alias.as_ref(),
+            "--ledger-address",
+            ledger_address
+        ],
         Some(1)
     )?;
     let (unread, matched) = find.exp_regex("voting power: .*\n")?;
@@ -79,8 +100,13 @@ pub fn find_voting_power(test: &Test, alias: impl AsRef<str>) -> Result<u64> {
 }
 
 /// Get the last committed epoch.
-pub fn get_epoch(test: &Test) -> Result<Epoch> {
-    let mut find = run!(test, Bin::Client, &["epoch"], Some(5))?;
+pub fn get_epoch(test: &Test, ledger_address: &str) -> Result<Epoch> {
+    let mut find = run!(
+        test,
+        Bin::Client,
+        &["epoch", "--ledger-address", ledger_address],
+        Some(5)
+    )?;
     let (unread, matched) = find.exp_regex("Last committed epoch: .*\n")?;
     let epoch_str = matched.trim().rsplit_once(" ").unwrap().1;
     let epoch = u64::from_str(epoch_str).map_err(|e| {

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -73,7 +73,16 @@ pub fn add_validators(num: u8, mut genesis: GenesisConfig) -> GenesisConfig {
         validator.intent_gossip_seed = None;
         let mut net_address = net_address_0;
         // 5 ports for each validator
-        net_address.set_port(net_address_port_0 + 5 * (ix as u16 + 1));
+        let first_port = net_address_port_0
+            + 5 * (ix as u16 + 1)
+            + if cfg!(feature = "ABCI") {
+                0
+            } else {
+                // The ABCI++ ports at `26670 + ABCI_PLUS_PLUS_PORT_OFFSET`,
+                // see `network`
+                ABCI_PLUS_PLUS_PORT_OFFSET
+            };
+        net_address.set_port(first_port);
         validator.net_address = Some(net_address.to_string());
         let name = format!("validator-{}", ix + 1);
         genesis.validator.insert(name, validator);

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -42,6 +42,10 @@ pub struct Network {
     pub chain_id: ChainId,
 }
 
+/// Offset the ports used in the network configuration by 1000 for ABCI++ to
+/// avoid shared resources
+pub const ABCI_PLUS_PLUS_PORT_OFFSET: u16 = 1000;
+
 /// Add `num` validators to the genesis config. Note that called from inside
 /// the [`network`]'s first argument's closure, there is 1 validator already
 /// present to begin with, so e.g. `add_validators(1, _)` will configure a
@@ -101,17 +105,17 @@ pub fn network(
     );
 
     if !cfg!(feature = "ABCI") {
-        // For the ABCI++ feature, we set the port to be the current+10, to
-        // avoid using shared resources with ABCI feature if running at the same
-        // time.
+        // The ABCI ports start at `26670`, ABCI++ at `26670 +
+        // ABCI_PLUS_PLUS_PORT_OFFSET`to avoid using shared resources with ABCI
+        // feature if running at the same time.
         let validator_0 = genesis.validator.get_mut("validator-0").unwrap();
         let mut net_address_0 =
             SocketAddr::from_str(validator_0.net_address.as_ref().unwrap())
                 .unwrap();
         let current_port = net_address_0.port();
-        net_address_0.set_port(current_port + 10);
+        net_address_0.set_port(current_port + ABCI_PLUS_PLUS_PORT_OFFSET);
         validator_0.net_address = Some(net_address_0.to_string());
-    }
+    };
 
     // Run the provided function on it
     let genesis = update_genesis(genesis);

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -39,7 +39,7 @@ const SINGLE_NODE_NET_GENESIS: &str = "genesis/e2e-tests-single-node.toml";
 /// An E2E test network.
 #[derive(Debug)]
 pub struct Network {
-    chain_id: ChainId,
+    pub chain_id: ChainId,
 }
 
 /// Add `num` validators to the genesis config. Note that called from inside
@@ -177,6 +177,7 @@ pub fn network(
         working_dir,
         base_dir,
         net,
+        genesis,
     })
 }
 
@@ -193,6 +194,7 @@ pub struct Test {
     pub working_dir: PathBuf,
     pub base_dir: TempDir,
     pub net: Network,
+    pub genesis: GenesisConfig,
 }
 
 impl Drop for Test {
@@ -327,6 +329,11 @@ impl Test {
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
     {
+        let base_dir = self.get_base_dir(&who);
+        run_cmd(bin, args, timeout_sec, &self.working_dir, &base_dir, loc)
+    }
+
+    pub fn get_base_dir(&self, who: &Who) -> PathBuf {
         let base_dir = match who {
             Who::NonValidator => self.base_dir.path().to_owned(),
             Who::Validator(index) => self
@@ -337,7 +344,7 @@ impl Test {
                 .join(format!("validator-{}", index))
                 .join(config::DEFAULT_BASE_DIR),
         };
-        run_cmd(bin, args, timeout_sec, &self.working_dir, &base_dir, loc)
+        base_dir
     }
 }
 


### PR DESCRIPTION
This fixes the incorrect usage of `std::mem::forget` introduced in #746 by using `Box::into_raw` to get a raw point to matchmaker's state to allow for arbitrary matchmaker implementations. The `forget` call was causing issues that were only observed in release build.

Based on #799.