### PR TITLE
wallet: remove redundant clone()

### DIFF
--- a/apps/src/bin/anoma-wallet/cli.rs
+++ b/apps/src/bin/anoma-wallet/cli.rs
@@ -153,7 +153,7 @@ fn key_list(
 fn key_export(ctx: Context, args::KeyExport { alias }: args::KeyExport) {
     let mut wallet = ctx.wallet;
     wallet
-        .find_key(alias.clone().to_lowercase())
+        .find_key(alias.to_lowercase())
         .map(|keypair| {
             let file_data = keypair
                 .try_to_vec()

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -677,7 +677,7 @@ fn init_established_account(
     if config.address.is_none() {
         let address = address::gen_established_address("established");
         config.address = Some(address.to_string());
-        wallet.add_address(name.as_ref().to_string(), address);
+        wallet.add_address(&name, address);
     }
     if config.public_key.is_none() {
         println!("Generating established account {} key...", name.as_ref());

--- a/apps/src/lib/wallet/alias.rs
+++ b/apps/src/lib/wallet/alias.rs
@@ -1,0 +1,88 @@
+//! Wallet address and key aliases.
+
+use std::convert::Infallible;
+use std::fmt::Display;
+use std::hash::Hash;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+/// Aliases created from raw strings are kept in-memory as given, but their
+/// `Serialize` and `Display` instance converts them to lowercase. Their
+/// `PartialEq` instance is case-insensitive.
+#[derive(Clone, Debug, Default, Deserialize, PartialOrd, Ord, Eq)]
+#[serde(transparent)]
+pub struct Alias(String);
+
+impl Alias {
+    /// Normalize an alias to lower-case
+    pub fn normalize(&self) -> String {
+        self.0.to_lowercase()
+    }
+
+    /// Returns the length of the underlying `String`.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Is the underlying `String` empty?
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl Serialize for Alias {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.normalize().serialize(serializer)
+    }
+}
+
+impl PartialEq for Alias {
+    fn eq(&self, other: &Self) -> bool {
+        self.normalize() == other.normalize()
+    }
+}
+
+impl Hash for Alias {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.normalize().hash(state);
+    }
+}
+
+impl<T> From<T> for Alias
+where
+    T: AsRef<str>,
+{
+    fn from(raw: T) -> Self {
+        Self(raw.as_ref().to_owned())
+    }
+}
+
+impl From<Alias> for String {
+    fn from(alias: Alias) -> Self {
+        alias.normalize()
+    }
+}
+
+impl<'a> From<&'a Alias> for String {
+    fn from(alias: &'a Alias) -> Self {
+        alias.normalize()
+    }
+}
+
+impl Display for Alias {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.normalize().fmt(f)
+    }
+}
+
+impl FromStr for Alias {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.into()))
+    }
+}

--- a/apps/src/lib/wallet/defaults.rs
+++ b/apps/src/lib/wallet/defaults.rs
@@ -12,7 +12,7 @@ pub use dev::{
 };
 
 use crate::config::genesis::genesis_config::GenesisConfig;
-use crate::wallet::store::Alias;
+use crate::wallet::alias::Alias;
 
 /// The default addresses with their aliases.
 pub fn addresses_from_genesis(genesis: GenesisConfig) -> Vec<(Alias, Address)> {
@@ -25,14 +25,20 @@ pub fn addresses_from_genesis(genesis: GenesisConfig) -> Vec<(Alias, Address)> {
     let validator_addresses =
         genesis.validator.into_iter().map(|(alias, validator)| {
             // The address must be set in the genesis config file
-            (alias, Address::decode(validator.address.unwrap()).unwrap())
+            (
+                alias.into(),
+                Address::decode(validator.address.unwrap()).unwrap(),
+            )
         });
     addresses.extend(validator_addresses);
     // Genesis tokens
     if let Some(accounts) = genesis.token {
         let token_addresses = accounts.into_iter().map(|(alias, token)| {
             // The address must be set in the genesis config file
-            (alias, Address::decode(token.address.unwrap()).unwrap())
+            (
+                alias.into(),
+                Address::decode(token.address.unwrap()).unwrap(),
+            )
         });
         addresses.extend(token_addresses);
     }
@@ -41,7 +47,7 @@ pub fn addresses_from_genesis(genesis: GenesisConfig) -> Vec<(Alias, Address)> {
         let est_addresses = accounts.into_iter().map(|(alias, established)| {
             // The address must be set in the genesis config file
             (
-                alias,
+                alias.into(),
                 Address::decode(established.address.unwrap()).unwrap(),
             )
         });
@@ -55,7 +61,7 @@ pub fn addresses_from_genesis(genesis: GenesisConfig) -> Vec<(Alias, Address)> {
                 implicit.public_key.map(|pk| {
                     let pk: PublicKey = pk.to_public_key().unwrap();
                     let addr: Address = (&pk).into();
-                    (alias, addr)
+                    (alias.into(), addr)
                 })
             });
         addresses.extend(imp_addresses);
@@ -69,7 +75,7 @@ mod dev {
     use anoma::types::address::{self, Address};
     use anoma::types::key::ed25519::Keypair;
 
-    use crate::wallet::store::Alias;
+    use crate::wallet::alias::Alias;
 
     /// The default keys with their aliases.
     pub fn keys() -> Vec<(Alias, Keypair)> {
@@ -97,7 +103,7 @@ mod dev {
         ];
         let token_addresses = address::tokens()
             .into_iter()
-            .map(|(addr, alias)| (alias.to_owned(), addr));
+            .map(|(addr, alias)| (alias.into(), addr));
         addresses.extend(token_addresses);
         addresses
     }

--- a/apps/src/lib/wallet/defaults.rs
+++ b/apps/src/lib/wallet/defaults.rs
@@ -18,8 +18,8 @@ use crate::wallet::alias::Alias;
 pub fn addresses_from_genesis(genesis: GenesisConfig) -> Vec<(Alias, Address)> {
     // Internal addresses
     let mut addresses: Vec<(Alias, Address)> = vec![
-        ("PoS".into(), pos::ADDRESS),
-        ("PosSlashPool".into(), pos::SLASH_POOL_ADDRESS),
+        ("pos".into(), pos::ADDRESS),
+        ("pos_slash_pool".into(), pos::SLASH_POOL_ADDRESS),
     ];
     // Genesis validators
     let validator_addresses =
@@ -80,10 +80,10 @@ mod dev {
     /// The default keys with their aliases.
     pub fn keys() -> Vec<(Alias, Keypair)> {
         vec![
-            ("Albert".into(), albert_keypair()),
-            ("Bertha".into(), bertha_keypair()),
-            ("Christel".into(), christel_keypair()),
-            ("Daewon".into(), daewon_keypair()),
+            ("albert".into(), albert_keypair()),
+            ("bertha".into(), bertha_keypair()),
+            ("christel".into(), christel_keypair()),
+            ("daewon".into(), daewon_keypair()),
             ("matchmaker".into(), matchmaker_keypair()),
             ("validator".into(), validator_keypair()),
         ]
@@ -92,14 +92,14 @@ mod dev {
     /// The default addresses with their aliases.
     pub fn addresses() -> Vec<(Alias, Address)> {
         let mut addresses: Vec<(Alias, Address)> = vec![
-            ("PoS".into(), pos::ADDRESS),
-            ("PosSlashPool".into(), pos::SLASH_POOL_ADDRESS),
+            ("pos".into(), pos::ADDRESS),
+            ("pos_slash_pool".into(), pos::SLASH_POOL_ADDRESS),
             ("matchmaker".into(), matchmaker_address()),
             ("validator".into(), validator_address()),
-            ("Albert".into(), albert_address()),
-            ("Bertha".into(), bertha_address()),
-            ("Christel".into(), christel_address()),
-            ("Daewon".into(), daewon_address()),
+            ("albert".into(), albert_address()),
+            ("bertha".into(), bertha_address()),
+            ("christel".into(), christel_address()),
+            ("daewon".into(), daewon_address()),
         ];
         let token_addresses = address::tokens()
             .into_iter()

--- a/apps/src/lib/wallet/mod.rs
+++ b/apps/src/lib/wallet/mod.rs
@@ -1,3 +1,4 @@
+mod alias;
 pub mod defaults;
 mod keys;
 mod store;
@@ -12,8 +13,9 @@ use anoma::types::key::ed25519::{Keypair, PublicKey, PublicKeyHash};
 pub use store::wallet_file;
 use thiserror::Error;
 
+use self::alias::Alias;
 pub use self::keys::{DecryptionError, StoredKeypair};
-use self::store::{Alias, Store};
+use self::store::Store;
 use crate::cli;
 use crate::config::genesis::genesis_config::GenesisConfig;
 use crate::std::fs;
@@ -77,11 +79,12 @@ impl Wallet {
     }
 
     /// Generate a new keypair and derive an implicit address from its public
-    /// and insert them into the store with the provided alias, converter to
-    /// lower case. If none provided, the alias will be the public key hash.
-    /// If the key is to be encrypted, will prompt for password from stdin.
-    /// Stores the key in decrypted key cache and returns the alias of the key
-    /// and a reference-counting pointer to the key.
+    /// and insert them into the store with the provided alias, converted to
+    /// lower case. If none provided, the alias will be the public key hash (in
+    /// lowercase too). If the key is to be encrypted, will prompt for
+    /// password from stdin. Stores the key in decrypted key cache and
+    /// returns the alias of the key and a reference-counting pointer to the
+    /// key.
     pub fn gen_key(
         &mut self,
         alias: Option<String>,
@@ -109,7 +112,7 @@ impl Wallet {
         let (alias, key) = self.store.gen_key(alias, password);
         // Cache the newly added key
         self.decrypted_key_cache.insert(alias.clone(), key.clone());
-        (alias, key)
+        (alias.into(), key)
     }
 
     /// Find the stored key by an alias, a public key hash or a public key.
@@ -121,8 +124,9 @@ impl Wallet {
         alias_pkh_or_pk: impl AsRef<str>,
     ) -> Result<Rc<Keypair>, FindKeyError> {
         // Try cache first
-        if let Some(cached_key) =
-            self.decrypted_key_cache.get(alias_pkh_or_pk.as_ref())
+        if let Some(cached_key) = self
+            .decrypted_key_cache
+            .get(&alias_pkh_or_pk.as_ref().into())
         {
             return Ok(cached_key.clone());
         }
@@ -134,7 +138,7 @@ impl Wallet {
         Self::decrypt_stored_key(
             &mut self.decrypted_key_cache,
             stored_key,
-            alias_pkh_or_pk,
+            alias_pkh_or_pk.into(),
         )
     }
 
@@ -151,7 +155,7 @@ impl Wallet {
         let alias = self
             .store
             .find_alias_by_pkh(&pkh)
-            .unwrap_or_else(|| pkh.to_string());
+            .unwrap_or_else(|| pkh.to_string().into());
         // Try read cache
         if let Some(cached_key) = self.decrypted_key_cache.get(&alias) {
             return Ok(cached_key.clone());
@@ -180,7 +184,7 @@ impl Wallet {
         let alias = self
             .store
             .find_alias_by_pkh(pkh)
-            .unwrap_or_else(|| pkh.to_string());
+            .unwrap_or_else(|| pkh.to_string().into());
         // Try read cache
         if let Some(cached_key) = self.decrypted_key_cache.get(&alias) {
             return Ok(cached_key.clone());
@@ -201,9 +205,9 @@ impl Wallet {
     /// If a given storage key needs to be decrypted, prompt for password from
     /// stdin and if successfully decrypted, store it in a cache.
     fn decrypt_stored_key(
-        decrypted_key_cache: &mut HashMap<String, Rc<Keypair>>,
+        decrypted_key_cache: &mut HashMap<Alias, Rc<Keypair>>,
         stored_key: &StoredKeypair,
-        alias_pkh_or_pk: impl AsRef<str>,
+        alias: Alias,
     ) -> Result<Rc<Keypair>, FindKeyError> {
         match stored_key {
             StoredKeypair::Encrypted(encrypted) => {
@@ -211,7 +215,6 @@ impl Wallet {
                 let key = encrypted
                     .decrypt(password)
                     .map_err(FindKeyError::KeyDecryptionError)?;
-                let alias = alias_pkh_or_pk.as_ref().to_owned();
                 decrypted_key_cache.insert(alias.clone(), Rc::new(key));
                 decrypted_key_cache
                     .get(&alias)
@@ -225,8 +228,12 @@ impl Wallet {
     /// Get all known keys by their alias, paired with PKH, if known.
     pub fn get_keys(
         &self,
-    ) -> HashMap<Alias, (&StoredKeypair, Option<&PublicKeyHash>)> {
-        self.store.get_keys()
+    ) -> HashMap<String, (&StoredKeypair, Option<&PublicKeyHash>)> {
+        self.store
+            .get_keys()
+            .into_iter()
+            .map(|(alias, value)| (alias.into(), value))
+            .collect()
     }
 
     /// Find the stored address by an alias.
@@ -235,8 +242,12 @@ impl Wallet {
     }
 
     /// Get all known addresses by their alias, paired with PKH, if known.
-    pub fn get_addresses(&self) -> &HashMap<Alias, Address> {
-        self.store.get_addresses()
+    pub fn get_addresses(&self) -> HashMap<String, Address> {
+        self.store
+            .get_addresses()
+            .iter()
+            .map(|(alias, value)| (alias.into(), value.clone()))
+            .collect()
     }
 
     /// Add a new address with the given alias. If the alias is already used,
@@ -246,22 +257,25 @@ impl Wallet {
     /// nothing.
     pub fn add_address(
         &mut self,
-        alias: Alias,
+        alias: impl AsRef<str>,
         address: Address,
-    ) -> Option<Alias> {
-        self.store.insert_address(alias.to_lowercase(), address)
+    ) -> Option<String> {
+        self.store
+            .insert_address(alias.into(), address)
+            .map(Into::into)
     }
 
     /// Insert a new key with the given alias. If the alias is already used,
     /// will prompt for overwrite confirmation.
     pub fn insert_keypair(
         &mut self,
-        alias: Alias,
+        alias: String,
         keypair: StoredKeypair,
         pkh: PublicKeyHash,
-    ) -> Option<Alias> {
+    ) -> Option<String> {
         self.store
-            .insert_keypair(alias.to_lowercase(), keypair, pkh)
+            .insert_keypair(alias.into(), keypair, pkh)
+            .map(Into::into)
     }
 }
 

--- a/apps/src/lib/wallet/mod.rs
+++ b/apps/src/lib/wallet/mod.rs
@@ -77,10 +77,10 @@ impl Wallet {
     }
 
     /// Generate a new keypair and derive an implicit address from its public
-    /// and insert them into the store with the provided alias, converter to 
-    /// lower case. If none provided, the alias will be the public key hash. 
-    /// If the key is to be encrypted, will prompt for password from stdin. 
-    /// Stores the key in decrypted key cache and returns the alias of the key 
+    /// and insert them into the store with the provided alias, converter to
+    /// lower case. If none provided, the alias will be the public key hash.
+    /// If the key is to be encrypted, will prompt for password from stdin.
+    /// Stores the key in decrypted key cache and returns the alias of the key
     /// and a reference-counting pointer to the key.
     pub fn gen_key(
         &mut self,
@@ -260,7 +260,8 @@ impl Wallet {
         keypair: StoredKeypair,
         pkh: PublicKeyHash,
     ) -> Option<Alias> {
-        self.store.insert_keypair(alias.to_lowercase(), keypair, pkh)
+        self.store
+            .insert_keypair(alias.to_lowercase(), keypair, pkh)
     }
 }
 

--- a/apps/src/lib/wallet/store.rs
+++ b/apps/src/lib/wallet/store.rs
@@ -10,11 +10,10 @@ use anoma::types::key::ed25519::{Keypair, PublicKey, PublicKeyHash};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use super::alias::Alias;
 use super::keys::StoredKeypair;
 use crate::cli;
 use crate::config::genesis::genesis_config::GenesisConfig;
-
-pub type Alias = String;
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct Store {
@@ -155,7 +154,7 @@ impl Store {
         let alias_pkh_or_pk = alias_pkh_or_pk.as_ref();
         // Try to find by alias
         self.keys
-            .get(alias_pkh_or_pk)
+            .get(&alias_pkh_or_pk.into())
             // Try to find by PKH
             .or_else(|| {
                 let pkh = PublicKeyHash::from_str(alias_pkh_or_pk).ok()?;
@@ -190,7 +189,7 @@ impl Store {
 
     /// Find the stored address by an alias.
     pub fn find_address(&self, alias: impl AsRef<str>) -> Option<&Address> {
-        self.addresses.get(alias.as_ref())
+        self.addresses.get(&alias.into())
     }
 
     /// Get all known keys by their alias, paired with PKH, if known.
@@ -233,13 +232,13 @@ impl Store {
         &mut self,
         alias: Option<String>,
         password: Option<String>,
-    ) -> (String, Rc<Keypair>) {
+    ) -> (Alias, Rc<Keypair>) {
         let keypair = Self::generate_keypair();
         let pkh: PublicKeyHash = PublicKeyHash::from(&keypair.public);
         let (keypair_to_store, raw_keypair) =
             StoredKeypair::new(keypair, password);
         let address = Address::Implicit(ImplicitAddress::Ed25519(pkh.clone()));
-        let alias = alias.unwrap_or_else(|| pkh.clone().into()).to_lowercase();
+        let alias: Alias = alias.unwrap_or_else(|| pkh.clone().into()).into();
         if self
             .insert_keypair(alias.clone(), keypair_to_store, pkh)
             .is_none()
@@ -267,7 +266,7 @@ impl Store {
         if alias.is_empty() {
             println!(
                 "Empty alias given, defaulting to {}.",
-                alias = Into::<Alias>::into(pkh.clone())
+                alias = Into::<Alias>::into(pkh.to_string())
             );
         }
         if self.keys.contains_key(&alias) {
@@ -332,7 +331,7 @@ enum ConfirmationResponse {
 /// chosen alias to a name of their chosing, or cancel the aliasing.
 
 fn show_overwrite_confirmation(
-    alias: &str,
+    alias: &Alias,
     alias_for: &str,
 ) -> ConfirmationResponse {
     print!(
@@ -358,7 +357,7 @@ fn show_overwrite_confirmation(
                     io::stdout().flush().unwrap();
                     if io::stdin().read_line(&mut buffer).is_ok() {
                         return ConfirmationResponse::Reselect(
-                            buffer.trim().to_string(),
+                            buffer.trim().into(),
                         );
                     }
                 }

--- a/tests/src/e2e/wallet_tests.rs
+++ b/tests/src/e2e/wallet_tests.rs
@@ -43,7 +43,7 @@ fn wallet_encrypted_key_cmds() -> Result<()> {
     cmd.send_line(password)?;
     cmd.exp_string(&format!(
         "Successfully added a key and an address with alias: \"{}\"",
-        key_alias
+        key_alias.to_lowercase()
     ))?;
 
     // 2. key find
@@ -61,7 +61,10 @@ fn wallet_encrypted_key_cmds() -> Result<()> {
 
     // 3. key list
     let mut cmd = run!(test, Bin::Wallet, &["key", "list"], Some(20))?;
-    cmd.exp_string(&format!("Alias \"{}\" (encrypted):", key_alias))?;
+    cmd.exp_string(&format!(
+        "Alias \"{}\" (encrypted):",
+        key_alias.to_lowercase()
+    ))?;
 
     Ok(())
 }


### PR DESCRIPTION
The initial version of 'wallet: canonicalize all aliases to lowercase'
(ac3f0ba8e) was made against a less stringent clippy, and I failed
to check for new warnings when applying it. Rectify the redundant
clone warning.