### PR TITLE
pos: is_validator should not take mutable self

### DIFF
--- a/proof_of_stake/src/lib.rs
+++ b/proof_of_stake/src/lib.rs
@@ -250,7 +250,7 @@ pub trait PosActions: PosReadOnly {
 
     /// Check if the given address is a validator by checking that it has some
     /// state.
-    fn is_validator(&mut self, address: &Self::Address) -> bool {
+    fn is_validator(&self, address: &Self::Address) -> bool {
         self.read_validator_state(address).is_some()
     }
 


### PR DESCRIPTION
Based on 62397c8c82, but present since the initial revision of this
file. Caught in toolchain update by Yuji.