### PR TITLE
Fixing up tomas/abcipp-rebase-v0.6.0 for v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,6 @@ dependencies = [
  "concat-idents",
  "derivative",
  "escargot",
- "expectrl",
  "eyre",
  "file-serve",
  "fs_extra",
@@ -273,6 +272,7 @@ dependencies = [
  "pretty_assertions",
  "proptest",
  "prost 0.9.0",
+ "rexpect",
  "serde_json",
  "sha2 0.9.9",
  "tempfile",
@@ -1322,15 +1322,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "conpty"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977baae4026273d7f9bb69a0a8eb4aed7ab9dac98799f742dce09173a9734754"
-dependencies = [
- "windows",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,6 +1989,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "backtrace",
+ "version_check 0.9.4",
+]
+
+[[package]]
 name = "escargot"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2014,17 +2015,6 @@ name = "event-listener"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
-
-[[package]]
-name = "expectrl"
-version = "0.4.0"
-source = "git+https://github.com/heliaxdev/expectrl.git?branch=tomas/expect-eager-2#9982bb2fd32560b359619dafe92964656406d36e"
-dependencies = [
- "conpty",
- "nix 0.23.1",
- "ptyprocess",
- "regex",
-]
 
 [[package]]
 name = "eyre"
@@ -4194,35 +4184,22 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 0.1.10",
+ "libc",
+ "void",
+]
+
+[[package]]
+name = "nix"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5e06129fb611568ef4e868c14b326274959aa70ff7776e9d55323531c374945"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nix"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d9f3521ea8e0641a153b3cddaf008dcbf26acd4ed739a2517295e0760d12c7"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nix"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
 dependencies = [
  "bitflags",
  "cc",
@@ -5073,15 +5050,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ptyprocess"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69c28fcebfd842bfe19d69409fc321230ea8c1bebe31f274906485c761ce1917"
-dependencies = [
- "nix 0.21.2",
-]
-
-[[package]]
 name = "pwasm-utils"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5495,6 +5463,17 @@ checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
  "hostname",
  "quick-error 1.2.3",
+]
+
+[[package]]
+name = "rexpect"
+version = "0.4.0"
+source = "git+https://github.com/heliaxdev/rexpect.git?branch=tomas/eof-hack-fix#3b5d729bfae74bd2c1d7bccf91b82273f05a1f45"
+dependencies = [
+ "error-chain",
+ "nix 0.14.1",
+ "regex",
+ "tempfile",
 ]
 
 [[package]]
@@ -8201,36 +8180,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac7fef12f4b59cd0a29339406cc9203ab44e440ddff6b3f5a41455349fa9cf3"
-dependencies = [
- "windows_aarch64_msvc 0.29.0",
- "windows_i686_gnu 0.29.0",
- "windows_i686_msvc 0.29.0",
- "windows_x86_64_gnu 0.29.0",
- "windows_x86_64_msvc 0.29.0",
-]
-
-[[package]]
 name = "windows-sys"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d027175d00b01e0cbeb97d6ab6ebe03b12330a35786cbaca5252b1c4bf5d9b"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -8240,21 +8200,9 @@ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8793f59f7b8e8b01eda1a652b2697d87b93097198ae85f823b969ca5b89bba58"
-
-[[package]]
-name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8602f6c418b67024be2996c512f5f995de3ba417f4c75af68401ab8756796ae4"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8264,21 +8212,9 @@ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d615f419543e0bd7d2b3323af0d86ff19cbc4f816e6453f36a2c2ce889c354"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d95421d9ed3672c280884da53201a5c46b7b2765ca6faf34b0d71cf34a3561"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,10 +92,10 @@ dependencies = [
  "ferveo-common",
  "group-threshold-cryptography",
  "hex",
- "ibc 0.12.0 (git+https://github.com/heliaxdev/ibc-rs?branch=bat/abcipp-rebase-master)",
  "ibc 0.12.0 (git+https://github.com/heliaxdev/ibc-rs?branch=yuji/v0.12.0_tm_v0.23.5)",
- "ibc-proto 0.16.0 (git+https://github.com/heliaxdev/ibc-rs?branch=bat/abcipp-rebase-master)",
+ "ibc 0.12.0 (git+https://github.com/heliaxdev/ibc-rs?rev=30b3495ac56c6c37c99bc69ef9f2e84c3309c6cc)",
  "ibc-proto 0.16.0 (git+https://github.com/heliaxdev/ibc-rs?branch=yuji/v0.12.0_tm_v0.23.5)",
+ "ibc-proto 0.16.0 (git+https://github.com/heliaxdev/ibc-rs?rev=30b3495ac56c6c37c99bc69ef9f2e84c3309c6cc)",
  "ics23",
  "itertools 0.10.3",
  "loupe",
@@ -113,10 +113,10 @@ dependencies = [
  "sha2 0.9.9",
  "sparse-merkle-tree",
  "tempfile",
- "tendermint 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master)",
  "tendermint 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/rebase_v0.23.5)",
- "tendermint-proto 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master)",
+ "tendermint 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9)",
  "tendermint-proto 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/rebase_v0.23.5)",
+ "tendermint-proto 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9)",
  "test-log",
  "thiserror",
  "tonic-build",
@@ -196,14 +196,14 @@ dependencies = [
  "sysinfo",
  "tar",
  "tempfile",
- "tendermint 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master)",
  "tendermint 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/rebase_v0.23.5)",
- "tendermint-config 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master)",
+ "tendermint 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9)",
  "tendermint-config 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/rebase_v0.23.5)",
- "tendermint-proto 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master)",
+ "tendermint-config 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9)",
  "tendermint-proto 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/rebase_v0.23.5)",
- "tendermint-rpc 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master)",
+ "tendermint-proto 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9)",
  "tendermint-rpc 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/rebase_v0.23.5)",
+ "tendermint-rpc 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9)",
  "test-log",
  "thiserror",
  "tokio",
@@ -212,8 +212,8 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tower",
- "tower-abci 0.1.0 (git+https://github.com/heliaxdev/tower-abci?branch=bat/abcipp-rebase-master)",
  "tower-abci 0.1.0 (git+https://github.com/heliaxdev/tower-abci?branch=yuji/rebase_v0.23.5_tracing)",
+ "tower-abci 0.1.0 (git+https://github.com/heliaxdev/tower-abci?rev=f6463388fc319b6e210503b43b3aecf6faf6b200)",
  "tracing 0.1.35",
  "tracing-log",
  "tracing-subscriber 0.3.11",
@@ -2837,33 +2837,6 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.12.0"
-source = "git+https://github.com/heliaxdev/ibc-rs?branch=bat/abcipp-rebase-master#83dbb07e8e1a51c03681966eaf31653250699196"
-dependencies = [
- "bytes 1.1.0",
- "derive_more",
- "flex-error",
- "ibc-proto 0.16.0 (git+https://github.com/heliaxdev/ibc-rs?branch=bat/abcipp-rebase-master)",
- "ics23",
- "num-traits 0.2.15",
- "prost 0.9.0",
- "prost-types 0.9.0",
- "safe-regex",
- "serde 1.0.137",
- "serde_derive",
- "serde_json",
- "sha2 0.10.2",
- "subtle-encoding",
- "tendermint 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master)",
- "tendermint-light-client-verifier 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master)",
- "tendermint-proto 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master)",
- "tendermint-testgen 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master)",
- "time 0.3.9",
- "tracing 0.1.35",
-]
-
-[[package]]
-name = "ibc"
-version = "0.12.0"
 source = "git+https://github.com/heliaxdev/ibc-rs?branch=yuji/v0.12.0_tm_v0.23.5#e14560ecfc3f275a63b5702e038cbabd2797b2b6"
 dependencies = [
  "bytes 1.1.0",
@@ -2889,16 +2862,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "ibc-proto"
-version = "0.16.0"
-source = "git+https://github.com/heliaxdev/ibc-rs?branch=bat/abcipp-rebase-master#83dbb07e8e1a51c03681966eaf31653250699196"
+name = "ibc"
+version = "0.12.0"
+source = "git+https://github.com/heliaxdev/ibc-rs?rev=30b3495ac56c6c37c99bc69ef9f2e84c3309c6cc#30b3495ac56c6c37c99bc69ef9f2e84c3309c6cc"
 dependencies = [
  "bytes 1.1.0",
+ "derive_more",
+ "flex-error",
+ "ibc-proto 0.16.0 (git+https://github.com/heliaxdev/ibc-rs?rev=30b3495ac56c6c37c99bc69ef9f2e84c3309c6cc)",
+ "ics23",
+ "num-traits 0.2.15",
  "prost 0.9.0",
  "prost-types 0.9.0",
+ "safe-regex",
  "serde 1.0.137",
- "tendermint-proto 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master)",
- "tonic",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.2",
+ "subtle-encoding",
+ "tendermint 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9)",
+ "tendermint-light-client-verifier 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9)",
+ "tendermint-proto 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9)",
+ "tendermint-testgen 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9)",
+ "time 0.3.9",
+ "tracing 0.1.35",
 ]
 
 [[package]]
@@ -2911,6 +2898,19 @@ dependencies = [
  "prost-types 0.9.0",
  "serde 1.0.137",
  "tendermint-proto 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/rebase_v0.23.5)",
+ "tonic",
+]
+
+[[package]]
+name = "ibc-proto"
+version = "0.16.0"
+source = "git+https://github.com/heliaxdev/ibc-rs?rev=30b3495ac56c6c37c99bc69ef9f2e84c3309c6cc#30b3495ac56c6c37c99bc69ef9f2e84c3309c6cc"
+dependencies = [
+ "bytes 1.1.0",
+ "prost 0.9.0",
+ "prost-types 0.9.0",
+ "serde 1.0.137",
+ "tendermint-proto 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9)",
  "tonic",
 ]
 
@@ -6388,34 +6388,6 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master#95c52476bc37927218374f94ac8e2a19bd35bec9"
-dependencies = [
- "async-trait",
- "bytes 1.1.0",
- "ed25519",
- "ed25519-dalek",
- "flex-error",
- "futures 0.3.21",
- "num-traits 0.2.15",
- "once_cell",
- "prost 0.9.0",
- "prost-types 0.9.0",
- "serde 1.0.137",
- "serde_bytes",
- "serde_json",
- "serde_repr",
- "sha2 0.9.9",
- "signature",
- "subtle 2.4.1",
- "subtle-encoding",
- "tendermint-proto 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master)",
- "time 0.3.9",
- "zeroize",
-]
-
-[[package]]
-name = "tendermint"
-version = "0.23.5"
 source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/abcipp-v0.23.5#e43b68719e70e8e1c002e7f6fa557e0bafa01e0d"
 dependencies = [
  "async-trait",
@@ -6470,16 +6442,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "tendermint-config"
+name = "tendermint"
 version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master#95c52476bc37927218374f94ac8e2a19bd35bec9"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9#95c52476bc37927218374f94ac8e2a19bd35bec9"
 dependencies = [
+ "async-trait",
+ "bytes 1.1.0",
+ "ed25519",
+ "ed25519-dalek",
  "flex-error",
+ "futures 0.3.21",
+ "num-traits 0.2.15",
+ "once_cell",
+ "prost 0.9.0",
+ "prost-types 0.9.0",
  "serde 1.0.137",
+ "serde_bytes",
  "serde_json",
- "tendermint 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master)",
- "toml",
- "url 2.2.2",
+ "serde_repr",
+ "sha2 0.9.9",
+ "signature",
+ "subtle 2.4.1",
+ "subtle-encoding",
+ "tendermint-proto 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9)",
+ "time 0.3.9",
+ "zeroize",
 ]
 
 [[package]]
@@ -6496,16 +6483,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "tendermint-light-client-verifier"
+name = "tendermint-config"
 version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master#95c52476bc37927218374f94ac8e2a19bd35bec9"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9#95c52476bc37927218374f94ac8e2a19bd35bec9"
 dependencies = [
- "derive_more",
  "flex-error",
  "serde 1.0.137",
- "tendermint 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master)",
- "tendermint-rpc 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master)",
- "time 0.3.9",
+ "serde_json",
+ "tendermint 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9)",
+ "toml",
+ "url 2.2.2",
 ]
 
 [[package]]
@@ -6522,19 +6509,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "tendermint-proto"
+name = "tendermint-light-client-verifier"
 version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master#95c52476bc37927218374f94ac8e2a19bd35bec9"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9#95c52476bc37927218374f94ac8e2a19bd35bec9"
 dependencies = [
- "bytes 1.1.0",
+ "derive_more",
  "flex-error",
- "num-derive",
- "num-traits 0.2.15",
- "prost 0.9.0",
- "prost-types 0.9.0",
  "serde 1.0.137",
- "serde_bytes",
- "subtle-encoding",
+ "tendermint 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9)",
+ "tendermint-rpc 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9)",
  "time 0.3.9",
 ]
 
@@ -6573,36 +6556,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "tendermint-rpc"
+name = "tendermint-proto"
 version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master#95c52476bc37927218374f94ac8e2a19bd35bec9"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9#95c52476bc37927218374f94ac8e2a19bd35bec9"
 dependencies = [
- "async-trait",
- "async-tungstenite",
  "bytes 1.1.0",
  "flex-error",
- "futures 0.3.21",
- "getrandom 0.2.6",
- "http",
- "hyper 0.14.19",
- "hyper-proxy",
- "hyper-rustls",
- "peg",
- "pin-project 1.0.10",
+ "num-derive",
+ "num-traits 0.2.15",
+ "prost 0.9.0",
+ "prost-types 0.9.0",
  "serde 1.0.137",
  "serde_bytes",
- "serde_json",
  "subtle-encoding",
- "tendermint 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master)",
- "tendermint-config 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master)",
- "tendermint-proto 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master)",
- "thiserror",
  "time 0.3.9",
- "tokio",
- "tracing 0.1.35",
- "url 2.2.2",
- "uuid",
- "walkdir",
 ]
 
 [[package]]
@@ -6639,18 +6606,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "tendermint-testgen"
+name = "tendermint-rpc"
 version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master#95c52476bc37927218374f94ac8e2a19bd35bec9"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9#95c52476bc37927218374f94ac8e2a19bd35bec9"
 dependencies = [
- "ed25519-dalek",
- "gumdrop",
+ "async-trait",
+ "async-tungstenite",
+ "bytes 1.1.0",
+ "flex-error",
+ "futures 0.3.21",
+ "getrandom 0.2.6",
+ "http",
+ "hyper 0.14.19",
+ "hyper-proxy",
+ "hyper-rustls",
+ "peg",
+ "pin-project 1.0.10",
  "serde 1.0.137",
+ "serde_bytes",
  "serde_json",
- "simple-error",
- "tempfile",
- "tendermint 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master)",
+ "subtle-encoding",
+ "tendermint 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9)",
+ "tendermint-config 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9)",
+ "tendermint-proto 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9)",
+ "thiserror",
  "time 0.3.9",
+ "tokio",
+ "tracing 0.1.35",
+ "url 2.2.2",
+ "uuid",
+ "walkdir",
 ]
 
 [[package]]
@@ -6665,6 +6650,21 @@ dependencies = [
  "simple-error",
  "tempfile",
  "tendermint 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/rebase_v0.23.5)",
+ "time 0.3.9",
+]
+
+[[package]]
+name = "tendermint-testgen"
+version = "0.23.5"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9#95c52476bc37927218374f94ac8e2a19bd35bec9"
+dependencies = [
+ "ed25519-dalek",
+ "gumdrop",
+ "serde 1.0.137",
+ "serde_json",
+ "simple-error",
+ "tempfile",
+ "tendermint 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9)",
  "time 0.3.9",
 ]
 
@@ -7107,13 +7107,13 @@ dependencies = [
 [[package]]
 name = "tower-abci"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/tower-abci?branch=bat/abcipp-rebase-master#25a0c673ea6748730f86f7f20c933d0f07b50621"
+source = "git+https://github.com/heliaxdev/tower-abci?branch=yuji/rebase_v0.23.5_tracing#73e43bf79fb21b4969cc09f79a0a40ce4cc7bb52"
 dependencies = [
  "bytes 1.1.0",
  "futures 0.3.21",
  "pin-project 1.0.10",
  "prost 0.9.0",
- "tendermint-proto 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=bat/abcipp-rebase-master)",
+ "tendermint-proto 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/rebase_v0.23.5)",
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.10",
@@ -7125,13 +7125,13 @@ dependencies = [
 [[package]]
 name = "tower-abci"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/tower-abci?branch=yuji/rebase_v0.23.5_tracing#73e43bf79fb21b4969cc09f79a0a40ce4cc7bb52"
+source = "git+https://github.com/heliaxdev/tower-abci?rev=f6463388fc319b6e210503b43b3aecf6faf6b200#f6463388fc319b6e210503b43b3aecf6faf6b200"
 dependencies = [
  "bytes 1.1.0",
  "futures 0.3.21",
  "pin-project 1.0.10",
  "prost 0.9.0",
- "tendermint-proto 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/rebase_v0.23.5)",
+ "tendermint-proto 0.23.5 (git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9)",
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.10",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ dependencies = [
  "concat-idents",
  "derivative",
  "escargot",
+ "expectrl",
  "eyre",
  "file-serve",
  "fs_extra",
@@ -272,7 +273,6 @@ dependencies = [
  "pretty_assertions",
  "proptest",
  "prost 0.9.0",
- "rexpect",
  "serde_json",
  "sha2 0.9.9",
  "tempfile",
@@ -1322,6 +1322,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "conpty"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977baae4026273d7f9bb69a0a8eb4aed7ab9dac98799f742dce09173a9734754"
+dependencies = [
+ "windows",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1989,16 +1998,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "backtrace",
- "version_check 0.9.4",
-]
-
-[[package]]
 name = "escargot"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2015,6 +2014,17 @@ name = "event-listener"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
+
+[[package]]
+name = "expectrl"
+version = "0.4.0"
+source = "git+https://github.com/heliaxdev/expectrl.git?branch=tomas/expect-eager-2#9982bb2fd32560b359619dafe92964656406d36e"
+dependencies = [
+ "conpty",
+ "nix 0.23.1",
+ "ptyprocess",
+ "regex",
+]
 
 [[package]]
 name = "eyre"
@@ -4184,22 +4194,35 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.14.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
+checksum = "f5e06129fb611568ef4e868c14b326274959aa70ff7776e9d55323531c374945"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "void",
+ "memoffset",
 ]
 
 [[package]]
 name = "nix"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e06129fb611568ef4e868c14b326274959aa70ff7776e9d55323531c374945"
+checksum = "77d9f3521ea8e0641a153b3cddaf008dcbf26acd4ed739a2517295e0760d12c7"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
 dependencies = [
  "bitflags",
  "cc",
@@ -5050,6 +5073,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptyprocess"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69c28fcebfd842bfe19d69409fc321230ea8c1bebe31f274906485c761ce1917"
+dependencies = [
+ "nix 0.21.2",
+]
+
+[[package]]
 name = "pwasm-utils"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5463,17 +5495,6 @@ checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
  "hostname",
  "quick-error 1.2.3",
-]
-
-[[package]]
-name = "rexpect"
-version = "0.4.0"
-source = "git+https://github.com/heliaxdev/rexpect.git?branch=tomas/eof-hack-fix#3b5d729bfae74bd2c1d7bccf91b82273f05a1f45"
-dependencies = [
- "error-chain",
- "nix 0.14.1",
- "regex",
- "tempfile",
 ]
 
 [[package]]
@@ -8180,17 +8201,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aac7fef12f4b59cd0a29339406cc9203ab44e440ddff6b3f5a41455349fa9cf3"
+dependencies = [
+ "windows_aarch64_msvc 0.29.0",
+ "windows_i686_gnu 0.29.0",
+ "windows_i686_msvc 0.29.0",
+ "windows_x86_64_gnu 0.29.0",
+ "windows_x86_64_msvc 0.29.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d027175d00b01e0cbeb97d6ab6ebe03b12330a35786cbaca5252b1c4bf5d9b"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -8200,9 +8240,21 @@ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8793f59f7b8e8b01eda1a652b2697d87b93097198ae85f823b969ca5b89bba58"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8602f6c418b67024be2996c512f5f995de3ba417f4c75af68401ab8756796ae4"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8212,9 +8264,21 @@ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d615f419543e0bd7d2b3323af0d86ff19cbc4f816e6453f36a2c2ce889c354"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d95421d9ed3672c280884da53201a5c46b7b2765ca6faf34b0d71cf34a3561"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -123,12 +123,12 @@ sparse-merkle-tree = {git = "https://github.com/heliaxdev/sparse-merkle-tree", b
 sysinfo = {version = "=0.21.1", default-features = false}
 tar = "0.4.37"
 # temporarily using fork work-around
-tendermint = {git = "https://github.com/heliaxdev/tendermint-rs", branch = "bat/abcipp-rebase-master", optional = true}
-tendermint-config = {git = "https://github.com/heliaxdev/tendermint-rs", branch = "bat/abcipp-rebase-master", optional = true}
+tendermint = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", optional = true}
+tendermint-config = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", optional = true}
 tendermint-config-abci = {package = "tendermint-config", git = "https://github.com/heliaxdev/tendermint-rs", branch = "yuji/rebase_v0.23.5", optional = true}
-tendermint-proto = {git = "https://github.com/heliaxdev/tendermint-rs", branch = "bat/abcipp-rebase-master", optional = true}
+tendermint-proto = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", optional = true}
 tendermint-proto-abci = {package = "tendermint-proto", git = "https://github.com/heliaxdev/tendermint-rs", branch = "yuji/rebase_v0.23.5", optional = true}
-tendermint-rpc = {git = "https://github.com/heliaxdev/tendermint-rs", branch = "bat/abcipp-rebase-master", optional = true, features = ["http-client", "websocket-client"]}
+tendermint-rpc = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", optional = true, features = ["http-client", "websocket-client"]}
 tendermint-rpc-abci = {package = "tendermint-rpc", git = "https://github.com/heliaxdev/tendermint-rs", branch = "yuji/rebase_v0.23.5", optional = true, features = ["http-client", "websocket-client"]}
 tendermint-stable = {package = "tendermint", git = "https://github.com/heliaxdev/tendermint-rs", branch = "yuji/rebase_v0.23.5", optional = true}
 thiserror = "1.0.30"
@@ -138,7 +138,7 @@ tonic = "0.6.1"
 tower = "0.4"
 # Also, using the same version of tendermint-rs as we do here.
 # with a patch for https://github.com/penumbra-zone/tower-abci/issues/7.
-tower-abci = {git = "https://github.com/heliaxdev/tower-abci", branch = "bat/abcipp-rebase-master", optional = true}
+tower-abci = {git = "https://github.com/heliaxdev/tower-abci", rev = "f6463388fc319b6e210503b43b3aecf6faf6b200", optional = true}
 tower-abci-old = {package = "tower-abci", git = "https://github.com/heliaxdev/tower-abci", branch = "yuji/rebase_v0.23.5_tracing", optional = true}
 tracing = "0.1.30"
 tracing-log = "0.1.2"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -79,9 +79,9 @@ ferveo-common = {git = "https://github.com/anoma/ferveo"}
 hex = "0.4.3"
 tpke = {package = "group-threshold-cryptography", optional = true, git = "https://github.com/anoma/ferveo"}
 # TODO using the same version of tendermint-rs as we do here.
-ibc = {git = "https://github.com/heliaxdev/ibc-rs", branch = "bat/abcipp-rebase-master", default-features = false, optional = true}
+ibc = {git = "https://github.com/heliaxdev/ibc-rs", rev = "30b3495ac56c6c37c99bc69ef9f2e84c3309c6cc", default-features = false, optional = true}
 ibc-abci = {package = "ibc", git = "https://github.com/heliaxdev/ibc-rs", branch = "yuji/v0.12.0_tm_v0.23.5", default-features = false, optional = true}
-ibc-proto = {git = "https://github.com/heliaxdev/ibc-rs", branch = "bat/abcipp-rebase-master", default-features = false, optional = true}
+ibc-proto = {git = "https://github.com/heliaxdev/ibc-rs", rev = "30b3495ac56c6c37c99bc69ef9f2e84c3309c6cc", default-features = false, optional = true}
 ibc-proto-abci = {package = "ibc-proto", git = "https://github.com/heliaxdev/ibc-rs", branch = "yuji/v0.12.0_tm_v0.23.5", default-features = false, optional = true}
 ics23 = "0.6.7"
 itertools = "0.10.0"
@@ -103,8 +103,8 @@ sha2 = "0.9.3"
 sparse-merkle-tree = {git = "https://github.com/heliaxdev/sparse-merkle-tree", branch = "yuji/prost-0.9", default-features = false, features = ["std", "borsh"]}
 tempfile = {version = "3.2.0", optional = true}
 # temporarily using fork work-around for https://github.com/informalsystems/tendermint-rs/issues/971
-tendermint = {git = "https://github.com/heliaxdev/tendermint-rs", branch = "bat/abcipp-rebase-master", optional = true}
-tendermint-proto = {git = "https://github.com/heliaxdev/tendermint-rs", branch = "bat/abcipp-rebase-master", optional = true}
+tendermint = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", optional = true}
+tendermint-proto = {git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", optional = true}
 tendermint-proto-abci = {package = "tendermint-proto", git = "https://github.com/heliaxdev/tendermint-rs", branch = "yuji/rebase_v0.23.5", optional = true}
 tendermint-stable = {package = "tendermint", git = "https://github.com/heliaxdev/tendermint-rs", branch = "yuji/rebase_v0.23.5", optional = true}
 thiserror = "1.0.30"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -52,7 +52,7 @@ borsh = "0.9.1"
 color-eyre = "0.5.11"
 # NOTE: enable "print" feature to see output from builds ran by e2e tests
 escargot = {version = "0.5.7"} # , features = ["print"]}
-expectrl = {git = "https://github.com/heliaxdev/expectrl.git", branch = "tomas/expect-eager-2"}
+rexpect = {git = "https://github.com/heliaxdev/rexpect.git", branch = "tomas/eof-hack-fix"}
 eyre = "0.6.5"
 file-serve = "0.2.0"
 fs_extra = "1.2.0"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -23,6 +23,9 @@ ABCI-plus-plus = [
   "anoma_vm_env/ABCI-plus-plus",
 ]
 
+# re-enable once https://github.com/tendermint/tendermint/issues/8840 is fixed
+skip-tendermint-8840 = []
+
 [dependencies]
 anoma = {path = "../shared", default-features = false, features = ["testing"]}
 anoma_vm_env = {path = "../vm_env", default-features = false}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -52,7 +52,7 @@ borsh = "0.9.1"
 color-eyre = "0.5.11"
 # NOTE: enable "print" feature to see output from builds ran by e2e tests
 escargot = {version = "0.5.7"} # , features = ["print"]}
-rexpect = {git = "https://github.com/heliaxdev/rexpect.git", branch = "tomas/eof-hack-fix"}
+expectrl = {git = "https://github.com/heliaxdev/expectrl.git", branch = "tomas/expect-eager-2"}
 eyre = "0.6.5"
 file-serve = "0.2.0"
 fs_extra = "1.2.0"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -21,9 +21,10 @@ ABCI-plus-plus = [
   "anoma/ABCI-plus-plus",
   "anoma/ibc-mocks",
   "anoma_vm_env/ABCI-plus-plus",
+  "skip-tendermint-8840",
 ]
 
-# re-enable once https://github.com/tendermint/tendermint/issues/8840 is fixed
+# remove this everywhere once https://github.com/tendermint/tendermint/issues/8840 is fixed
 skip-tendermint-8840 = []
 
 [dependencies]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -21,11 +21,7 @@ ABCI-plus-plus = [
   "anoma/ABCI-plus-plus",
   "anoma/ibc-mocks",
   "anoma_vm_env/ABCI-plus-plus",
-  "skip-tendermint-8840",
 ]
-
-# remove this everywhere once https://github.com/tendermint/tendermint/issues/8840 is fixed
-skip-tendermint-8840 = []
 
 [dependencies]
 anoma = {path = "../shared", default-features = false, features = ["testing"]}

--- a/tests/src/e2e/eth_bridge_tests.rs
+++ b/tests/src/e2e/eth_bridge_tests.rs
@@ -39,6 +39,7 @@ fn everything() {
         .unwrap();
     anoman_ledger.exp_string("Tendermint node started").unwrap();
     anoman_ledger.exp_string("Committed block hash").unwrap();
+    let _bg_ledger = anoman_ledger.background();
 
     let tx_data_path = test.base_dir.path().join("queue_storage_key.txt");
     std::fs::write(&tx_data_path, &storage_key("queue")[..]).unwrap();

--- a/tests/src/e2e/eth_bridge_tests.rs
+++ b/tests/src/e2e/eth_bridge_tests.rs
@@ -39,7 +39,6 @@ fn everything() {
         .unwrap();
     anoman_ledger.exp_string("Tendermint node started").unwrap();
     anoman_ledger.exp_string("Committed block hash").unwrap();
-    let _bg_ledger = anoman_ledger.background();
 
     let tx_data_path = test.base_dir.path().join("queue_storage_key.txt");
     std::fs::write(&tx_data_path, &storage_key("queue")[..]).unwrap();

--- a/tests/src/e2e/gossip_tests.rs
+++ b/tests/src/e2e/gossip_tests.rs
@@ -56,7 +56,6 @@ fn run_gossip() -> Result<()> {
         .rsplit_once('\"')
         .unwrap()
         .1;
-    let _bg_node_0 = node_0.background();
 
     // Start the second gossip node (a peer node)
     let mut node_1 =
@@ -75,8 +74,6 @@ fn run_gossip() -> Result<()> {
         "Connect to a new peer: PeerId(\"{}\")",
         node_0_peer_id
     ))?;
-    let _bg_node_1 = node_1.background();
-
     // Start the third gossip node (another peer node)
     let mut node_2 =
         run_as!(test, Who::Validator(2), Bin::Node, &["gossip"], Some(20))?;
@@ -125,7 +122,6 @@ fn match_intents() -> Result<()> {
     ledger.exp_string("No state could be found")?;
     // Wait to commit a block
     ledger.exp_regex(r"Committed block hash.*, height: [0-9]+")?;
-    let bg_ledger = ledger.background();
 
     let intent_a_path_input = test.base_dir.path().join("intent.A.data");
     let intent_b_path_input = test.base_dir.path().join("intent.B.data");
@@ -202,7 +198,6 @@ fn match_intents() -> Result<()> {
 
     // Wait gossip to start
     gossiper.exp_string(&format!("RPC started at {}", rpc_address))?;
-    let _bg_gossiper = gossiper.background();
 
     // Start matchmaker
     let mut matchmaker = run_as!(
@@ -225,7 +220,6 @@ fn match_intents() -> Result<()> {
 
     // Wait for the matchmaker to start
     matchmaker.exp_string("Connected to the server")?;
-    let bg_matchmaker = matchmaker.background();
 
     let rpc_address = format!("http://{}", rpc_address);
     //  Send intent A
@@ -255,9 +249,7 @@ fn match_intents() -> Result<()> {
     )?;
     drop(session_send_intent_a);
 
-    let mut matchmaker = bg_matchmaker.foreground();
     matchmaker.exp_string("trying to match new intent")?;
-    let bg_matchmaker = matchmaker.background();
 
     // Send intent B
     let mut session_send_intent_b = run!(
@@ -286,9 +278,7 @@ fn match_intents() -> Result<()> {
     )?;
     drop(session_send_intent_b);
 
-    let mut matchmaker = bg_matchmaker.foreground();
     matchmaker.exp_string("trying to match new intent")?;
-    let bg_matchmaker = matchmaker.background();
 
     // Send intent C
     let mut session_send_intent_c = run!(
@@ -318,7 +308,6 @@ fn match_intents() -> Result<()> {
     drop(session_send_intent_c);
 
     // check that the transfers transactions are correct
-    let mut matchmaker = bg_matchmaker.foreground();
     matchmaker.exp_string(&format!(
         "crafting transfer: {}, {}, 70",
         bertha, albert
@@ -333,7 +322,6 @@ fn match_intents() -> Result<()> {
     ))?;
 
     // check that the all VPs accept the transaction
-    let mut ledger = bg_ledger.foreground();
     ledger.exp_string("all VPs accepted transaction")?;
 
     Ok(())

--- a/tests/src/e2e/gossip_tests.rs
+++ b/tests/src/e2e/gossip_tests.rs
@@ -56,6 +56,7 @@ fn run_gossip() -> Result<()> {
         .rsplit_once('\"')
         .unwrap()
         .1;
+    let _bg_node_0 = node_0.background();
 
     // Start the second gossip node (a peer node)
     let mut node_1 =
@@ -74,6 +75,8 @@ fn run_gossip() -> Result<()> {
         "Connect to a new peer: PeerId(\"{}\")",
         node_0_peer_id
     ))?;
+    let _bg_node_1 = node_1.background();
+
     // Start the third gossip node (another peer node)
     let mut node_2 =
         run_as!(test, Who::Validator(2), Bin::Node, &["gossip"], Some(20))?;
@@ -122,6 +125,7 @@ fn match_intents() -> Result<()> {
     ledger.exp_string("No state could be found")?;
     // Wait to commit a block
     ledger.exp_regex(r"Committed block hash.*, height: [0-9]+")?;
+    let bg_ledger = ledger.background();
 
     let intent_a_path_input = test.base_dir.path().join("intent.A.data");
     let intent_b_path_input = test.base_dir.path().join("intent.B.data");
@@ -198,6 +202,7 @@ fn match_intents() -> Result<()> {
 
     // Wait gossip to start
     gossiper.exp_string(&format!("RPC started at {}", rpc_address))?;
+    let _bg_gossiper = gossiper.background();
 
     // Start matchmaker
     let mut matchmaker = run_as!(
@@ -220,6 +225,7 @@ fn match_intents() -> Result<()> {
 
     // Wait for the matchmaker to start
     matchmaker.exp_string("Connected to the server")?;
+    let bg_matchmaker = matchmaker.background();
 
     let rpc_address = format!("http://{}", rpc_address);
     //  Send intent A
@@ -249,7 +255,9 @@ fn match_intents() -> Result<()> {
     )?;
     drop(session_send_intent_a);
 
+    let mut matchmaker = bg_matchmaker.foreground();
     matchmaker.exp_string("trying to match new intent")?;
+    let bg_matchmaker = matchmaker.background();
 
     // Send intent B
     let mut session_send_intent_b = run!(
@@ -278,7 +286,9 @@ fn match_intents() -> Result<()> {
     )?;
     drop(session_send_intent_b);
 
+    let mut matchmaker = bg_matchmaker.foreground();
     matchmaker.exp_string("trying to match new intent")?;
+    let bg_matchmaker = matchmaker.background();
 
     // Send intent C
     let mut session_send_intent_c = run!(
@@ -308,6 +318,7 @@ fn match_intents() -> Result<()> {
     drop(session_send_intent_c);
 
     // check that the transfers transactions are correct
+    let mut matchmaker = bg_matchmaker.foreground();
     matchmaker.exp_string(&format!(
         "crafting transfer: {}, {}, 70",
         bertha, albert
@@ -322,6 +333,7 @@ fn match_intents() -> Result<()> {
     ))?;
 
     // check that the all VPs accept the transaction
+    let mut ledger = bg_ledger.foreground();
     ledger.exp_string("all VPs accepted transaction")?;
 
     Ok(())

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -248,9 +248,6 @@ fn ledger_txs_and_queries() -> Result<()> {
     } else {
         ledger.exp_string("Started node")?;
     }
-
-    let _bg_ledger = ledger.background();
-
     let vp_user = wasm_abs_path(VP_USER_WASM);
     let vp_user = vp_user.to_string_lossy();
     let tx_no_op = wasm_abs_path(TX_NO_OP_WASM);
@@ -429,9 +426,6 @@ fn invalid_transactions() -> Result<()> {
     }
     // Wait to commit a block
     ledger.exp_regex(r"Committed block hash.*, height: [0-9]+")?;
-
-    let bg_ledger = ledger.background();
-
     // 2. Submit a an invalid transaction (trying to mint tokens should fail
     // in the token's VP)
     let tx_data_path = test.base_dir.path().join("tx.data");
@@ -478,7 +472,6 @@ fn invalid_transactions() -> Result<()> {
     client.exp_string(r#""code": "1"#)?;
 
     client.assert_success();
-    let mut ledger = bg_ledger.foreground();
     ledger.exp_string("some VPs rejected transaction")?;
 
     // Wait to commit a block
@@ -500,7 +493,6 @@ fn invalid_transactions() -> Result<()> {
 
     // There should be previous state now
     ledger.exp_string("Last state root hash:")?;
-    let _bg_ledger = ledger.background();
 
     // 5. Submit an invalid transactions (invalid token address)
     let tx_args = vec![
@@ -587,8 +579,6 @@ fn pos_bonds() -> Result<()> {
     } else {
         ledger.exp_string("Started node")?;
     }
-    let _bg_ledger = ledger.background();
-
     let validator_one_rpc = get_actor_rpc(&test, &Who::Validator(0));
 
     // 2. Submit a self-bond for the gepnesis validator
@@ -785,7 +775,6 @@ fn pos_init_validator() -> Result<()> {
     } else {
         ledger.exp_string("Started node")?;
     }
-    let _bg_ledger = ledger.background();
 
     let validator_one_rpc = get_actor_rpc(&test, &Who::Validator(0));
 
@@ -955,8 +944,6 @@ fn ledger_many_txs_in_a_block() -> Result<()> {
 
     // Wait to commit a block
     ledger.exp_regex(r"Committed block hash.*, height: [0-9]+")?;
-    let bg_ledger = ledger.background();
-
     let validator_one_rpc = Arc::new(get_actor_rpc(&test, &Who::Validator(0)));
 
     // A token transfer tx args
@@ -1007,7 +994,6 @@ fn ledger_many_txs_in_a_block() -> Result<()> {
         task.join().unwrap()?;
     }
     // Wait to commit a block
-    let mut ledger = bg_ledger.foreground();
     ledger.exp_regex(r"Committed block hash.*, height: [0-9]+")?;
 
     Ok(())
@@ -1047,7 +1033,6 @@ fn proposal_submission() -> Result<()> {
     } else {
         ledger.exp_string("Started node")?;
     }
-    let _bg_ledger = ledger.background();
 
     let validator_one_rpc = get_actor_rpc(&test, &Who::Validator(0));
 
@@ -1399,8 +1384,6 @@ fn proposal_offline() -> Result<()> {
     } else {
         ledger.exp_string("Started node")?;
     }
-    let _bg_ledger = ledger.background();
-
     let validator_one_rpc = get_actor_rpc(&test, &Who::Validator(0));
 
     // 1.1 Delegate some token

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -248,6 +248,9 @@ fn ledger_txs_and_queries() -> Result<()> {
     } else {
         ledger.exp_string("Started node")?;
     }
+
+    let _bg_ledger = ledger.background();
+
     let vp_user = wasm_abs_path(VP_USER_WASM);
     let vp_user = vp_user.to_string_lossy();
     let tx_no_op = wasm_abs_path(TX_NO_OP_WASM);
@@ -426,6 +429,9 @@ fn invalid_transactions() -> Result<()> {
     }
     // Wait to commit a block
     ledger.exp_regex(r"Committed block hash.*, height: [0-9]+")?;
+
+    let bg_ledger = ledger.background();
+
     // 2. Submit a an invalid transaction (trying to mint tokens should fail
     // in the token's VP)
     let tx_data_path = test.base_dir.path().join("tx.data");
@@ -472,6 +478,7 @@ fn invalid_transactions() -> Result<()> {
     client.exp_string(r#""code": "1"#)?;
 
     client.assert_success();
+    let mut ledger = bg_ledger.foreground();
     ledger.exp_string("some VPs rejected transaction")?;
 
     // Wait to commit a block
@@ -493,6 +500,7 @@ fn invalid_transactions() -> Result<()> {
 
     // There should be previous state now
     ledger.exp_string("Last state root hash:")?;
+    let _bg_ledger = ledger.background();
 
     // 5. Submit an invalid transactions (invalid token address)
     let tx_args = vec![
@@ -579,6 +587,8 @@ fn pos_bonds() -> Result<()> {
     } else {
         ledger.exp_string("Started node")?;
     }
+    let _bg_ledger = ledger.background();
+
     let validator_one_rpc = get_actor_rpc(&test, &Who::Validator(0));
 
     // 2. Submit a self-bond for the gepnesis validator
@@ -775,6 +785,7 @@ fn pos_init_validator() -> Result<()> {
     } else {
         ledger.exp_string("Started node")?;
     }
+    let _bg_ledger = ledger.background();
 
     let validator_one_rpc = get_actor_rpc(&test, &Who::Validator(0));
 
@@ -944,6 +955,8 @@ fn ledger_many_txs_in_a_block() -> Result<()> {
 
     // Wait to commit a block
     ledger.exp_regex(r"Committed block hash.*, height: [0-9]+")?;
+    let bg_ledger = ledger.background();
+
     let validator_one_rpc = Arc::new(get_actor_rpc(&test, &Who::Validator(0)));
 
     // A token transfer tx args
@@ -994,6 +1007,7 @@ fn ledger_many_txs_in_a_block() -> Result<()> {
         task.join().unwrap()?;
     }
     // Wait to commit a block
+    let mut ledger = bg_ledger.foreground();
     ledger.exp_regex(r"Committed block hash.*, height: [0-9]+")?;
 
     Ok(())
@@ -1033,6 +1047,7 @@ fn proposal_submission() -> Result<()> {
     } else {
         ledger.exp_string("Started node")?;
     }
+    let _bg_ledger = ledger.background();
 
     let validator_one_rpc = get_actor_rpc(&test, &Who::Validator(0));
 
@@ -1384,6 +1399,8 @@ fn proposal_offline() -> Result<()> {
     } else {
         ledger.exp_string("Started node")?;
     }
+    let _bg_ledger = ledger.background();
+
     let validator_one_rpc = get_actor_rpc(&test, &Who::Validator(0));
 
     // 1.1 Delegate some token

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -9,27 +9,20 @@
 //! To keep the temporary files created by a test, use env var
 //! `ANOMA_E2E_KEEP_TEMP=true`.
 
-use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
-use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::process::Command;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use anoma::types::chain::ChainId;
 use anoma::types::token;
 use anoma_apps::config::genesis::genesis_config::{
-    self, GenesisConfig, ParametersConfig, PosParamsConfig,
-    ValidatorPreGenesisConfig,
+    GenesisConfig, ParametersConfig, PosParamsConfig,
 };
-use anoma_apps::config::Config;
 use borsh::BorshSerialize;
 use color_eyre::eyre::Result;
 use serde_json::json;
 use setup::constants::*;
-use tempfile::tempdir;
 
 use super::setup::working_dir;
 use crate::e2e::helpers::{
@@ -73,6 +66,7 @@ fn run_ledger() -> Result<()> {
 /// 1. Run 2 genesis validator ledger nodes and 1 non-validator node
 /// 2. Submit a valid token transfer tx
 /// 3. Check that all the nodes processed the tx with the same result
+#[cfg(feature = "skip-tendermint-8840")]
 #[test]
 fn test_node_connectivity() -> Result<()> {
     // Setup 2 genesis validator nodes
@@ -1558,7 +1552,19 @@ fn generate_proposal_json(
 /// 4. Submit a valid token transfer tx from one validator to the other
 /// 5. Check that all the nodes processed the tx with the same result
 #[test]
+#[cfg(feature = "skip-tendermint-8840")]
 fn test_genesis_validators() -> Result<()> {
+    use std::collections::HashMap;
+    use std::net::SocketAddr;
+    use std::str::FromStr;
+
+    use anoma::types::chain::ChainId;
+    use anoma_apps::config::genesis::genesis_config::{
+        self, ValidatorPreGenesisConfig,
+    };
+    use anoma_apps::config::Config;
+    use tempfile::tempdir;
+
     // This test is not using the `setup::network`, because we're setting up
     // custom genesis validators
     setup::INIT.call_once(|| {

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -66,7 +66,7 @@ fn run_ledger() -> Result<()> {
 /// 1. Run 2 genesis validator ledger nodes and 1 non-validator node
 /// 2. Submit a valid token transfer tx
 /// 3. Check that all the nodes processed the tx with the same result
-#[cfg(feature = "skip-tendermint-8840")]
+#[cfg(not(feature = "skip-tendermint-8840"))]
 #[test]
 fn test_node_connectivity() -> Result<()> {
     // Setup 2 genesis validator nodes
@@ -1534,8 +1534,8 @@ fn generate_proposal_json(
 /// 3. Setup and start the 2 genesis validator nodes and a non-validator node
 /// 4. Submit a valid token transfer tx from one validator to the other
 /// 5. Check that all the nodes processed the tx with the same result
+#[cfg(not(feature = "skip-tendermint-8840"))]
 #[test]
-#[cfg(feature = "skip-tendermint-8840")]
 fn test_genesis_validators() -> Result<()> {
     use std::collections::HashMap;
     use std::net::SocketAddr;

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -66,7 +66,8 @@ fn run_ledger() -> Result<()> {
 /// 1. Run 2 genesis validator ledger nodes and 1 non-validator node
 /// 2. Submit a valid token transfer tx
 /// 3. Check that all the nodes processed the tx with the same result
-#[cfg(not(feature = "skip-tendermint-8840"))]
+/// TODO: run this test for ABCI-plus-plus once https://github.com/tendermint/tendermint/issues/8840 is fixed
+#[cfg(not(feature = "ABCI-plus-plus"))]
 #[test]
 fn test_node_connectivity() -> Result<()> {
     // Setup 2 genesis validator nodes
@@ -1534,7 +1535,8 @@ fn generate_proposal_json(
 /// 3. Setup and start the 2 genesis validator nodes and a non-validator node
 /// 4. Submit a valid token transfer tx from one validator to the other
 /// 5. Check that all the nodes processed the tx with the same result
-#[cfg(not(feature = "skip-tendermint-8840"))]
+/// TODO: run this test for ABCI-plus-plus once https://github.com/tendermint/tendermint/issues/8840 is fixed
+#[cfg(not(feature = "ABCI-plus-plus"))]
 #[test]
 fn test_genesis_validators() -> Result<()> {
     use std::collections::HashMap;

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -961,7 +961,7 @@ fn ledger_many_txs_in_a_block() -> Result<()> {
 
     // Wait to commit a block
     ledger.exp_regex(r"Committed block hash.*, height: [0-9]+")?;
-    let _bg_ledger = ledger.background();
+    let bg_ledger = ledger.background();
 
     let validator_one_rpc = Arc::new(get_actor_rpc(&test, &Who::Validator(0)));
 
@@ -1013,6 +1013,7 @@ fn ledger_many_txs_in_a_block() -> Result<()> {
         task.join().unwrap()?;
     }
     // Wait to commit a block
+    let mut ledger = bg_ledger.foreground();
     ledger.exp_regex(r"Committed block hash.*, height: [0-9]+")?;
 
     Ok(())

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -14,9 +14,9 @@ use assert_cmd::assert::OutputAssertExt;
 use color_eyre::eyre::Result;
 use color_eyre::owo_colors::OwoColorize;
 use escargot::CargoBuild;
-use expectrl::session::Session;
-use expectrl::{Eof, WaitStatus};
 use eyre::eyre;
+use rexpect::process::wait::WaitStatus;
+use rexpect::session::{spawn_command, PtySession};
 use tempfile::{tempdir, TempDir};
 
 /// For `color_eyre::install`, which fails if called more than once in the same
@@ -401,62 +401,18 @@ pub fn working_dir() -> PathBuf {
 
 /// A command under test
 pub struct AnomaCmd {
-    pub session: Session,
+    pub session: PtySession,
     pub cmd_str: String,
 }
 
-/// A command under test running on a background thread
-pub struct AnomaBgCmd {
-    join_handle: std::thread::JoinHandle<AnomaCmd>,
-    abort_send: std::sync::mpsc::Sender<()>,
-}
-
-impl AnomaBgCmd {
-    /// Re-gain control of a background command (created with
-    /// [`AnomaCmd::background()`]) to check its output.
-    pub fn foreground(self) -> AnomaCmd {
-        self.abort_send.send(()).unwrap();
-        self.join_handle.join().unwrap()
-    }
-}
-
 impl AnomaCmd {
-    /// Keep reading the session's output in a background thread to prevent the
-    /// buffer from filling up. Call [`AnomaBgCmd::foreground()`] on the
-    /// returned [`AnomaBgCmd`] to stop the loop and return back the original
-    /// command.
-    pub fn background(self) -> AnomaBgCmd {
-        let (abort_send, abort_recv) = std::sync::mpsc::channel();
-        let join_handle = std::thread::spawn(move || {
-            let mut cmd = self;
-            loop {
-                match abort_recv.try_recv() {
-                    Ok(())
-                    | Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                        return cmd;
-                    }
-                    Err(std::sync::mpsc::TryRecvError::Empty) => {}
-                }
-                cmd.session.is_matched(Eof).unwrap();
-            }
-        });
-        AnomaBgCmd {
-            join_handle,
-            abort_send,
-        }
-    }
-
     /// Assert that the process exited with success
     pub fn assert_success(&self) {
-        let status = self.session.wait().unwrap();
-        assert_eq!(WaitStatus::Exited(self.session.pid(), 0), status);
-    }
-
-    /// Assert that the process exited with failure
-    #[allow(dead_code)]
-    pub fn assert_failure(&self) {
-        let status = self.session.wait().unwrap();
-        assert_ne!(WaitStatus::Exited(self.session.pid(), 0), status);
+        let status = self.session.process.wait().unwrap();
+        assert_eq!(
+            WaitStatus::Exited(self.session.process.child_pid, 0),
+            status
+        );
     }
 
     /// Wait until provided string is seen on stdout of child process.
@@ -465,16 +421,9 @@ impl AnomaCmd {
     /// Wrapper over the inner `PtySession`'s functions with custom error
     /// reporting.
     pub fn exp_string(&mut self, needle: &str) -> Result<String> {
-        let found = self
-            .session
-            .expect_eager(needle)
-            .map_err(|e| eyre!(format!("{}\n Needle: {}", e, needle)))?;
-        if found.is_empty() {
-            Err(eyre!(format!("Expected needle not found: {}", needle)))
-        } else {
-            String::from_utf8(found.before().to_vec())
-                .map_err(|e| eyre!(format!("{}", e)))
-        }
+        self.session
+            .exp_string(needle)
+            .map_err(|e| eyre!(format!("{}", e)))
     }
 
     /// Wait until provided regex is seen on stdout of child process.
@@ -482,40 +431,22 @@ impl AnomaCmd {
     /// 1. the yet unread output
     /// 2. the matched regex
     ///
-    /// Wrapper over the inner `Session`'s functions with custom error
-    /// reporting as well as converting bytes back to `String`.
+    /// Wrapper over the inner `PtySession`'s functions with custom error
+    /// reporting.
     pub fn exp_regex(&mut self, regex: &str) -> Result<(String, String)> {
-        let found = self
-            .session
-            .expect_eager(expectrl::Regex(regex))
-            .map_err(|e| eyre!(format!("{}", e)))?;
-        if found.is_empty() {
-            Err(eyre!(format!("Expected regex not found: {}", regex)))
-        } else {
-            let unread = String::from_utf8(found.before().to_vec())
-                .map_err(|e| eyre!(format!("{}", e)))?;
-            let matched =
-                String::from_utf8(found.matches().next().unwrap().to_vec())
-                    .map_err(|e| eyre!(format!("{}", e)))?;
-            Ok((unread, matched))
-        }
+        self.session
+            .exp_regex(regex)
+            .map_err(|e| eyre!(format!("{}", e)))
     }
 
     /// Wait until we see EOF (i.e. child process has terminated)
     /// Return all the yet unread output
     ///
-    /// Wrapper over the inner `Session`'s functions with custom error
+    /// Wrapper over the inner `PtySession`'s functions with custom error
     /// reporting.
     #[allow(dead_code)]
     pub fn exp_eof(&mut self) -> Result<String> {
-        let found =
-            self.session.expect_eager(Eof).map_err(|e| eyre!("{}", e))?;
-        if found.is_empty() {
-            Err(eyre!("Expected EOF"))
-        } else {
-            String::from_utf8(found.before().to_vec())
-                .map_err(|e| eyre!(format!("{}", e)))
-        }
+        self.session.exp_eof().map_err(|e| eyre!(format!("{}", e)))
     }
 
     /// Send a control code to the running process and consume resulting output
@@ -524,7 +455,7 @@ impl AnomaCmd {
     /// E.g. `send_control('c')` sends ctrl-c. Upper/smaller case does not
     /// matter.
     ///
-    /// Wrapper over the inner `Session`'s functions with custom error
+    /// Wrapper over the inner `PtySession`'s functions with custom error
     /// reporting.
     pub fn send_control(&mut self, c: char) -> Result<()> {
         self.session
@@ -536,9 +467,9 @@ impl AnomaCmd {
     /// the input to appear.
     /// Return: number of bytes written
     ///
-    /// Wrapper over the inner `Session`'s functions with custom error
+    /// Wrapper over the inner `PtySession`'s functions with custom error
     /// reporting.
-    pub fn send_line(&mut self, line: &str) -> Result<()> {
+    pub fn send_line(&mut self, line: &str) -> Result<usize> {
         self.session
             .send_line(line)
             .map_err(|e| eyre!(format!("{}", e)))
@@ -553,39 +484,48 @@ impl Drop for AnomaCmd {
             "Waiting for command to finish".underline().yellow(),
             self.cmd_str,
         );
-        let _result = self.send_control('c');
-        match self.exp_eof() {
+        if let Err(error) = self.session.process.exit() {
+            eprintln!(
+                "\n{}: {}\n{}: {}",
+                "Error waiting for command to finish".underline().red(),
+                self.cmd_str,
+                "Error".underline().red(),
+                error,
+            );
+            return;
+        };
+        println!(
+            "\n{}: {}",
+            "Command finished".underline().green(),
+            self.cmd_str,
+        );
+        let output = match self.session.exp_eof() {
+            Ok(output) => output,
             Err(error) => {
                 eprintln!(
                     "\n{}: {}\n{}: {}",
-                    "Error waiting for command to finish".underline().red(),
+                    "Error reading output for command".underline().red(),
                     self.cmd_str,
                     "Error".underline().red(),
                     error,
                 );
+                return;
             }
-            Ok(output) => {
-                println!(
-                    "\n{}: {}",
-                    "Command finished".underline().green(),
-                    self.cmd_str,
-                );
-                let output = output.trim();
-                if !output.is_empty() {
-                    println!(
-                        "\n{}: {}\n\n{}",
-                        "Unread output for command".underline().yellow(),
-                        self.cmd_str,
-                        output
-                    );
-                } else {
-                    println!(
-                        "\n{}: {}",
-                        "No unread output for command".underline().green(),
-                        self.cmd_str
-                    );
-                }
-            }
+        };
+        let output = output.trim();
+        if !output.is_empty() {
+            println!(
+                "\n{}: {}\n\n{}",
+                "Unread output for command".underline().yellow(),
+                self.cmd_str,
+                output
+            );
+        } else {
+            println!(
+                "\n{}: {}",
+                "No unread output for command".underline().green(),
+                self.cmd_str
+            );
         }
     }
 }
@@ -671,8 +611,9 @@ where
         .args(args);
     let cmd_str = format!("{:?}", run_cmd);
 
+    let timeout_ms = timeout_sec.map(|sec| sec * 1_000);
     println!("{}: {}", "Running".underline().green(), cmd_str);
-    let mut session = Session::spawn(run_cmd).map_err(|e| {
+    let mut session = spawn_command(run_cmd, timeout_ms).map_err(|e| {
         eyre!(
             "\n\n{}: {}\n{}: {}\n{}: {}",
             "Failed to run".underline().red(),
@@ -683,34 +624,33 @@ where
             e
         )
     })?;
-    session.set_expect_timeout(timeout_sec.map(std::time::Duration::from_secs));
 
-    let mut cmd_process = AnomaCmd { session, cmd_str };
     if let Bin::Node = &bin {
         // When running a node command, we need to wait a bit before checking
         // status
         sleep(1);
 
         // If the command failed, try print out its output
-        if let Ok(WaitStatus::Exited(_, result)) = cmd_process.session.status()
+        if let Some(rexpect::process::wait::WaitStatus::Exited(_, result)) =
+            session.process.status()
         {
             if result != 0 {
-                let output = cmd_process.exp_eof().unwrap_or_else(|err| {
-                    format!("No output found, error: {}", err)
-                });
                 return Err(eyre!(
                     "\n\n{}: {}\n{}: {} \n\n{}: {}",
                     "Failed to run".underline().red(),
-                    cmd_process.cmd_str,
+                    cmd_str,
                     "Location".underline().red(),
                     loc,
                     "Output".underline().red(),
-                    output,
+                    session.exp_eof().unwrap_or_else(|err| format!(
+                        "No output found, error: {}",
+                        err
+                    ))
                 ));
             }
         }
     }
-    Ok(cmd_process)
+    Ok(AnomaCmd { session, cmd_str })
 }
 
 /// Sleep for given `seconds`.


### PR DESCRIPTION
This PR replaces https://github.com/anoma/anoma/pull/1177 which was targeting `bat/abcipp-rebase-master`

- fix a compilation error in `ledger_many_txs_in_a_block`
- skip `test_node_connectivity` and `test_genesis_validators` in ABCI++ for now, due to https://github.com/tendermint/tendermint/issues/8840
- use the specific commits of the dependencies `ibc-rs`, `tendermint-rs` and `tower-abci` that will work with a Tendermint binary built off of [29e5fbcc648510e4763bd0af0b461aed92c21f30](https://github.com/tendermint/tendermint/commit/29e5fbcc648510e4763bd0af0b461aed92c21f30), which is the one we are using in CI for ABCI++ e2e tests

# TODO
- merge https://github.com/heliaxdev/tower-abci/pull/1 and https://github.com/heliaxdev/ibc-rs/pull/2 and use those commits in this branch for `tower-abci` and `ibc-rs` dependencies, respectively
- verify `make test-e2e-abci-plus-plus` passes locally