### PR TITLE
Fix: do not replace hashed key when computing non-existence proof

### DIFF
--- a/shared/src/ledger/storage/merkle_tree.rs
+++ b/shared/src/ledger/storage/merkle_tree.rs
@@ -574,6 +574,7 @@ mod test {
         let pos_val = [2u8; 8].to_vec();
         tree.update(&pos_key, pos_val).unwrap();
         let pos_val2 = [3u8; 8].to_vec();
+        // to prevent the subtree from being empty after deletion
         tree.update(&pos_key2, pos_val2).unwrap();
 
         let specs = tree.proof_specs();

--- a/shared/src/ledger/storage/merkle_tree.rs
+++ b/shared/src/ledger/storage/merkle_tree.rs
@@ -610,10 +610,8 @@ mod test {
         // Check the base root
         assert_eq!(sub_root, tree.root().0);
 
-        // Delete the pos key
+        // Delete the pos key and verify non-existence proof for it
         tree.delete(&pos_key).unwrap();
-        assert!(tree.has_key(&ibc_key).unwrap());
-        assert!(!tree.has_key(&pos_key).unwrap());
 
         let nep = tree.get_non_existence_proof(&pos_key).unwrap();
         let subtree_nep = nep.ops.get(0).unwrap();
@@ -663,13 +661,13 @@ mod test {
             };
         let basetree_root =
             ics23::calculate_existence_root(&basetree_ics23_ep).unwrap();
-        let verify_basetree_res = ics23::verify_membership(
+        let basetree_verification_res = ics23::verify_membership(
             &basetree_ep_commitment_proof,
             specs.get(1).unwrap(),
             &basetree_root,
             store_type.to_string().as_bytes(),
             &subtree_root,
         );
-        assert!(verify_basetree_res);
+        assert!(basetree_verification_res);
     }
 }

--- a/shared/src/ledger/storage/merkle_tree.rs
+++ b/shared/src/ledger/storage/merkle_tree.rs
@@ -7,8 +7,7 @@ use std::str::FromStr;
 use borsh::{BorshDeserialize, BorshSerialize};
 use ics23::commitment_proof::Proof as Ics23Proof;
 use ics23::{
-    CommitmentProof, ExistenceProof, HashOp, LeafOp, LengthOp,
-    NonExistenceProof, ProofSpec,
+    CommitmentProof, ExistenceProof, HashOp, LeafOp, LengthOp, ProofSpec,
 };
 use prost::Message;
 use sha2::{Digest, Sha256};
@@ -273,18 +272,7 @@ impl<H: StorageHasher + Default> MerkleTree<H> {
         // Get a proof of the sub tree
         let hashed_sub_key = H::hash(&sub_key.to_string());
         let cp = subtree.non_membership_proof(&hashed_sub_key)?;
-        // Replace the key with the non-hashed key for the verification
-        let sub_proof = match cp.proof.expect("The proof should exist") {
-            Ics23Proof::Nonexist(nep) => CommitmentProof {
-                proof: Some(Ics23Proof::Nonexist(NonExistenceProof {
-                    key: sub_key.to_string().as_bytes().to_vec(),
-                    ..nep
-                })),
-            },
-            // the proof should have a NonExistenceProof
-            _ => unreachable!(),
-        };
-        self.get_proof(key, sub_proof)
+        self.get_proof(key, cp)
     }
 
     /// Get the Tendermint proof with the base proof

--- a/shared/src/ledger/storage/merkle_tree.rs
+++ b/shared/src/ledger/storage/merkle_tree.rs
@@ -567,11 +567,14 @@ mod test {
         let key_prefix: Key =
             Address::Internal(InternalAddress::PoS).to_db_key().into();
         let pos_key = key_prefix.push(&"test".to_string()).unwrap();
+        let pos_key2 = key_prefix.push(&"test2".to_string()).unwrap();
 
         let ibc_val = [1u8; 8].to_vec();
         tree.update(&ibc_key, ibc_val.clone()).unwrap();
         let pos_val = [2u8; 8].to_vec();
         tree.update(&pos_key, pos_val).unwrap();
+        let pos_val2 = [3u8; 8].to_vec();
+        tree.update(&pos_key2, pos_val2).unwrap();
 
         let specs = tree.proof_specs();
         let proof =
@@ -605,5 +608,67 @@ mod test {
         }
         // Check the base root
         assert_eq!(sub_root, tree.root().0);
+
+        // Delete the pos key
+        tree.delete(&pos_key).unwrap();
+        assert!(tree.has_key(&ibc_key).unwrap());
+        assert!(!tree.has_key(&pos_key).unwrap());
+
+        let nep = tree.get_non_existence_proof(&pos_key).unwrap();
+        let subtree_nep = nep.ops.get(0).unwrap();
+        let nep_commitment_proof =
+            CommitmentProof::decode(&*subtree_nep.data).unwrap();
+        let non_existence_proof =
+            match nep_commitment_proof.clone().proof.unwrap() {
+                Ics23Proof::Nonexist(nep) => nep,
+                _ => unreachable!(),
+            };
+        let subtree_root = if let Some(left) = &non_existence_proof.left {
+            ics23::calculate_existence_root(left).unwrap()
+        } else if let Some(right) = &non_existence_proof.right {
+            ics23::calculate_existence_root(right).unwrap()
+        } else {
+            unreachable!()
+        };
+        let (store_type, sub_key) = StoreType::sub_key(&pos_key).unwrap();
+
+        let subtree_spec = specs.get(0).unwrap();
+        let leaf_spec = Some(LeafOp {
+            hash: Sha256Hasher::hash_op().into(),
+            prehash_key: HashOp::NoHash.into(),
+            prehash_value: HashOp::NoHash.into(),
+            length: LengthOp::NoPrefix.into(),
+            prefix: H256::zero().as_slice().to_vec(),
+        });
+        let subtree_spec = ProofSpec {
+            leaf_spec,
+            ..subtree_spec.clone()
+        };
+        let nep_verification_res = ics23::verify_non_membership(
+            &nep_commitment_proof,
+            &subtree_spec,
+            &subtree_root,
+            sub_key.to_string().as_bytes(),
+        );
+        assert!(nep_verification_res);
+
+        let basetree_ep = nep.ops.get(1).unwrap();
+        let basetree_ep_commitment_proof =
+            CommitmentProof::decode(&*basetree_ep.data).unwrap();
+        let basetree_ics23_ep =
+            match basetree_ep_commitment_proof.clone().proof.unwrap() {
+                Ics23Proof::Exist(ep) => ep,
+                _ => unreachable!(),
+            };
+        let basetree_root =
+            ics23::calculate_existence_root(&basetree_ics23_ep).unwrap();
+        let verify_basetree_res = ics23::verify_membership(
+            &basetree_ep_commitment_proof,
+            specs.get(1).unwrap(),
+            &basetree_root,
+            store_type.to_string().as_bytes(),
+            &subtree_root,
+        );
+        assert!(verify_basetree_res);
     }
 }


### PR DESCRIPTION
Add non-existence proof verification test.