### PR TITLE
Add `anomac utils fetch-wasms` command

### DIFF
--- a/.changelog/unreleased/improvements/1159-anomac-download-wasms.md
+++ b/.changelog/unreleased/improvements/1159-anomac-download-wasms.md
@@ -1,0 +1,2 @@
+- Add functionality to anomac to download wasms for a given chain
+  ([#1159](https://github.com/anoma/anoma/pull/1159))

--- a/apps/src/bin/anoma-client/cli.rs
+++ b/apps/src/bin/anoma-client/cli.rs
@@ -94,6 +94,9 @@ pub async fn main() -> Result<()> {
             Utils::JoinNetwork(JoinNetwork(args)) => {
                 utils::join_network(global_args, args).await
             }
+            Utils::FetchWasms(FetchWasms(args)) => {
+                utils::fetch_wasms(global_args, args).await
+            }
             Utils::InitNetwork(InitNetwork(args)) => {
                 utils::init_network(global_args, args)
             }

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -1262,6 +1262,7 @@ pub mod cmds {
     #[derive(Clone, Debug)]
     pub enum Utils {
         JoinNetwork(JoinNetwork),
+        FetchWasms(FetchWasms),
         InitNetwork(InitNetwork),
         InitGenesisValidator(InitGenesisValidator),
     }
@@ -1273,11 +1274,15 @@ pub mod cmds {
             matches.subcommand_matches(Self::CMD).and_then(|matches| {
                 let join_network =
                     SubCmd::parse(matches).map(Self::JoinNetwork);
+                let fetch_wasms = SubCmd::parse(matches).map(Self::FetchWasms);
                 let init_network =
                     SubCmd::parse(matches).map(Self::InitNetwork);
                 let init_genesis =
                     SubCmd::parse(matches).map(Self::InitGenesisValidator);
-                join_network.or(init_network).or(init_genesis)
+                join_network
+                    .or(fetch_wasms)
+                    .or(init_network)
+                    .or(init_genesis)
             })
         }
 
@@ -1285,6 +1290,7 @@ pub mod cmds {
             App::new(Self::CMD)
                 .about("Utilities.")
                 .subcommand(JoinNetwork::def())
+                .subcommand(FetchWasms::def())
                 .subcommand(InitNetwork::def())
                 .subcommand(InitGenesisValidator::def())
                 .setting(AppSettings::SubcommandRequiredElseHelp)
@@ -1307,6 +1313,25 @@ pub mod cmds {
             App::new(Self::CMD)
                 .about("Configure Anoma to join an existing network.")
                 .add_args::<args::JoinNetwork>()
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct FetchWasms(pub args::FetchWasms);
+
+    impl SubCmd for FetchWasms {
+        const CMD: &'static str = "fetch-wasms";
+
+        fn parse(matches: &ArgMatches) -> Option<Self> {
+            matches
+                .subcommand_matches(Self::CMD)
+                .map(|matches| Self(args::FetchWasms::parse(matches)))
+        }
+
+        fn def() -> App {
+            App::new(Self::CMD)
+                .about("Ensure pre-built wasms are present")
+                .add_args::<args::FetchWasms>()
         }
     }
 
@@ -2926,6 +2951,22 @@ pub mod args {
             app.arg(CHAIN_ID.def().about("The chain ID. The chain must be known in the https://github.com/heliaxdev/anoma-network-config repository."))
                 .arg(GENESIS_VALIDATOR.def().about("The alias of the genesis validator that you want to set up as, if any."))
                 .arg(PRE_GENESIS_PATH.def().about("The path to the pre-genesis directory for genesis validator, if any. Defaults to \"{base-dir}/pre-genesis/{genesis-validator}\"."))
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct FetchWasms {
+        pub chain_id: ChainId,
+    }
+
+    impl Args for FetchWasms {
+        fn parse(matches: &ArgMatches) -> Self {
+            let chain_id = CHAIN_ID.parse(matches);
+            Self { chain_id }
+        }
+
+        fn def(app: App) -> App {
+            app.arg(CHAIN_ID.def().about("The chain ID. The chain must be known in the https://github.com/heliaxdev/anoma-network-config repository, in which case it should have pre-built wasms available for download."))
         }
     }
 

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -349,6 +349,7 @@ pub async fn join_network(
         .await
         .unwrap();
     }
+    fetch_wasms_aux(&base_dir, &chain_id).await;
 
     println!("Successfully configured for chain ID {}", chain_id);
 }

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -361,6 +361,7 @@ pub async fn fetch_wasms(
 }
 
 pub async fn fetch_wasms_aux(base_dir: &Path, chain_id: &ChainId) {
+    println!("Fetching wasms for chain ID {}...", chain_id);
     let wasm_dir = {
         let mut path = base_dir.to_owned();
         path.push(chain_id.as_str());

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -353,6 +353,23 @@ pub async fn join_network(
     println!("Successfully configured for chain ID {}", chain_id);
 }
 
+pub async fn fetch_wasms(
+    global_args: args::Global,
+    args::FetchWasms { chain_id }: args::FetchWasms,
+) {
+    fetch_wasms_aux(&global_args.base_dir, &chain_id).await;
+}
+
+pub async fn fetch_wasms_aux(base_dir: &Path, chain_id: &ChainId) {
+    let wasm_dir = {
+        let mut path = base_dir.to_owned();
+        path.push(chain_id.as_str());
+        path.push("wasm");
+        path
+    };
+    wasm_loader::pre_fetch_wasm(&wasm_dir).await;
+}
+
 /// Length of a Tendermint Node ID in bytes
 const TENDERMINT_NODE_ID_LENGTH: usize = 20;
 

--- a/apps/src/lib/wasm_loader/mod.rs
+++ b/apps/src/lib/wasm_loader/mod.rs
@@ -100,9 +100,8 @@ impl Checksums {
     }
 }
 
-/// Download all the pre-build WASMs, or if they're already downloaded, verify
-/// their checksums. Download all the pre-build WASMs, or if they're already
-/// downloaded, verify their checksums.
+/// Download all the pre-built wasms, or if they're already downloaded, verify
+/// their checksums.
 pub async fn pre_fetch_wasm(wasm_directory: impl AsRef<Path>) {
     #[cfg(feature = "dev")]
     {


### PR DESCRIPTION
Will fix anoma/namada#98

This is a minimal PR to make it possible to get precompiled wasms without having to acquire and run an `anoman` binary. `anomac utils join-network` downloads wasms as well, so joining a chain looks something like this.

```
mbp> target/debug/anomac utils join-network --chain-id $ANOMA_CHAIN_ID
Downloading config release from http://localhost:8123/dev.aa6b7392c6c42ea85d601b905a.tar.gz ...
Fetching wasms for chain ID dev.aa6b7392c6c42ea85d601b905a...
2022-07-08T14:39:02.131222Z  INFO anoma_apps::wasm_loader: Downloading WASM https://heliax-anoma-wasm-v1.s3.eu-west-1.amazonaws.com/tx_init_validator.83a93ba9a1c40c03ddb92012ee354743f8dff8c5796ebdc557654c2bd95a497c.wasm...
2022-07-08T14:39:02.131186Z  INFO anoma_apps::wasm_loader: Downloading WASM https://heliax-anoma-wasm-v1.s3.eu-west-1.amazonaws.com/tx_transfer.f2773e82cd6519662f7d9dbdeb10a2aff9a5fc8ca54d144e6cff571b1fca97cd.wasm...
2022-07-08T14:39:02.131188Z  INFO anoma_apps::wasm_loader: Downloading WASM https://heliax-anoma-wasm-v1.s3.eu-west-1.amazonaws.com/tx_mint_nft.9c582bc9d4ee0f185a66c2c468290ee0668064987050779529b1a4db39a3989b.wasm...
2022-07-08T14:39:02.131194Z  INFO anoma_apps::wasm_loader: Downloading WASM https://heliax-anoma-wasm-v1.s3.eu-west-1.amazonaws.com/tx_init_nft.92c350bd1640aec55618155573f2d520a85676959fbcec548f5c6378419124f0.wasm...
2022-07-08T14:39:02.131281Z  INFO anoma_apps::wasm_loader: Downloading WASM https://heliax-anoma-wasm-v1.s3.eu-west-1.amazonaws.com/tx_from_intent.9309a7f0ac8f7b57d897cd69e913cb7ce183e2172e255e2d808c471217a7486b.wasm...
2022-07-08T14:39:02.131214Z  INFO anoma_apps::wasm_loader: Downloading WASM https://heliax-anoma-wasm-v1.s3.eu-west-1.amazonaws.com/tx_bond.753f415cfc1ab36b23afc113e6b988fd84e24e493b651906bda007471c6d767d.wasm...
2022-07-08T14:39:02.131188Z  INFO anoma_apps::wasm_loader: Downloading WASM https://heliax-anoma-wasm-v1.s3.eu-west-1.amazonaws.com/vp_testnet_faucet.07226b30af3f6c091b5acfd0e6f7794f31e363cbbdb5db9acb8a0086fff82005.wasm...
2022-07-08T14:39:02.131408Z  INFO anoma_apps::wasm_loader: Downloading WASM https://heliax-anoma-wasm-v1.s3.eu-west-1.amazonaws.com/tx_update_vp.23a6a4f18e826c67708b32b98be67c7c241fd1478424196ae47f972c7a1334e0.wasm...
2022-07-08T14:39:02.131426Z  INFO anoma_apps::wasm_loader: Downloading WASM https://heliax-anoma-wasm-v1.s3.eu-west-1.amazonaws.com/tx_ibc.5f526fcc143bc57988a3015e5c93250406a4a9ea5467f44d940eece3e0af781d.wasm...
2022-07-08T14:39:02.131367Z  INFO anoma_apps::wasm_loader: Downloading WASM https://heliax-anoma-wasm-v1.s3.eu-west-1.amazonaws.com/tx_unbond.b4ae4df26a3501af40ab409d95b72bff27f953d2e2ebf20c3f7395a2454dad68.wasm...
2022-07-08T14:39:02.131733Z  INFO anoma_apps::wasm_loader: Downloading WASM https://heliax-anoma-wasm-v1.s3.eu-west-1.amazonaws.com/vp_user.9299851563f7fdb4e8bc9b0f23ae948655b0a049e402b090ddb453df37eb98ff.wasm...
2022-07-08T14:39:02.131740Z  INFO anoma_apps::wasm_loader: Downloading WASM https://heliax-anoma-wasm-v1.s3.eu-west-1.amazonaws.com/vp_token.bad2c74e2788089ec2692b1fce0549466f57769336df774c8582076cd3fad136.wasm...
2022-07-08T14:39:02.131747Z  INFO anoma_apps::wasm_loader: Downloading WASM https://heliax-anoma-wasm-v1.s3.eu-west-1.amazonaws.com/tx_vote_proposal.466a6be90f5a5a79965a2106b8a5a385accc1cdb6f66345c9f39e6488e4e2a05.wasm...
2022-07-08T14:39:02.131756Z  INFO anoma_apps::wasm_loader: Downloading WASM https://heliax-anoma-wasm-v1.s3.eu-west-1.amazonaws.com/tx_init_account.7523feaefe42396b98728b6b8993648041b99c2c4b97faa85e1016fe0ef35ce0.wasm...
2022-07-08T14:39:02.131795Z  INFO anoma_apps::wasm_loader: Downloading WASM https://heliax-anoma-wasm-v1.s3.eu-west-1.amazonaws.com/vp_nft.d85a9628f4702f31f54888b704745f8e868b7945208d40d24ead134b338557d1.wasm...
2022-07-08T14:39:02.131883Z  INFO anoma_apps::wasm_loader: Downloading WASM https://heliax-anoma-wasm-v1.s3.eu-west-1.amazonaws.com/tx_withdraw.aabfff97bf82723436bdddbd584e8199a18355decc2f1c10818ad84c57e92182.wasm...
2022-07-08T14:39:02.131910Z  INFO anoma_apps::wasm_loader: Downloading WASM https://heliax-anoma-wasm-v1.s3.eu-west-1.amazonaws.com/tx_init_proposal.7ac4859d1ebd536d119c8936336ddd7ea5cb491b079261b2f83f03bf89255d3f.wasm...
Successfully configured for chain ID dev.aa6b7392c6c42ea85d601b905a
```

Also added a subcommand just for fetching wasms (`anomac utils fetch-wasms`), I'm unsure if we should couple it tightly with `anomac utils join-network`, we may want it to be an explicit step.

Also, the underlying `wasm_loader::pre_fetch_wasm` function used does some integrity checking of any wasms present which may be useful even after having joined a network - it looks like you could run it to "fix" a chain's wasm directory so that it downloads wasms as according to the `checksums.json` file.
