### PR TITLE
client/utils: fix init-network Tendermint node ID derivation

### DIFF
--- a/.changelog/unreleased/bug-fixes/992-fix-tendermint-node-id.md
+++ b/.changelog/unreleased/bug-fixes/992-fix-tendermint-node-id.md
@@ -1,0 +1,2 @@
+- Client: Fix Tendermint node ID derivation from ed25519 keys in "utils init-
+  network" command ([#992](https://github.com/anoma/anoma/issues/992))

--- a/.changelog/unreleased/improvements/978-default-tendermint-mode.md
+++ b/.changelog/unreleased/improvements/978-default-tendermint-mode.md
@@ -1,0 +1,2 @@
+- Ledger: Use non-validator full node Tendermint mode by default.
+  ([#978](https://github.com/anoma/anoma/pull/978))

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -204,8 +204,8 @@ pub async fn join_network(
 /// Length of a Tendermint Node ID in bytes
 const TENDERMINT_NODE_ID_LENGTH: usize = 20;
 
-/// Derive node ID from public key
-fn id_from_pk<PK: PublicKey>(pk: PK) -> TendermintNodeId {
+/// Derive Tendermint node ID from public key
+fn id_from_pk(pk: &ed25519::PublicKey) -> TendermintNodeId {
     let digest = Sha256::digest(pk.try_to_vec().unwrap().as_slice());
     let mut bytes = [0u8; TENDERMINT_NODE_ID_LENGTH];
     bytes.copy_from_slice(&digest[..TENDERMINT_NODE_ID_LENGTH]);
@@ -280,31 +280,23 @@ pub fn init_network(
         let validator_dir = accounts_dir.join(name);
 
         // Generate a node key
-        let node_seckey: common::SecretKey =
-            ed25519::SigScheme::generate(&mut rng).try_to_sk().unwrap();
-        let node_pk: common::PublicKey = node_seckey.ref_to();
+        let node_sk = ed25519::SigScheme::generate(&mut rng);
+        let node_pk: ed25519::PublicKey = node_sk.ref_to();
 
         // Derive the node ID from the node key
-        let node_id: TendermintNodeId = id_from_pk(node_pk);
+        let node_id: TendermintNodeId = id_from_pk(&node_pk);
 
-        let tm_node_keypair_json =
-            ed25519::SecretKey::try_from_sk(&node_seckey)
-                .map(|sk| {
-                    // Convert and write the keypair into Tendermint
-                    // node_key.json file
-                    let node_keypair = [
-                        sk.try_to_vec().unwrap(),
-                        sk.ref_to().try_to_vec().unwrap(),
-                    ]
-                    .concat();
-                    json!({
-                        "priv_key": {
-                            "type": "tendermint/PrivKeyEd25519",
-                            "value": base64::encode(node_keypair),
-                        }
-                    })
-                })
-                .unwrap();
+        // Convert and write the keypair into Tendermint
+        // node_key.json file
+        let node_keypair =
+            [node_sk.try_to_vec().unwrap(), node_pk.try_to_vec().unwrap()]
+                .concat();
+        let tm_node_keypair_json = json!({
+            "priv_key": {
+                "type": "tendermint/PrivKeyEd25519",
+                "value": base64::encode(node_keypair),
+            }
+        });
         let chain_dir = validator_dir.join(&accounts_temp_dir);
         let tm_home_dir = chain_dir.join("tendermint");
         let tm_config_dir = tm_home_dir.join("config");

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -732,11 +732,7 @@ pub fn init_network(
     );
 
     // Update the ledger config persistent peers and save it
-    let mut config = Config::load(
-        &global_args.base_dir,
-        &chain_id,
-        Some(TendermintMode::Validator),
-    );
+    let mut config = Config::load(&global_args.base_dir, &chain_id, None);
     config.ledger.tendermint.p2p_persistent_peers = persistent_peers;
     config.ledger.tendermint.consensus_timeout_commit =
         consensus_timeout_commit;

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -737,6 +737,7 @@ pub fn init_network(
             .p2p_address
             .set_ip(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)));
     }
+    config.ledger.tendermint.p2p_addr_book_strict = !localhost;
     config.ledger.genesis_time = genesis.genesis_time.into();
     config.intent_gossiper.seed_peers = seed_peers;
     config

--- a/apps/src/lib/config/mod.rs
+++ b/apps/src/lib/config/mod.rs
@@ -120,6 +120,9 @@ pub struct Tendermint {
     pub p2p_pex: bool,
     /// Toggle to disable guard against peers connecting from the same IP
     pub p2p_allow_duplicate_ip: bool,
+    /// Set `true` for strict address routability rules
+    /// Set `false` for private or local networks
+    pub p2p_addr_book_strict: bool,
     /// How long we wait after committing a block, before starting on the new
     /// height
     pub consensus_timeout_commit: Timeout,
@@ -188,6 +191,7 @@ impl Ledger {
                 p2p_persistent_peers: vec![],
                 p2p_pex: true,
                 p2p_allow_duplicate_ip: false,
+                p2p_addr_book_strict: true,
                 consensus_timeout_commit: Timeout::from_str("1s").unwrap(),
                 tendermint_mode: mode,
                 instrumentation_prometheus: false,

--- a/apps/src/lib/config/mod.rs
+++ b/apps/src/lib/config/mod.rs
@@ -344,7 +344,7 @@ impl Config {
     ) -> Result<Self> {
         let file_path = Self::file_path(base_dir, chain_id);
         let file_name = file_path.to_str().expect("Expected UTF-8 file path");
-        let mode = mode.unwrap_or(TendermintMode::Validator);
+        let mode = mode.unwrap_or(TendermintMode::Full);
         if !file_path.exists() {
             return Self::generate(base_dir, chain_id, mode, true);
         };

--- a/apps/src/lib/node/ledger/tendermint_node.rs
+++ b/apps/src/lib/node/ledger/tendermint_node.rs
@@ -330,6 +330,7 @@ async fn update_tendermint_config(
     config.p2p.persistent_peers = tendermint_config.p2p_persistent_peers;
     config.p2p.pex = tendermint_config.p2p_pex;
     config.p2p.allow_duplicate_ip = tendermint_config.p2p_allow_duplicate_ip;
+    config.p2p.addr_book_strict = tendermint_config.p2p_addr_book_strict;
 
     // In "dev", only produce blocks when there are txs or when the AppHash
     // changes

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -59,6 +59,59 @@ fn run_ledger() -> Result<()> {
 }
 
 /// In this test we:
+/// 1. Run 2 genesis validator ledger nodes and 1 non-validator node
+/// 2. Submit a valid token transfer tx
+/// 3. Check that all the nodes processed the tx with the same result
+#[test]
+fn test_node_connectivity() -> Result<()> {
+    // Setup 2 genesis validator nodes
+    let test =
+        setup::network(|genesis| setup::add_validators(1, genesis), None)?;
+
+    // 1. Run 2 genesis validator ledger nodes and 1 non-validator node
+    let args = ["ledger"];
+    let mut validator_0 =
+        run_as!(test, Who::Validator(0), Bin::Node, args, Some(40))?;
+    let mut validator_1 =
+        run_as!(test, Who::Validator(1), Bin::Node, args, Some(40))?;
+    let mut non_validator =
+        run_as!(test, Who::NonValidator, Bin::Node, args, Some(40))?;
+
+    // 2. Submit a valid token transfer tx
+    let validator_one_rpc = get_actor_rpc(&test, &Who::Validator(0));
+    let tx_args = [
+        "transfer",
+        "--source",
+        BERTHA,
+        "--target",
+        ALBERT,
+        "--token",
+        XAN,
+        "--amount",
+        "10.1",
+        "--fee-amount",
+        "0",
+        "--gas-limit",
+        "0",
+        "--fee-token",
+        XAN,
+        "--ledger-address",
+        &validator_one_rpc,
+    ];
+    let mut client = run!(test, Bin::Client, tx_args, Some(40))?;
+    client.exp_string("Transaction is valid.")?;
+    client.assert_success();
+
+    // 3. Check that all the nodes processed the tx with the same result
+    let expected_result = "all VPs accepted apply_tx storage modification";
+    validator_0.exp_string(expected_result)?;
+    validator_1.exp_string(expected_result)?;
+    non_validator.exp_string(expected_result)?;
+
+    Ok(())
+}
+
+/// In this test we:
 /// 1. Start up the ledger
 /// 2. Kill the tendermint process
 /// 3. Check that the node detects this

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -148,6 +148,7 @@ pub fn network(
         "e2e-test",
         "--localhost",
         "--dont-archive",
+        "--allow-duplicate-ip",
         "--wasm-checksums-path",
         &checksums_path,
     ];


### PR DESCRIPTION
depends on #983 

Tendermint node ID should be derived from the standard 32-bytes encoding of ed25519 public key.

todo:
- [x] add a test case in e2e