### PR TITLE
Install MASP params as part of `anomac utils join-network`

### DIFF
--- a/.changelog/unreleased/improvements/1044-download-file.md
+++ b/.changelog/unreleased/improvements/1044-download-file.md
@@ -1,0 +1,2 @@
+- Show an error when calling `anomac utils join-network` if trying to download a
+  file and it is missing ([#1044](https://github.com/anoma/anoma/pull/1044))

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -43,7 +43,7 @@ use crate::wasm_loader;
 pub const NET_ACCOUNTS_DIR: &str = "setup";
 pub const NET_OTHER_ACCOUNTS_DIR: &str = "other";
 /// Github URL prefix of released Anoma network configs
-const DEFAULT_RELEASES_SERVER: &str = "http://localhost:8000";
+const DEFAULT_RELEASES_SERVER: &str = "https://github.com/heliaxdev/anoma-network-config/releases/download";
 
 const MASP_PARAMS_ARCHIVE_FILENAME: &str = "masp-params.tar.gz";
 const MASP_PARAMS_ARCHIVE_INNER_DIR: &str = ".masp-params";
@@ -119,7 +119,7 @@ pub async fn join_network(
     // MASP params may not be present for every release
     let masp_url = masp_params_tgz_url(DEFAULT_RELEASES_SERVER, &chain_id);
     if not_found(&masp_url).await.unwrap() {
-        println!("No MASP params found for this release.")
+        println!("Not downloading MASP params for this release as none were found at {}", masp_url);
     } else {
         println!("Downloading MASP params from {} ...", masp_url);
         download_and_unpack(&masp_url, &unpack_dir).await.unwrap();

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -45,10 +45,14 @@ pub const NET_OTHER_ACCOUNTS_DIR: &str = "other";
 /// Github URL prefix of released Anoma network configs
 const DEFAULT_RELEASES_SERVER: &str = "http://localhost:8000";
 
+const MASP_PARAMS_ARCHIVE_FILENAME: &str = "masp-params.tar.gz";
+const MASP_PARAMS_ARCHIVE_INNER_DIR: &str = ".masp-params";
+const CHAIN_MASP_PARAMS_DIR: &str = "masp";
+
 fn release_asset_urls(base_url: &str, chain_id: &ChainId) -> [String; 2] {
     [
         format!("{}/{}/{}.tar.gz", base_url, chain_id, chain_id),
-        format!("{}/{}/masp-params.tar.gz", base_url, chain_id)
+        format!("{}/{}/{}", base_url, chain_id, MASP_PARAMS_ARCHIVE_FILENAME)
     ]
 }
 
@@ -171,8 +175,8 @@ pub async fn join_network(
 
     // Move the MASP params
     fs::rename(
-        unpack_dir.join(".masp-params"),
-        base_dir_full.join(chain_id.as_str()).join("masp"),
+        unpack_dir.join(MASP_PARAMS_ARCHIVE_INNER_DIR),
+        base_dir_full.join(chain_id.as_str()).join(CHAIN_MASP_PARAMS_DIR),
     )
     .await
     .unwrap();

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -1004,14 +1004,8 @@ async fn download_and_unpack(url: String, unpack_dir: &Path) -> eyre::Result<()>
     let contents = download_file(url).await?;
     println!("Downloaded {} bytes", contents.len());
 
-    // Decode and unpack the archive
     let decoder = GzDecoder::new(&contents[..]);
-    let mut buf = vec![];
-    for byte in decoder.bytes() {
-        buf.push(byte?);
-    }
-
-    let mut archive = tar::Archive::new(buf.as_slice());
+    let mut archive = tar::Archive::new(decoder);
     archive.unpack(unpack_dir).wrap_err("Couldn't unpack")
 }
 

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -48,7 +48,6 @@ const DEFAULT_RELEASES_SERVER: &str =
 
 const MASP_PARAMS_ARCHIVE_FILENAME: &str = "masp-params.tar.gz";
 const MASP_PARAMS_ARCHIVE_INNER_DIR: &str = ".masp-params";
-const CHAIN_MASP_PARAMS_DIR: &str = "masp";
 
 fn chain_tgz_url(base_url: &str, chain_id: &ChainId) -> String {
     format!("{}/{}/{}.tar.gz", base_url, chain_id, chain_id)
@@ -130,9 +129,9 @@ pub async fn join_network(
         download_and_unpack(&masp_url, &unpack_dir).await.unwrap();
         fs::rename(
             unpack_dir.join(MASP_PARAMS_ARCHIVE_INNER_DIR),
-            base_dir_full
-                .join(chain_id.as_str())
-                .join(CHAIN_MASP_PARAMS_DIR),
+            anoma::masp::ParamsDirectory::for_chain_directory(
+                base_dir_full.join(chain_id.as_str()),
+            ),
         )
         .await
         .unwrap();

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -43,7 +43,8 @@ use crate::wasm_loader;
 pub const NET_ACCOUNTS_DIR: &str = "setup";
 pub const NET_OTHER_ACCOUNTS_DIR: &str = "other";
 /// Github URL prefix of released Anoma network configs
-const DEFAULT_RELEASES_SERVER: &str = "https://github.com/heliaxdev/anoma-network-config/releases/download";
+const DEFAULT_RELEASES_SERVER: &str =
+    "https://github.com/heliaxdev/anoma-network-config/releases/download";
 
 const MASP_PARAMS_ARCHIVE_FILENAME: &str = "masp-params.tar.gz";
 const MASP_PARAMS_ARCHIVE_INNER_DIR: &str = ".masp-params";
@@ -119,7 +120,11 @@ pub async fn join_network(
     // MASP params may not be present for every release
     let masp_url = masp_params_tgz_url(DEFAULT_RELEASES_SERVER, &chain_id);
     if not_found(&masp_url).await.unwrap() {
-        println!("Not downloading MASP params for this release as none were found at {}", masp_url);
+        println!(
+            "Not downloading MASP params for this release as none were found \
+             at {}",
+            masp_url
+        );
     } else {
         println!("Downloading MASP params from {} ...", masp_url);
         download_and_unpack(&masp_url, &unpack_dir).await.unwrap();

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
+use std::io::Write;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -14,7 +14,6 @@ use eyre::WrapErr;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
-use itertools::Itertools;
 use prost::bytes::Bytes;
 use rand::prelude::ThreadRng;
 use rand::thread_rng;
@@ -44,8 +43,7 @@ use crate::wasm_loader;
 pub const NET_ACCOUNTS_DIR: &str = "setup";
 pub const NET_OTHER_ACCOUNTS_DIR: &str = "other";
 /// Github URL prefix of released Anoma network configs
-const DEFAULT_RELEASES_SERVER: &str =
-    "http://localhost:8000";
+const DEFAULT_RELEASES_SERVER: &str = "http://localhost:8000";
 
 /// Server serving release assets for Anoma chains
 struct ReleasesServer {
@@ -129,7 +127,9 @@ pub async fn join_network(
 
     let masp_params_tgz_url = server.masp_params_tgz_url(&chain_id);
     println!("Downloading MASP params from {} ...", masp_params_tgz_url);
-    if let Err(error) = download_and_unpack(masp_params_tgz_url, &unpack_dir).await {
+    if let Err(error) =
+        download_and_unpack(masp_params_tgz_url, &unpack_dir).await
+    {
         eprintln!("Couldn't download: {}", error);
         cli::safe_exit(1);
     };
@@ -1000,7 +1000,10 @@ fn init_genesis_validator_aux(
     genesis_validator
 }
 
-async fn download_and_unpack(url: impl AsRef<str>, unpack_dir: &Path) -> eyre::Result<()> {
+async fn download_and_unpack(
+    url: impl AsRef<str>,
+    unpack_dir: &Path,
+) -> eyre::Result<()> {
     let contents = download(url).await?;
     println!("Downloaded {} bytes", contents.len());
     gunzip(&contents[..], unpack_dir).wrap_err("Couldn't unpack")

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -13,6 +13,7 @@ use borsh::BorshSerialize;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
+use prost::bytes::Bytes;
 use rand::prelude::ThreadRng;
 use rand::thread_rng;
 use serde_json::json;
@@ -976,10 +977,10 @@ fn init_genesis_validator_aux(
     genesis_validator
 }
 
-async fn download_file(url: impl AsRef<str>) -> reqwest::Result<Vec<u8>> {
+async fn download_file(url: impl AsRef<str>) -> reqwest::Result<Bytes> {
     let url = url.as_ref();
     let response = reqwest::get(url).await?;
     response.error_for_status_ref()?;
     let contents = response.bytes().await?;
-    Ok(contents.to_vec())
+    Ok(contents)
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -25,10 +25,10 @@ pub use tendermint_stable as tendermint;
 
 pub mod bytes;
 pub mod ledger;
+pub mod masp;
 pub mod proto;
 pub mod types;
 pub mod vm;
-pub mod masp;
 
 #[cfg(test)]
 #[macro_use]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -28,6 +28,7 @@ pub mod ledger;
 pub mod proto;
 pub mod types;
 pub mod vm;
+pub mod masp;
 
 #[cfg(test)]
 #[macro_use]

--- a/shared/src/masp/mod.rs
+++ b/shared/src/masp/mod.rs
@@ -1,0 +1,26 @@
+use std::path::{Path, PathBuf};
+use crate::types::chain::ChainId;
+
+pub struct ParamsDirectory {
+    pub path: PathBuf,
+}
+
+impl ParamsDirectory {
+    pub fn for_chain_directory(chain_dir: impl AsRef<Path>) -> Self {
+        ParamsDirectory { path: chain_dir.as_ref().join("masp") }
+    }
+
+    pub fn spend_path(&self) -> PathBuf {
+        (&self).path.join("masp-spend.params")
+    }
+
+    pub fn output_path(&self) -> PathBuf {
+        (&self).path.join("masp-output.params")
+    }
+}
+
+impl AsRef<Path> for ParamsDirectory {
+    fn as_ref(&self) -> &Path {
+        return &self.path;
+    }
+}

--- a/shared/src/masp/mod.rs
+++ b/shared/src/masp/mod.rs
@@ -1,26 +1,35 @@
+//! Helpers for using MASP
 use std::path::{Path, PathBuf};
-use crate::types::chain::ChainId;
 
+/// Represents a directory containing MASP parameters e.g.
+/// `~/Library/Application Support/MASPParams/`
 pub struct ParamsDirectory {
+    /// The actual path to the directory
     pub path: PathBuf,
 }
 
 impl ParamsDirectory {
+    /// Returns the MASP parameters directory for a given chain directory e.g.
+    /// `.anoma/anoma-masp-0.3.51d2f83a8412b95/masp/`
     pub fn for_chain_directory(chain_dir: impl AsRef<Path>) -> Self {
-        ParamsDirectory { path: chain_dir.as_ref().join("masp") }
+        ParamsDirectory {
+            path: chain_dir.as_ref().join("masp"),
+        }
     }
 
+    /// Returns the path to the spend parameters
     pub fn spend_path(&self) -> PathBuf {
-        (&self).path.join("masp-spend.params")
+        self.path.join("masp-spend.params")
     }
 
+    /// Returns the path to the output parameters
     pub fn output_path(&self) -> PathBuf {
-        (&self).path.join("masp-output.params")
+        self.path.join("masp-output.params")
     }
 }
 
 impl AsRef<Path> for ParamsDirectory {
     fn as_ref(&self) -> &Path {
-        return &self.path;
+        &self.path
     }
 }


### PR DESCRIPTION
Closes #1035

(based off of/depends on PR https://github.com/anoma/anoma/pull/1044)

This PR makes `anomac utils join-network` download MASP params from a GitHub release (e.g. `https://github.com/heliaxdev/anoma-network-config/releases/download/anoma-masp-0.3.51d2f83a8412b95/masp-params.tar.gz` once the params are uploaded there), then install them to a `masp/` directory in the chain directory e.g. `.anoma/anoma-masp-0.3.51d2f83a8412b95/masp/`. If there are no MASP params for a GitHub release, it should work similarly to before.

```shell
$ anomac utils join-network --chain-id anoma-masp-0.3.51d2f83a8412b95
Downloading config release from https://github.com/heliaxdev/anoma-network-config/releases/download/anoma-masp-0.3.51d2f83a8412b95/anoma-masp-0.3.51d2f83a8412b95.tar.gz ...
Not downloading MASP params for this release as none were found at https://github.com/heliaxdev/anoma-network-config/releases/download/anoma-masp-0.3.51d2f83a8412b95/masp-params.tar.gz
Successfully configured for chain ID anoma-masp-0.3.51d2f83a8412b95
```

After this is merged, will still need to update `internal/testnet-n1` to use the `.anoma/<chain-id>/masp` directory rather than the default `MASPParams`/`.masp-params` directories.

## Testing
Started a server in a directory like below using `python3 -m http.server` and set `const DEFAULT_RELEASES_SERVER` to "http://localhost:8000" instead of the normal GitHub releases URL.

```
mbp> tree
Permissions Size User Date Modified Name
drwxr-xr-x     - main 13 Apr 14:38  .
drwxr-xr-x     - main 12 Apr 09:44  ├── anoma-devnet-3.5.64c17effa6be4
.rw-r--r--@ 4.6k main 12 Apr 09:44  │  └── anoma-devnet-3.5.64c17effa6be4.tar.gz
drwxr-xr-x     - main 13 Apr 14:38  ├── anoma-masp-0.3.51d2f83a8412b95
.rw-r--r--@ 4.8k main 12 Apr 09:45  │  ├── anoma-masp-0.3.51d2f83a8412b95.tar.gz
.rw-r--r--@  63M main 11 Apr 18:11  │  └── masp-params.tar.gz
```

Run commands like:

```shell
trash .anoma; anoma client utils join-network --chain-id anoma-devnet-3.5.64c17effa6be4
trash .anoma; anoma client utils join-network --chain-id anoma-masp-0.3.51d2f83a8412b95
```

Inspect the generated `.anoma/` directory to see that things extracted correctly.

```
mbp> tree .anoma                                                                            
Permissions Size User Date Modified Name
drwxr-xr-x     - main 13 Apr 14:48  .anoma
drwxr-xr-x     - main 13 Apr 14:49  ├── anoma-masp-0.3.51d2f83a8412b95
.rw-rw-r--  1.2k main 29 Mar 14:36  │  ├── config.toml
drwxr-xr-x     - main 13 Apr 14:49  │  ├── masp
.rw-r--r--   15M main 24 Mar 08:25  │  │  ├── masp-output.params
.rw-r--r--   48M main 24 Mar 08:25  │  │  └── masp-spend.params
drwxr-xr-x     - main 13 Apr 14:48  │  └── wasm
.rw-rw-r--  1.8k main 29 Mar 12:57  │     └── checksums.json
.rw-rw-r--  7.8k main 29 Mar 14:36  ├── anoma-masp-0.3.51d2f83a8412b95.toml
.rw-rw-r--    52 main 29 Mar 14:36  └── global-config.toml
```
