### PR TITLE
Update library docs

### DIFF
--- a/.changelog/unreleased/docs/1143-update-libraries-docs.md
+++ b/.changelog/unreleased/docs/1143-update-libraries-docs.md
@@ -1,0 +1,2 @@
+- Fixes libraries doc typos and correct comment on the clap crate
+  ([#1143](https://github.com/anoma/anoma/pull/1143))

--- a/docs/src/explore/libraries/cli.md
+++ b/docs/src/explore/libraries/cli.md
@@ -14,4 +14,4 @@ The considered libraries:
 
 Probably the most widely used CLI library in Rust.
 
-With version 2.x, we'd probably want to update clap to 3.x: this version comes with deriving attributes and also other new ways to build CLI commands (previously, deriving was only provided by [StructOpt](https://github.com/TeXitoi/structopt), which is now in maintenance mode).
+Comes with deriving attributes and also other new ways to build CLI commands (previously, deriving was only provided by [StructOpt](https://github.com/TeXitoi/structopt), which is now in maintenance mode).

--- a/docs/src/explore/libraries/cli.md
+++ b/docs/src/explore/libraries/cli.md
@@ -14,6 +14,4 @@ The considered libraries:
 
 Probably the most widely used CLI library in Rust.
 
-With version 2.x, we'd probably want to use it with [Structops](https://github.com/TeXitoi/structopt) for deriving.
-
-But we can probably use 3.0, which is not yet stable, but is pretty close <https://github.com/clap-rs/clap/issues/1037>. This version comes with deriving attributes and also other new ways to build CLI commands.
+With version 2.x, we'd probably want to update clap to 3.x: this version comes with deriving attributes and also other new ways to build CLI commands (previously, deriving was only provided by [StructOpt](https://github.com/TeXitoi/structopt), which is now in maintenance mode).

--- a/docs/src/explore/libraries/errors.md
+++ b/docs/src/explore/libraries/errors.md
@@ -2,7 +2,7 @@
 
 The current preference is to use `thiserror` for most code and `eyre` for reporting errors at the CLI level and the client.
 
-To make the code robust, we should avoid using code that may panic for errors that recoverable and handle all possible errors explicitly. Two exceptions to this rule are:
+To make the code robust, we should avoid using code that may panic for errors that are recoverable and handle all possible errors explicitly. Two exceptions to this rule are:
 - prototyping, where it's fine to use `unwrap`, `expect`, etc.
 - in code paths with conditional compilation **only** for development build, where it's preferable to use `expect` in place of `unwrap` to help with debugging
 
@@ -10,7 +10,7 @@ In case of panics, we should provide an error trace that is helpful for trouble-
 
 A great post on error handling library/application distinction: <https://nick.groenen.me/posts/rust-error-handling/>.
 
-The considered DBs:
+The considered libraries:
 - thiserror
 - anyhow
 - eyre

--- a/docs/src/explore/libraries/network.md
+++ b/docs/src/explore/libraries/network.md
@@ -1,4 +1,4 @@
-# network
+# Network
 
 ##  Libp2p : Peer To Peer network
 
@@ -13,7 +13,7 @@ encryption for us.
 
 Generates a client/server from protobuf file. This can be used for a rpc server.
 
-# network behaviour
+# Network behaviour
 
 ## Gossipsub
 


### PR DESCRIPTION
- Fixes typos
- Update section regarding the [clap](https://github.com/clap-rs/clap) library