### PR TITLE
`anomac utils join-network` should error if downloading file gives 404

### DIFF
--- a/.changelog/unreleased/improvements/1044-download-file.md
+++ b/.changelog/unreleased/improvements/1044-download-file.md
@@ -1,0 +1,2 @@
+- Show an error when calling `anomac utils join-network` if trying to download a
+  file and it is missing ([#1044](https://github.com/anoma/anoma/pull/1044))

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
+use std::io::Write;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -91,7 +91,6 @@ pub async fn join_network(
     let release_filename = format!("{}.tar.gz", chain_id);
     let release_url =
         format!("{}/{}/{}", RELEASE_PREFIX, chain_id, release_filename);
-    let cwd = env::current_dir().unwrap();
 
     // Read or download the release archive
     println!("Downloading config release from {} ...", release_url);
@@ -104,13 +103,12 @@ pub async fn join_network(
     };
 
     // Decode and unpack the archive
-    let mut decoder = GzDecoder::new(&release[..]);
-    let mut tar = String::new();
-    decoder.read_to_string(&mut tar).unwrap();
-    let mut archive = tar::Archive::new(tar.as_bytes());
+    let decoder = GzDecoder::new(&release[..]);
+    let mut archive = tar::Archive::new(decoder);
 
     // If the base-dir is non-default, unpack the archive into a temp dir inside
     // first.
+    let cwd = env::current_dir().unwrap();
     let (unpack_dir, non_default_dir) =
         if base_dir_full != cwd.join(config::DEFAULT_BASE_DIR) {
             (base_dir.clone(), true)

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -13,6 +13,7 @@ use borsh::BorshSerialize;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
+use prost::bytes::Bytes;
 use rand::prelude::ThreadRng;
 use rand::thread_rng;
 use serde_json::json;
@@ -976,10 +977,10 @@ fn init_genesis_validator_aux(
     genesis_validator
 }
 
-async fn download_file(url: impl AsRef<str>) -> reqwest::Result<Vec<u8>> {
+async fn download_file(url: impl AsRef<str>) -> reqwest::Result<Bytes> {
     let url = url.as_ref();
     let response = reqwest::get(url).await?;
     response.error_for_status_ref()?;
     let contents = response.bytes().await?;
-    Ok(contents.to_vec())
+    Ok(contents)
 }


### PR DESCRIPTION
Before, download_file() would return the contents of the response body even in the case of HTTP 404.

Some other refactoring as well, comments on diff.

Basing off of this for branch for https://github.com/anoma/anoma/issues/1035