### PR TITLE
docs.anoma.network should show latest master docs by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="sidebar-visible no-js light">
 
 <head>
-    <meta http-equiv="refresh" content="0; URL=https://docs.anoma.network/v0.5.0">
+    <meta http-equiv="refresh" content="0; URL=https://docs.anoma.network/master">
 </head>
 
 <body>


### PR DESCRIPTION
Closes #1031

I couldn't find a premade mdbook version picker unfortunately

Tested locally by doing `python3 -m http.server` in the root directory and then going to http://localhost:8000, it redirected to latest docs.