### PR TITLE
Handle connection errors in tower-abci

### DIFF
--- a/.changelog/unreleased/improvements/716-tower-error-handling.md
+++ b/.changelog/unreleased/improvements/716-tower-error-handling.md
@@ -1,0 +1,2 @@
+- Ledger: Handle spurious errors on user initiated shutdown.
+  ([#716](https://github.com/anoma/anoma/issues/716))


### PR DESCRIPTION
Closes #716 
Errors in tower now propagate rather than causing panic. If this happens on user shutdown, these spurious errors are suppressed

