### PR TITLE
eth-bridge-integration: add symbols relevant to the state update transaction

### DIFF
--- a/shared/src/proto/mod.rs
+++ b/shared/src/proto/mod.rs
@@ -4,7 +4,8 @@ pub mod generated;
 mod types;
 
 pub use types::{
-    Dkg, Error, Intent, IntentGossipMessage, IntentId, Signed, SignedTxData, Tx,
+    Dkg, Error, Intent, IntentGossipMessage, IntentId, MultiSigned, Signed,
+    SignedTxData, Tx,
 };
 
 #[cfg(test)]

--- a/shared/src/proto/types.rs
+++ b/shared/src/proto/types.rs
@@ -60,6 +60,22 @@ pub struct Signed<T: BorshSerialize + BorshDeserialize> {
     pub sig: common::Signature,
 }
 
+#[derive(
+    Clone,
+    Debug,
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
+    Serialize,
+    Deserialize,
+)]
+pub struct MultiSigned<T: BorshSerialize + BorshDeserialize> {
+    /// Arbitrary data to be signed
+    pub data: T,
+    /// The signature of the data
+    pub sigs: Vec<common::Signature>,
+}
+
 impl<T> PartialEq for Signed<T>
 where
     T: BorshSerialize + BorshDeserialize + PartialEq,

--- a/shared/src/types/ethereum_events.rs
+++ b/shared/src/types/ethereum_events.rs
@@ -1,0 +1,52 @@
+//! Types to do with interfacing with the Ethereum blockchain
+use std::fmt::Debug;
+
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+
+use crate::proto::MultiSigned;
+use crate::types::address::Address;
+use crate::types::token::Amount;
+
+/// An Ethereum event to be processed by the Anoma ledger
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, BorshSchema)]
+pub enum EthereumEvent {
+    /// Event transferring batches of ether from Ethereum to wrapped ETH on
+    /// Anoma
+    TransfersToNamada(Vec<TransferToNamada>),
+}
+
+/// Representation of address on Ethereum
+#[derive(
+    Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, BorshSchema,
+)]
+pub struct EthAddress(pub [u8; 20]);
+
+/// An event transferring some kind of value from Ethereum to Anoma
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, BorshSchema)]
+pub struct TransferToNamada {
+    /// Quantity of ether in the transfer
+    pub amount: Amount,
+    /// Address on Ethereum of the asset
+    pub asset: EthereumAsset,
+    /// The Namada address receiving wrapped assets on Anoma
+    pub receiver: Address,
+}
+
+/// Represents Ethereum assets on the Ethereum blockchain
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, BorshSchema)]
+pub enum EthereumAsset {
+    /// Native ETH
+    Eth,
+    /// An ERC20 token and the address of its contract
+    ERC20(EthAddress),
+}
+
+/// This is created by the block proposer based on the Ethereum events included
+/// in the vote extensions of the previous Tendermint round
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, BorshSchema)]
+pub struct MultiSignedEthEvent {
+    /// Address and voting power of the signing validators
+    pub signers: Vec<(Address, u64)>,
+    /// Events as signed by validators
+    pub event: MultiSigned<EthereumEvent>,
+}

--- a/shared/src/types/mod.rs
+++ b/shared/src/types/mod.rs
@@ -3,6 +3,7 @@
 pub mod address;
 pub mod chain;
 pub mod dylib;
+pub mod ethereum_events;
 pub mod governance;
 pub mod hash;
 pub mod ibc;

--- a/shared/src/types/transaction/protocol.rs
+++ b/shared/src/types/transaction/protocol.rs
@@ -33,6 +33,7 @@ mod protocol_txs {
 
     use super::*;
     use crate::proto::Tx;
+    use crate::types::ethereum_events::MultiSignedEthEvent;
     use crate::types::key::*;
     use crate::types::transaction::{EllipticCurve, TxError, TxType};
 
@@ -76,9 +77,8 @@ mod protocol_txs {
         DKG(DkgMessage),
         /// Tx requesting a new DKG session keypair
         NewDkgKeypair(Tx),
-        /// Aggregation of Ethereum state changes
-        /// voted on by validators in last block
-        EthereumStateUpdate(Tx),
+        /// Ethereum events contained in vote extensions
+        EthereumEvents(Vec<MultiSignedEthEvent>),
     }
 
     impl ProtocolTxType {


### PR DESCRIPTION
Relates to #1171

This PR adds symbols from the `bat/full-node-eth` branch that will be used in the state update transaction of the Ethereum bridge