### PR TITLE
[cli]: fix output of 'anoma wallet addres find' - #993

### DIFF
--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -2868,7 +2868,7 @@ pub mod args {
 
         fn def(app: App) -> App {
             app.arg(
-                ALIAS_OPT
+                ALIAS
                     .def()
                     .about("An alias associated with the address."),
             )


### PR DESCRIPTION
Fixes [#993](https://github.com/anoma/anoma/issues/993). Now, when running `anoma wallet address find`, the output looks like:

<img width="949" alt="image" src="https://user-images.githubusercontent.com/26880226/174300170-1e96509b-b228-43e4-baaf-a9e162529811.png">
