### PR TITLE
read_wasm: return a Result instead of exiting

### DIFF
--- a/.changelog/unreleased/bug-fixes/1099-wasm-reading.md
+++ b/.changelog/unreleased/bug-fixes/1099-wasm-reading.md
@@ -1,0 +1,2 @@
+- Make read_wasm return an error instead of exiting in InitChain
+  ([#1099](https://github.com/anoma/anoma/pull/1099))

--- a/apps/src/lib/cli/context.rs
+++ b/apps/src/lib/cli/context.rs
@@ -166,7 +166,13 @@ impl Context {
 
     /// Read the given WASM file from the WASM directory or an absolute path.
     pub fn read_wasm(&self, file_name: impl AsRef<Path>) -> Vec<u8> {
-        wasm_loader::read_wasm(self.wasm_dir(), file_name).unwrap()
+        match wasm_loader::read_wasm(self.wasm_dir(), file_name) {
+            Ok(wasm) => wasm,
+            Err(err) => {
+                eprintln!("Error reading wasm: {}", err);
+                safe_exit(1);
+            }
+        }
     }
 }
 

--- a/apps/src/lib/cli/context.rs
+++ b/apps/src/lib/cli/context.rs
@@ -166,7 +166,7 @@ impl Context {
 
     /// Read the given WASM file from the WASM directory or an absolute path.
     pub fn read_wasm(&self, file_name: impl AsRef<Path>) -> Vec<u8> {
-        wasm_loader::read_wasm(self.wasm_dir(), file_name)
+        wasm_loader::read_wasm(self.wasm_dir(), file_name).unwrap()
     }
 }
 

--- a/apps/src/lib/cli/context.rs
+++ b/apps/src/lib/cli/context.rs
@@ -166,13 +166,7 @@ impl Context {
 
     /// Read the given WASM file from the WASM directory or an absolute path.
     pub fn read_wasm(&self, file_name: impl AsRef<Path>) -> Vec<u8> {
-        match wasm_loader::read_wasm(self.wasm_dir(), file_name) {
-            Ok(wasm) => wasm,
-            Err(err) => {
-                eprintln!("Error reading wasm: {}", err);
-                safe_exit(1);
-            }
-        }
+        wasm_loader::read_wasm_or_exit(self.wasm_dir(), file_name)
     }
 }
 

--- a/apps/src/lib/node/ledger/shell/init_chain.rs
+++ b/apps/src/lib/node/ledger/shell/init_chain.rs
@@ -92,9 +92,10 @@ where
             storage,
         } in genesis.established_accounts
         {
-            let vp_code = vp_code_cache
-                .get_or_insert_with(vp_code_path.clone(), || {
+            let vp_code =
+                vp_code_cache.get_or_insert_with(vp_code_path.clone(), || {
                     wasm_loader::read_wasm(&self.wasm_dir, &vp_code_path)
+                        .unwrap()
                 });
 
             // In dev, we don't check the hash
@@ -147,9 +148,10 @@ where
             balances,
         } in genesis.token_accounts
         {
-            let vp_code = vp_code_cache
-                .get_or_insert_with(vp_code_path.clone(), || {
+            let vp_code =
+                vp_code_cache.get_or_insert_with(vp_code_path.clone(), || {
                     wasm_loader::read_wasm(&self.wasm_dir, &vp_code_path)
+                        .unwrap()
                 });
 
             // In dev, we don't check the hash
@@ -191,6 +193,7 @@ where
                         &self.wasm_dir,
                         &validator.validator_vp_code_path,
                     )
+                    .unwrap()
                 },
             );
 

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -106,6 +106,8 @@ pub enum Error {
     Broadcaster(tokio::sync::mpsc::error::TryRecvError),
     #[error("Error executing proposal {0}: {1}")]
     BadProposal(u64, String),
+    #[error("Error reading wasm: {0}")]
+    ReadingWasm(#[from] eyre::Error),
 }
 
 impl From<Error> for TxResult {

--- a/apps/src/lib/node/matchmaker.rs
+++ b/apps/src/lib/node/matchmaker.rs
@@ -143,7 +143,7 @@ impl Runner {
         // Prepare a client for intent gossiper node connection
         let (listener, dialer) = ClientListener::new_pair(intent_gossiper_addr);
 
-        let tx_code = wasm_loader::read_wasm(&wasm_dir, tx_code_path).unwrap();
+        let tx_code = wasm_loader::read_wasm_or_exit(&wasm_dir, tx_code_path);
 
         (
             Self {

--- a/apps/src/lib/node/matchmaker.rs
+++ b/apps/src/lib/node/matchmaker.rs
@@ -143,7 +143,7 @@ impl Runner {
         // Prepare a client for intent gossiper node connection
         let (listener, dialer) = ClientListener::new_pair(intent_gossiper_addr);
 
-        let tx_code = wasm_loader::read_wasm(&wasm_dir, tx_code_path);
+        let tx_code = wasm_loader::read_wasm(&wasm_dir, tx_code_path).unwrap();
 
         (
             Self {

--- a/apps/src/lib/wasm_loader/mod.rs
+++ b/apps/src/lib/wasm_loader/mod.rs
@@ -293,6 +293,19 @@ pub fn read_wasm(
     ))
 }
 
+pub fn read_wasm_or_exit(
+    wasm_directory: impl AsRef<Path>,
+    file_path: impl AsRef<Path>,
+) -> Vec<u8> {
+    match read_wasm(wasm_directory, file_path) {
+        Ok(wasm) => wasm,
+        Err(err) => {
+            eprintln!("Error reading wasm: {}", err);
+            safe_exit(1);
+        }
+    }
+}
+
 async fn download_wasm(url: String) -> Result<Vec<u8>, Error> {
     tracing::info!("Downloading WASM {}...", url);
     let response = reqwest::get(&url).await;

--- a/apps/src/lib/wasm_loader/mod.rs
+++ b/apps/src/lib/wasm_loader/mod.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
+use eyre::{eyre, WrapErr};
 use futures::future::join_all;
 use hex;
 use serde::{Deserialize, Serialize};
@@ -260,67 +261,36 @@ pub async fn pre_fetch_wasm(wasm_directory: impl AsRef<Path>) {
 pub fn read_wasm(
     wasm_directory: impl AsRef<Path>,
     file_path: impl AsRef<Path>,
-) -> Vec<u8> {
+) -> eyre::Result<Vec<u8>> {
     // load json with wasm hashes
     let checksums = Checksums::read_checksums(&wasm_directory);
 
     if let Some(os_name) = file_path.as_ref().file_name() {
         if let Some(name) = os_name.to_str() {
-            match checksums.0.get(name) {
+            let wasm_path = match checksums.0.get(name) {
                 Some(wasm_filename) => {
-                    let wasm_path = wasm_directory.as_ref().join(wasm_filename);
-                    match fs::read(&wasm_path) {
-                        Ok(bytes) => {
-                            return bytes;
-                        }
-                        Err(_) => {
-                            eprintln!(
-                                "File {} not found. ",
-                                wasm_path.to_string_lossy()
-                            );
-                            safe_exit(1);
-                        }
-                    }
+                    wasm_directory.as_ref().join(wasm_filename)
                 }
                 None => {
                     if !file_path.as_ref().is_absolute() {
-                        match fs::read(
-                            wasm_directory.as_ref().join(file_path.as_ref()),
-                        ) {
-                            Ok(bytes) => {
-                                return bytes;
-                            }
-                            Err(_) => {
-                                eprintln!(
-                                    "Could not read file {}. ",
-                                    file_path.as_ref().to_string_lossy()
-                                );
-                                safe_exit(1);
-                            }
-                        }
+                        wasm_directory.as_ref().join(file_path.as_ref())
                     } else {
-                        match fs::read(file_path.as_ref()) {
-                            Ok(bytes) => {
-                                return bytes;
-                            }
-                            Err(_) => {
-                                eprintln!(
-                                    "Could not read file {}. ",
-                                    file_path.as_ref().to_string_lossy()
-                                );
-                                safe_exit(1);
-                            }
-                        }
+                        file_path.as_ref().to_path_buf()
                     }
                 }
-            }
+            };
+            return fs::read(&wasm_path).wrap_err_with(|| {
+                format!(
+                    "Failed to read WASM from {}",
+                    &wasm_path.to_string_lossy()
+                )
+            });
         }
     }
-    eprintln!(
-        "File  {} does not exist.",
+    Err(eyre!(
+        "Could not read {}",
         file_path.as_ref().to_string_lossy()
-    );
-    safe_exit(1);
+    ))
 }
 
 async fn download_wasm(url: String) -> Result<Vec<u8>, Error> {


### PR DESCRIPTION
Relates to anoma/namada#104

This PR refactors `wasm_loader::read_wasm` to return a `Result` rather than exit the process if it can't read a wasm file - usages of `wasm_loader::read_wasm` have been updated to explicitly `.unwrap()` so in effect we `panic!` where before we exited the process.

When running `make test-unit` without having wasms present, the test runner can now finish and we get logs like the below, which is slightly more helpful (although doesn't explicitly indicate that wasms need to be present in order to run unit tests).

```
Location:
    apps/src/lib/wasm_loader/mod.rs:282:41', apps/src/lib/node/ledger/shell/init_chain.rs:98:26

---- node::ledger::shell::process_proposal::test_process_proposal::test_undecryptable stdout ----
thread 'node::ledger::shell::process_proposal::test_process_proposal::test_undecryptable' panicked at 'called `Result::unwrap()` on an `Err` value: Failed to read WASM from /opt/workspace/heliax/repos/anoma/tertiary/wasm/vp_user.41eb8fb2c109b6ec520b6a8bff213447d1a52daeb8057ace18dfddbbdd861ac2.wasm

Caused by:
    No such file or directory (os error 2)

Location:
    apps/src/lib/wasm_loader/mod.rs:282:41', apps/src/lib/node/ledger/shell/init_chain.rs:98:26

---- node::ledger::shell::process_proposal::test_process_proposal::test_wrapper_insufficient_balance_address stdout ----
thread 'node::ledger::shell::process_proposal::test_process_proposal::test_wrapper_insufficient_balance_address' panicked at 'called `Result::unwrap()` on an `Err` value: Failed to read WASM from /opt/workspace/heliax/repos/anoma/tertiary/wasm/vp_user.41eb8fb2c109b6ec520b6a8bff213447d1a52daeb8057ace18dfddbbdd861ac2.wasm

Caused by:
    No such file or directory (os error 2)

Location:
    apps/src/lib/wasm_loader/mod.rs:282:41', apps/src/lib/node/ledger/shell/init_chain.rs:98:26


failures:
    node::ledger::shell::finalize_block::test_finalize_block::test_mixed_txs_queued_in_correct_order
    node::ledger::shell::finalize_block::test_finalize_block::test_process_proposal_rejected_decrypted_tx
    node::ledger::shell::finalize_block::test_finalize_block::test_process_proposal_rejected_wrapper_tx
    node::ledger::shell::finalize_block::test_finalize_block::test_undecryptable_returns_error_code
    node::ledger::shell::process_proposal::test_process_proposal::test_invalid_hash_commitment
    node::ledger::shell::process_proposal::test_process_proposal::test_undecryptable
    node::ledger::shell::process_proposal::test_process_proposal::test_wrapper_insufficient_balance_address

test result: FAILED. 24 passed; 7 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.07s

error: test failed, to rerun pass '-p anoma_apps --lib'
make: *** [test-unit] Error 101

```