### PR TITLE
Fix loading of genesis validator VP

### DIFF
--- a/apps/src/lib/node/ledger/shell/init_chain.rs
+++ b/apps/src/lib/node/ledger/shell/init_chain.rs
@@ -187,15 +187,10 @@ where
             let vp_code = vp_code_cache.get_or_insert_with(
                 validator.validator_vp_code_path.clone(),
                 || {
-                    std::fs::read(
-                        self.wasm_dir.join(&validator.validator_vp_code_path),
+                    wasm_loader::read_wasm(
+                        &self.wasm_dir,
+                        &validator.validator_vp_code_path,
                     )
-                    .unwrap_or_else(|_| {
-                        panic!(
-                            "cannot load genesis VP {}.",
-                            validator.validator_vp_code_path
-                        )
-                    })
                 },
             );
 


### PR DESCRIPTION
Before, it was trying to load e.g. `vp_user.wasm` instead of `vp_user.<hash>.wasm`.