### PR TITLE
Use the chain-specific directory for MASP params

### DIFF
--- a/apps/src/lib/client/tx.rs
+++ b/apps/src/lib/client/tx.rs
@@ -686,11 +686,10 @@ async fn gen_shielded_transfer(
     }
     let params_dir = ctx.global_args.base_dir
         .join(&ctx.global_args.chain_id.to_owned().unwrap().as_str())
-        .join("masp");  // TODO: this should be a constant
+        .join("masp");
     let spend_path = params_dir.join("masp-spend.params");
     let output_path = params_dir.join("masp-output.params");
     if !(spend_path.exists() && output_path.exists()) {
-        // TODO: return an Err(...) of some kind (Result return type of this fn may need to be changed)
         panic!("Couldn't find MASP parameters in {}", params_dir.to_string_lossy());
     }
     // Build and return the constructed transaction

--- a/apps/src/lib/client/tx.rs
+++ b/apps/src/lib/client/tx.rs
@@ -686,7 +686,7 @@ async fn gen_shielded_transfer(
     }
     let chain_dir = ctx.global_args.base_dir
         .join(&ctx.global_config.default_chain_id.as_str());
-    let params_dir = anoma::masp::ParamsDirectory { path: chain_dir };
+    let params_dir = anoma::masp::ParamsDirectory::for_chain_directory(chain_dir);
     let spend_path = params_dir.spend_path();
     let output_path = params_dir.output_path();
     if !(spend_path.exists() && output_path.exists()) {

--- a/apps/src/lib/client/tx.rs
+++ b/apps/src/lib/client/tx.rs
@@ -684,13 +684,13 @@ async fn gen_shielded_transfer(
             amt
         )?;
     }
