### PR TITLE
open_genesis_config should return a human-friendly error

### DIFF
--- a/.changelog/unreleased/improvements/1176-genesis-config-error.md
+++ b/.changelog/unreleased/improvements/1176-genesis-config-error.md
@@ -1,0 +1,2 @@
+- Improve the error message that is displayed when anoma binaries are run without
+  having joined a chain ([#1176](https://github.com/anoma/anoma/pull/1176))

--- a/apps/src/bin/anoma-client/cli.rs
+++ b/apps/src/bin/anoma-client/cli.rs
@@ -6,7 +6,7 @@ use anoma_apps::client::{gossip, rpc, tx, utils};
 use color_eyre::eyre::Result;
 
 pub async fn main() -> Result<()> {
-    match cli::anoma_client_cli() {
+    match cli::anoma_client_cli()? {
         cli::AnomaClient::WithContext(cmd_box) => {
             let (cmd, ctx) = *cmd_box;
             use AnomaClientWithContext as Sub;

--- a/apps/src/bin/anoma-node/cli.rs
+++ b/apps/src/bin/anoma-node/cli.rs
@@ -5,7 +5,7 @@ use anoma_apps::node::{gossip, ledger, matchmaker};
 use eyre::{Context, Result};
 
 pub fn main() -> Result<()> {
-    let (cmd, mut ctx) = cli::anoma_node_cli();
+    let (cmd, mut ctx) = cli::anoma_node_cli()?;
     if let Some(mode) = ctx.global_args.mode.clone() {
         ctx.config.ledger.tendermint.tendermint_mode = mode;
     }

--- a/apps/src/bin/anoma-wallet/cli.rs
+++ b/apps/src/bin/anoma-wallet/cli.rs
@@ -12,7 +12,7 @@ use color_eyre::eyre::Result;
 use itertools::sorted;
 
 pub fn main() -> Result<()> {
-    let (cmd, ctx) = cli::anoma_wallet_cli();
+    let (cmd, ctx) = cli::anoma_wallet_cli()?;
     match cmd {
         cmds::AnomaWallet::Key(sub) => match sub {
             cmds::WalletKey::Gen(cmds::KeyGen(args)) => {

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -10,6 +10,7 @@ pub mod context;
 mod utils;
 
 use clap::{crate_authors, AppSettings, ArgMatches};
+use color_eyre::eyre::Result;
 pub use utils::safe_exit;
 use utils::*;
 
@@ -3059,7 +3060,7 @@ pub fn anoma_cli() -> (cmds::Anoma, String) {
     safe_exit(2);
 }
 
-pub fn anoma_node_cli() -> (cmds::AnomaNode, Context) {
+pub fn anoma_node_cli() -> Result<(cmds::AnomaNode, Context)> {
     let app = anoma_node_app();
     cmds::AnomaNode::parse_or_print_help(app)
 }
@@ -3069,7 +3070,7 @@ pub enum AnomaClient {
     WithContext(Box<(cmds::AnomaClientWithContext, Context)>),
 }
 
-pub fn anoma_client_cli() -> AnomaClient {
+pub fn anoma_client_cli() -> Result<AnomaClient> {
     let app = anoma_client_app();
     let mut app = cmds::AnomaClient::add_sub(app);
     let matches = app.clone().get_matches();
@@ -3078,11 +3079,11 @@ pub fn anoma_client_cli() -> AnomaClient {
             let global_args = args::Global::parse(&matches);
             match cmd {
                 cmds::AnomaClient::WithContext(sub_cmd) => {
-                    let context = Context::new(global_args);
-                    AnomaClient::WithContext(Box::new((sub_cmd, context)))
+                    let context = Context::new(global_args)?;
+                    Ok(AnomaClient::WithContext(Box::new((sub_cmd, context))))
                 }
                 cmds::AnomaClient::WithoutContext(sub_cmd) => {
-                    AnomaClient::WithoutContext(sub_cmd, global_args)
+                    Ok(AnomaClient::WithoutContext(sub_cmd, global_args))
                 }
             }
         }
@@ -3093,7 +3094,7 @@ pub fn anoma_client_cli() -> AnomaClient {
     }
 }
 
-pub fn anoma_wallet_cli() -> (cmds::AnomaWallet, Context) {
+pub fn anoma_wallet_cli() -> Result<(cmds::AnomaWallet, Context)> {
     let app = anoma_wallet_app();
     cmds::AnomaWallet::parse_or_print_help(app)
 }

--- a/apps/src/lib/cli/context.rs
+++ b/apps/src/lib/cli/context.rs
@@ -9,6 +9,7 @@ use std::str::FromStr;
 use anoma::types::address::Address;
 use anoma::types::chain::ChainId;
 use anoma::types::key::*;
+use color_eyre::eyre::Result;
 
 use super::args;
 use crate::cli::safe_exit;
@@ -49,7 +50,7 @@ pub struct Context {
 }
 
 impl Context {
-    pub fn new(global_args: args::Global) -> Self {
+    pub fn new(global_args: args::Global) -> Result<Self> {
         let global_config = read_or_try_new_global_config(&global_args);
         tracing::info!("Chain ID: {}", global_config.default_chain_id);
 
@@ -65,9 +66,10 @@ impl Context {
         let genesis_file_path = global_args
             .base_dir
             .join(format!("{}.toml", global_config.default_chain_id.as_str()));
-        let wallet = Wallet::load_or_new_from_genesis(&chain_dir, move || {
-            genesis_config::open_genesis_config(genesis_file_path)
-        });
+        let wallet = Wallet::load_or_new_from_genesis(
+            &chain_dir,
+            genesis_config::open_genesis_config(&genesis_file_path)?,
+        );
 
         // If the WASM dir specified, put it in the config
         match global_args.wasm_dir.as_ref() {
@@ -96,12 +98,12 @@ impl Context {
                 }
             }
         }
-        Self {
+        Ok(Self {
             global_args,
             wallet,
             global_config,
             config,
-        }
+        })
     }
 
     /// Parse and/or look-up the value from the context.

--- a/apps/src/lib/cli/utils.rs
+++ b/apps/src/lib/cli/utils.rs
@@ -4,6 +4,7 @@ use std::marker::PhantomData;
 use std::str::FromStr;
 
 use clap::ArgMatches;
+use color_eyre::eyre::Result;
 
 use super::args;
 use super::context::{Context, FromContext};
@@ -16,14 +17,14 @@ pub trait Cmd: Sized {
     fn add_sub(app: App) -> App;
     fn parse(matches: &ArgMatches) -> Option<Self>;
 
-    fn parse_or_print_help(app: App) -> (Self, Context) {
+    fn parse_or_print_help(app: App) -> Result<(Self, Context)> {
         let mut app = Self::add_sub(app);
         let matches = app.clone().get_matches();
         match Self::parse(&matches) {
             Some(cmd) => {
                 let global_args = args::Global::parse(&matches);
-                let context = Context::new(global_args);
-                (cmd, context)
+                let context = Context::new(global_args)?;
+                Ok((cmd, context))
             }
             None => {
                 app.print_help().unwrap();

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -273,10 +273,10 @@ pub async fn join_network(
 
         let genesis_file_path =
             base_dir.join(format!("{}.toml", chain_id.as_str()));
-        let mut wallet =
-            Wallet::load_or_new_from_genesis(&chain_dir, move || {
-                genesis_config::open_genesis_config(genesis_file_path)
-            });
+        let mut wallet = Wallet::load_or_new_from_genesis(
+            &chain_dir,
+            genesis_config::open_genesis_config(genesis_file_path).unwrap(),
+        );
 
         let address = wallet
             .find_address(&validator_alias)
@@ -384,7 +384,8 @@ pub fn init_network(
         archive_dir,
     }: args::InitNetwork,
 ) {
-    let mut config = genesis_config::open_genesis_config(&genesis_path);
+    let mut config =
+        genesis_config::open_genesis_config(&genesis_path).unwrap();
 
     // Update the WASM checksums
     let checksums =

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -273,11 +273,10 @@ where
                     );
                     let wallet = wallet::Wallet::load_or_new_from_genesis(
                         wallet_path,
-                        move || {
-                            genesis::genesis_config::open_genesis_config(
-                                genesis_path,
-                            )
-                        },
+                        genesis::genesis_config::open_genesis_config(
+                            genesis_path,
+                        )
+                        .unwrap(),
                     );
                     wallet
                         .take_validator_data()
@@ -628,10 +627,10 @@ where
         let genesis_path = &self
             .base_dir
             .join(format!("{}.toml", self.chain_id.as_str()));
-        let mut wallet =
-            wallet::Wallet::load_or_new_from_genesis(wallet_path, move || {
-                genesis::genesis_config::open_genesis_config(genesis_path)
-            });
+        let mut wallet = wallet::Wallet::load_or_new_from_genesis(
+            wallet_path,
+            genesis::genesis_config::open_genesis_config(genesis_path).unwrap(),
+        );
         self.mode.get_validator_address().map(|addr| {
             let pk_bytes = self
                 .storage

--- a/apps/src/lib/wallet/mod.rs
+++ b/apps/src/lib/wallet/mod.rs
@@ -68,9 +68,9 @@ impl Wallet {
     /// addresses loaded from the genesis file, if not found.
     pub fn load_or_new_from_genesis(
         store_dir: &Path,
-        load_genesis: impl FnOnce() -> GenesisConfig,
+        genesis_cfg: GenesisConfig,
     ) -> Self {
-        let store = Store::load_or_new_from_genesis(store_dir, load_genesis)
+        let store = Store::load_or_new_from_genesis(store_dir, genesis_cfg)
             .unwrap_or_else(|err| {
                 eprintln!("Unable to load the wallet: {}", err);
                 cli::safe_exit(1)

--- a/apps/src/lib/wallet/store.rs
+++ b/apps/src/lib/wallet/store.rs
@@ -135,15 +135,15 @@ impl Store {
     /// the genesis file, if not found.
     pub fn load_or_new_from_genesis(
         store_dir: &Path,
-        load_genesis: impl FnOnce() -> GenesisConfig,
+        genesis_cfg: GenesisConfig,
     ) -> Result<Self, LoadStoreError> {
         Self::load(store_dir).or_else(|_| {
             #[cfg(not(feature = "dev"))]
-            let store = Self::new(load_genesis());
+            let store = Self::new(genesis_cfg);
             #[cfg(feature = "dev")]
             let store = {
                 // The function is unused in dev
-                let _ = load_genesis;
+                let _ = genesis_cfg;
                 Self::new()
             };
             store.save(store_dir).map_err(|err| {

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -1678,7 +1678,7 @@ fn test_genesis_validators() -> Result<()> {
     // 2. Initialize a new network with the 2 validators
     let mut genesis = genesis_config::open_genesis_config(
         working_dir.join(setup::SINGLE_NODE_NET_GENESIS),
-    );
+    )?;
     let update_validator_config =
         |ix: u8, mut config: genesis_config::ValidatorConfig| {
             // Setup tokens balances and validity predicates

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -111,7 +111,7 @@ pub fn network(
     // Open the source genesis file
     let mut genesis = genesis_config::open_genesis_config(
         working_dir.join(SINGLE_NODE_NET_GENESIS),
-    );
+    )?;
 
     if !cfg!(feature = "ABCI") {
         // The ABCI ports start at `26670`, ABCI++ at `26670 +


### PR DESCRIPTION
Give a slightly better error message when `anomac` or `anomaw` commands are run, but a chain hasn't been joined. Before we would just get `No such file or directory (os error 2)`, now we should indicate that specifically we can't read a genesis config file.

```
mbp> target/debug/anomac epoch
2022-07-07T16:58:56.136364Z  INFO anoma_apps::cli::context: Chain ID: anoma-internal.000000000000000
Error: 
   0: couldn't read genesis config file from .anoma/anoma-internal.000000000000000.toml
   1: No such file or directory (os error 2)

Location:
   apps/src/lib/config/genesis.rs:601

Backtrace omitted.
Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
[1] - 2022-07-07 17:58:56
```

This PR also makes some changes such that we can propagate an error all the way back up to `main()` of `anomac`, `anoman`, `anomaw`, so that it will be easier in the future to propagate errors like this. (Relates to anoma/anoma#1049)

To close anoma/namada#97, we should catch the error and translate it to a friendly message such as one indicating to the user to join a network first, rather than panicking with a backtrace.