-    let params_dir = ctx.global_args.base_dir
-        .join(&ctx.global_config.default_chain_id.as_str())
-        .join("masp");
-    let spend_path = params_dir.join("masp-spend.params");
-    let output_path = params_dir.join("masp-output.params");
+    let chain_dir = ctx.global_args.base_dir
+        .join(&ctx.global_config.default_chain_id.as_str());
+    let params_dir = anoma::masp::ParamsDirectory(chain_dir);
+    let spend_path = params_dir.spend_path();
+    let output_path = params_dir.output_path();
     if !(spend_path.exists() && output_path.exists()) {
-        panic!("Couldn't find MASP parameters in {}", params_dir.to_string_lossy());
+        panic!("Couldn't find MASP parameters in {}", params_dir.0.to_string_lossy());
     }
     // Build and return the constructed transaction
     builder.build(

--- a/apps/src/lib/client/tx.rs
+++ b/apps/src/lib/client/tx.rs
@@ -686,11 +686,11 @@ async fn gen_shielded_transfer(
     }
     let chain_dir = ctx.global_args.base_dir
         .join(&ctx.global_config.default_chain_id.as_str());
-    let params_dir = anoma::masp::ParamsDirectory(chain_dir);
+    let params_dir = anoma::masp::ParamsDirectory { path: chain_dir };
     let spend_path = params_dir.spend_path();
     let output_path = params_dir.output_path();
     if !(spend_path.exists() && output_path.exists()) {
-        panic!("Couldn't find MASP parameters in {}", params_dir.0.to_string_lossy());
+        panic!("Couldn't find MASP parameters in {}", params_dir.path.to_string_lossy());
     }
     // Build and return the constructed transaction
     builder.build(

--- a/apps/src/lib/client/tx.rs
+++ b/apps/src/lib/client/tx.rs
@@ -685,7 +685,7 @@ async fn gen_shielded_transfer(
         )?;
     }
     let params_dir = ctx.global_args.base_dir
-        .join(&ctx.global_args.chain_id.to_owned().unwrap().as_str())
+        .join(&ctx.global_config.default_chain_id.as_str())
         .join("masp");
     let spend_path = params_dir.join("masp-spend.params");
     let output_path = params_dir.join("masp-output.params");

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -970,13 +970,6 @@ fn init_genesis_validator_aux(
     genesis_validator
 }
 
-pub fn download_params() {
-    masp_proofs::download_parameters().unwrap_or_else(|err| {
-        eprintln!("Failed to download MASP parameters: {}", err);
-        cli::safe_exit(1)
-    });
-}
-
 async fn download_file(url: impl AsRef<str>) -> Vec<u8> {
     let url = url.as_ref();
     reqwest::get(url)

--- a/shared/src/ledger/masp.rs
+++ b/shared/src/ledger/masp.rs
@@ -74,7 +74,7 @@ pub fn verify_shielded_tx(transaction: &Transaction) -> bool {
     let mut ctx = SaplingVerificationContext::new();
     let tx_data = transaction.deref();
 
-    let params_dir = crate::masp::ParamsDirectory(masp_proofs::default_params_folder().unwrap());
+    let params_dir = crate::masp::ParamsDirectory { path: masp_proofs::default_params_folder().unwrap() };
     let (_, spend_pvk) = load_params(params_dir.spend_path());
     let (_, output_pvk) = load_params(params_dir.output_path());
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -25,10 +25,10 @@ pub use tendermint_stable as tendermint;
 
 pub mod bytes;
 pub mod ledger;
+pub mod masp;
 pub mod proto;
 pub mod types;
 pub mod vm;
-pub mod masp;
 
 #[cfg(test)]
 #[macro_use]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -28,6 +28,7 @@ pub mod ledger;
 pub mod proto;
 pub mod types;
 pub mod vm;
+pub mod masp;
 
 #[cfg(test)]
 #[macro_use]

--- a/shared/src/masp/mod.rs
+++ b/shared/src/masp/mod.rs
@@ -1,0 +1,18 @@
+use std::path::{Path, PathBuf};
+use crate::types::chain::ChainId;
+
+pub struct ParamsDirectory(pub PathBuf);
+
+impl ParamsDirectory {
+    pub fn from_chain_directory(chain_dir: impl AsRef<Path>) -> Self {
+        ParamsDirectory(chain_dir.as_ref().join("masp"))
+    }
+
+    pub fn spend_path(&self) -> PathBuf {
+        (&self).0.join("masp-spend.params")
+    }
+
+    pub fn output_path(&self) -> PathBuf {
+        (&self).0.join("masp-output.params")
+    }
+}

--- a/shared/src/masp/mod.rs
+++ b/shared/src/masp/mod.rs
@@ -6,7 +6,7 @@ pub struct ParamsDirectory {
 }
 
 impl ParamsDirectory {
-    pub fn from_chain_directory(chain_dir: impl AsRef<Path>) -> Self {
+    pub fn for_chain_directory(chain_dir: impl AsRef<Path>) -> Self {
         ParamsDirectory { path: chain_dir.as_ref().join("masp") }
     }
 

--- a/shared/src/masp/mod.rs
+++ b/shared/src/masp/mod.rs
@@ -1,18 +1,20 @@
 use std::path::{Path, PathBuf};
 use crate::types::chain::ChainId;
 
-pub struct ParamsDirectory(pub PathBuf);
+pub struct ParamsDirectory {
+    pub path: PathBuf,
+}
 
 impl ParamsDirectory {
     pub fn from_chain_directory(chain_dir: impl AsRef<Path>) -> Self {
-        ParamsDirectory(chain_dir.as_ref().join("masp"))
+        ParamsDirectory { path: chain_dir.as_ref().join("masp") }
     }
 
     pub fn spend_path(&self) -> PathBuf {
-        (&self).0.join("masp-spend.params")
+        (&self).path.join("masp-spend.params")
     }
 
     pub fn output_path(&self) -> PathBuf {
-        (&self).0.join("masp-output.params")
+        (&self).path.join("masp-output.params")
     }
 }

--- a/shared/src/masp/mod.rs
+++ b/shared/src/masp/mod.rs
@@ -1,20 +1,35 @@
+//! Helpers for using MASP
 use std::path::{Path, PathBuf};
-use crate::types::chain::ChainId;
 
+/// Represents a directory containing MASP parameters e.g.
+/// `~/Library/Application Support/MASPParams/`
 pub struct ParamsDirectory {
+    /// The actual path to the directory
     pub path: PathBuf,
 }
 
 impl ParamsDirectory {
+    /// Returns the MASP parameters directory for a given chain directory e.g.
+    /// `.anoma/anoma-masp-0.3.51d2f83a8412b95/masp/`
     pub fn for_chain_directory(chain_dir: impl AsRef<Path>) -> Self {
-        ParamsDirectory { path: chain_dir.as_ref().join("masp") }
+        ParamsDirectory {
+            path: chain_dir.as_ref().join("masp"),
+        }
     }
 
+    /// Returns the path to the spend parameters
     pub fn spend_path(&self) -> PathBuf {
-        (&self).path.join("masp-spend.params")
+        self.path.join("masp-spend.params")
     }
 
+    /// Returns the path to the output parameters
     pub fn output_path(&self) -> PathBuf {
-        (&self).path.join("masp-output.params")
+        self.path.join("masp-output.params")
+    }
+}
+
+impl AsRef<Path> for ParamsDirectory {
+    fn as_ref(&self) -> &Path {
+        &self.path
     }
 }


### PR DESCRIPTION
Relates to #1035

The client can easily start using MASP params from the chain-specific directory (e.g. `.anoma/<chain-id>/masp/`), but the ledger cannot as it doesn't have easy access to the chain ID when verifying a shielded transaction (it only has a `Transaction` struct). Eventually the ledger won't need access to the MASP params files anymore as the verifying key should be embedded in the binary, at which point we won't need to worry about the ledger needing to access the MASP params.