### PR TITLE
Updates to the `eth-bridge-integration` branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,6 @@ dependencies = [
  "ed25519-consensus",
  "ferveo",
  "ferveo-common",
- "fraction",
  "group-threshold-cryptography",
  "hex",
  "ibc 0.12.0 (git+https://github.com/heliaxdev/ibc-rs?branch=bat/abcipp-rebase-master)",
@@ -100,6 +99,7 @@ dependencies = [
  "ics23",
  "itertools 0.10.3",
  "loupe",
+ "num-rational",
  "parity-wasm",
  "pretty_assertions",
  "proptest",
@@ -2206,16 +2206,6 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding 2.1.0",
-]
-
-[[package]]
-name = "fraction"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c42ca58f4e486c530d93c7f74ab469293b20d7f86b478ca9d702a2f95fed61"
-dependencies = [
- "lazy_static 1.4.0",
- "num",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,7 @@ dependencies = [
  "ed25519-consensus",
  "ferveo",
  "ferveo-common",
+ "fraction",
  "group-threshold-cryptography",
  "hex",
  "ibc 0.12.0 (git+https://github.com/heliaxdev/ibc-rs?branch=bat/abcipp-rebase-master)",
@@ -2205,6 +2206,16 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding 2.1.0",
+]
+
+[[package]]
+name = "fraction"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c42ca58f4e486c530d93c7f74ab469293b20d7f86b478ca9d702a2f95fed61"
+dependencies = [
+ "lazy_static 1.4.0",
+ "num",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,7 @@ dependencies = [
  "clru",
  "derivative",
  "ed25519-consensus",
+ "eyre",
  "ferveo",
  "ferveo-common",
  "group-threshold-cryptography",

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -76,6 +76,7 @@ derivative = "2.2.0"
 ed25519-consensus = "1.2.0"
 ferveo = {optional = true, git = "https://github.com/anoma/ferveo"}
 ferveo-common = {git = "https://github.com/anoma/ferveo"}
+fraction = "0.11.0"
 hex = "0.4.3"
 tpke = {package = "group-threshold-cryptography", optional = true, git = "https://github.com/anoma/ferveo"}
 # TODO using the same version of tendermint-rs as we do here.

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -74,6 +74,7 @@ chrono = "0.4.19"
 clru = {git = "https://github.com/marmeladema/clru-rs.git", rev = "71ca566"}
 derivative = "2.2.0"
 ed25519-consensus = "1.2.0"
+eyre = "0.6.8"
 ferveo = {optional = true, git = "https://github.com/anoma/ferveo"}
 ferveo-common = {git = "https://github.com/anoma/ferveo"}
 num-rational = "0.4.1"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -76,7 +76,7 @@ derivative = "2.2.0"
 ed25519-consensus = "1.2.0"
 ferveo = {optional = true, git = "https://github.com/anoma/ferveo"}
 ferveo-common = {git = "https://github.com/anoma/ferveo"}
-fraction = "0.11.0"
+num-rational = "0.4.1"
 hex = "0.4.3"
 tpke = {package = "group-threshold-cryptography", optional = true, git = "https://github.com/anoma/ferveo"}
 # TODO using the same version of tendermint-rs as we do here.

--- a/shared/src/types/ethereum_events.rs
+++ b/shared/src/types/ethereum_events.rs
@@ -65,7 +65,13 @@ pub enum EthereumAsset {
 #[derive(
     Clone, PartialEq, Eq, Debug, BorshSerialize, BorshDeserialize, BorshSchema,
 )]
-struct FractionalVotingPower(fraction::Fraction);
+pub struct FractionalVotingPower(u64, u64);
+
+impl From<FractionalVotingPower> for fraction::Fraction {
+    fn from(fvp: FractionalVotingPower) -> Self {
+        fraction::Fraction::new(fvp.0, fvp.1)
+    }
+}
 
 /// This is created by the block proposer based on the Ethereum events included
 /// in the vote extensions of the previous Tendermint round

--- a/shared/src/types/ethereum_events.rs
+++ b/shared/src/types/ethereum_events.rs
@@ -12,7 +12,7 @@ use crate::types::token::Amount;
 #[derive(
     Debug, PartialEq, Eq, Clone, BorshSerialize, BorshDeserialize, BorshSchema,
 )]
-pub struct EthereumEventNonce(u64);
+pub struct Nonce(u64);
 
 /// An Ethereum event to be processed by the Anoma ledger
 #[derive(
@@ -21,7 +21,7 @@ pub struct EthereumEventNonce(u64);
 pub enum EthereumEvent {
     /// Event transferring batches of ether from Ethereum to wrapped ETH on
     /// Anoma
-    TransfersToNamada(Vec<TransferToNamada>, EthereumEventNonce),
+    TransfersToNamada(Vec<TransferToNamada>, Nonce),
 }
 
 impl EthereumEvent {
@@ -89,7 +89,7 @@ mod tests {
 
     #[test]
     fn test_ethereum_event_hash() {
-        let nonce = EthereumEventNonce(123);
+        let nonce = Nonce(123);
         let event = EthereumEvent::TransfersToNamada(vec![], nonce);
 
         let hash = event.hash().unwrap();

--- a/shared/src/types/ethereum_events.rs
+++ b/shared/src/types/ethereum_events.rs
@@ -19,6 +19,7 @@ pub enum EthereumEvent {
 }
 
 impl EthereumEvent {
+    /// SHA256 of the Borsh serialization of the [`EthereumEvent`]
     fn hash(&self) -> Result<[u8; 32], std::io::Error> {
         let bytes = self.try_to_vec()?;
         let mut hasher = Sha256::new();

--- a/shared/src/types/ethereum_events.rs
+++ b/shared/src/types/ethereum_events.rs
@@ -18,10 +18,22 @@ pub struct Nonce(u64);
 #[derive(
     Debug, PartialEq, Eq, Clone, BorshSerialize, BorshDeserialize, BorshSchema,
 )]
-pub enum EthereumEvent {
-    /// Event transferring batches of ether from Ethereum to wrapped ETH on
-    /// Anoma
-    TransfersToNamada(Vec<TransferToNamada>, Nonce),
+pub enum RawEvent {
+    /// Event transferring batches of Ethereum assets from Ethereum to wrapped
+    /// assets on Anoma
+    TransfersToNamada(Vec<TransferToNamada>),
+}
+
+/// An Ethereum event emitted by an Ethereum bridge smart contract.
+#[derive(
+    Debug, PartialEq, Eq, Clone, BorshSerialize, BorshDeserialize, BorshSchema,
+)]
+pub struct EthereumEvent {
+    /// The Ethereum event.
+    pub event: RawEvent,
+    /// All events must be emitted with a nonce so that otherwise identical
+    /// events will be unique.
+    pub nonce: Nonce,
 }
 
 impl EthereumEvent {
@@ -90,7 +102,8 @@ mod tests {
     #[test]
     fn test_ethereum_event_hash() {
         let nonce = Nonce(123);
-        let event = EthereumEvent::TransfersToNamada(vec![], nonce);
+        let event = RawEvent::TransfersToNamada(vec![]);
+        let event = EthereumEvent { nonce, event };
 
         let hash = event.hash().unwrap();
 

--- a/shared/src/types/ethereum_events.rs
+++ b/shared/src/types/ethereum_events.rs
@@ -2,10 +2,10 @@
 use std::fmt::Debug;
 
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use sha2::{Digest, Sha256};
 
 use crate::proto::MultiSigned;
 use crate::types::address::Address;
+use crate::types::hash::Hash;
 use crate::types::token::Amount;
 
 /// Each event has a nonce set by the Ethereum smart contract that emitted it.
@@ -25,13 +25,10 @@ pub enum EthereumEvent {
 }
 
 impl EthereumEvent {
-    /// SHA256 of the Borsh serialization of the [`EthereumEvent`]
-    fn hash(&self) -> Result<[u8; 32], std::io::Error> {
+    /// SHA256 of the Borsh serialization of the [`EthereumEvent`].
+    fn hash(&self) -> Result<Hash, std::io::Error> {
         let bytes = self.try_to_vec()?;
-        let mut hasher = Sha256::new();
-        hasher.update(&bytes);
-        let hash: [u8; 32] = hasher.finalize().into();
-        Ok(hash)
+        Ok(Hash::sha256(&bytes))
     }
 }
 
@@ -86,11 +83,11 @@ mod tests {
 
         assert_eq!(
             hash,
-            [
+            Hash([
                 94, 227, 170, 45, 164, 208, 161, 180, 203, 148, 96, 173, 90,
                 30, 102, 44, 30, 187, 124, 90, 117, 204, 19, 188, 7, 104, 19,
                 46, 13, 62, 203, 243
-            ]
+            ])
         );
     }
 }

--- a/shared/src/types/ethereum_events.rs
+++ b/shared/src/types/ethereum_events.rs
@@ -41,8 +41,6 @@ pub struct TransferToNamada {
     Debug, PartialEq, Eq, Clone, BorshSerialize, BorshDeserialize, BorshSchema,
 )]
 pub enum EthereumAsset {
-    /// Native ETH
-    Eth,
     /// An ERC20 token and the address of its contract
     ERC20(EthAddress),
 }

--- a/shared/src/types/ethereum_events.rs
+++ b/shared/src/types/ethereum_events.rs
@@ -8,6 +8,12 @@ use crate::proto::MultiSigned;
 use crate::types::address::Address;
 use crate::types::token::Amount;
 
+/// Each event has a nonce set by the Ethereum smart contract that emitted it.
+#[derive(
+    Debug, PartialEq, Eq, Clone, BorshSerialize, BorshDeserialize, BorshSchema,
+)]
+pub struct EthereumEventNonce(u64);
+
 /// An Ethereum event to be processed by the Anoma ledger
 #[derive(
     Debug, PartialEq, Eq, Clone, BorshSerialize, BorshDeserialize, BorshSchema,
@@ -15,7 +21,7 @@ use crate::types::token::Amount;
 pub enum EthereumEvent {
     /// Event transferring batches of ether from Ethereum to wrapped ETH on
     /// Anoma
-    TransfersToNamada(Vec<TransferToNamada>),
+    TransfersToNamada(Vec<TransferToNamada>, EthereumEventNonce),
 }
 
 impl EthereumEvent {
@@ -73,16 +79,17 @@ mod tests {
 
     #[test]
     fn test_ethereum_event_hash() {
-        let event = EthereumEvent::TransfersToNamada(vec![]);
+        let nonce = EthereumEventNonce(123);
+        let event = EthereumEvent::TransfersToNamada(vec![], nonce);
 
         let hash = event.hash().unwrap();
 
         assert_eq!(
             hash,
             [
-                136, 85, 80, 138, 173, 225, 110, 197, 115, 210, 30, 106, 72,
-                93, 253, 10, 118, 36, 8, 92, 26, 20, 181, 236, 221, 100, 133,
-                222, 12, 104, 57, 164
+                94, 227, 170, 45, 164, 208, 161, 180, 203, 148, 96, 173, 90,
+                30, 102, 44, 30, 187, 124, 90, 117, 204, 19, 188, 7, 104, 19,
+                46, 13, 62, 203, 243
             ]
         );
     }

--- a/shared/src/types/ethereum_events.rs
+++ b/shared/src/types/ethereum_events.rs
@@ -60,12 +60,19 @@ pub enum EthereumAsset {
     ERC20(EthAddress),
 }
 
+/// A fraction of the total voting power. This should always be a reduced
+/// fraction that is between zero and one inclusive.
+#[derive(
+    Clone, PartialEq, Eq, Debug, BorshSerialize, BorshDeserialize, BorshSchema,
+)]
+struct FractionalVotingPower(fraction::Fraction);
+
 /// This is created by the block proposer based on the Ethereum events included
 /// in the vote extensions of the previous Tendermint round
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize, BorshSchema)]
 pub struct MultiSignedEthEvent {
     /// Address and voting power of the signing validators
-    pub signers: Vec<(Address, u64)>,
+    pub signers: Vec<(Address, FractionalVotingPower)>,
     /// Events as signed by validators
     pub event: MultiSigned<EthereumEvent>,
 }

--- a/shared/src/types/ethereum_events.rs
+++ b/shared/src/types/ethereum_events.rs
@@ -8,7 +8,9 @@ use crate::types::address::Address;
 use crate::types::token::Amount;
 
 /// An Ethereum event to be processed by the Anoma ledger
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(
+    Debug, PartialEq, Eq, Clone, BorshSerialize, BorshDeserialize, BorshSchema,
+)]
 pub enum EthereumEvent {
     /// Event transferring batches of ether from Ethereum to wrapped ETH on
     /// Anoma
@@ -17,12 +19,14 @@ pub enum EthereumEvent {
 
 /// Representation of address on Ethereum
 #[derive(
-    Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize, BorshSchema,
+    Clone, PartialEq, Eq, Debug, BorshSerialize, BorshDeserialize, BorshSchema,
 )]
 pub struct EthAddress(pub [u8; 20]);
 
 /// An event transferring some kind of value from Ethereum to Anoma
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(
+    Debug, PartialEq, Eq, Clone, BorshSerialize, BorshDeserialize, BorshSchema,
+)]
 pub struct TransferToNamada {
     /// Quantity of ether in the transfer
     pub amount: Amount,
@@ -33,7 +37,9 @@ pub struct TransferToNamada {
 }
 
 /// Represents Ethereum assets on the Ethereum blockchain
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, BorshSchema)]
+#[derive(
+    Debug, PartialEq, Eq, Clone, BorshSerialize, BorshDeserialize, BorshSchema,
+)]
 pub enum EthereumAsset {
     /// Native ETH
     Eth,

--- a/shared/src/types/ethereum_events.rs
+++ b/shared/src/types/ethereum_events.rs
@@ -75,7 +75,7 @@ pub enum EthereumAsset {
 
 /// A fraction of the total voting power. This should always be a reduced
 /// fraction that is between zero and one inclusive.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Debug)]
 pub struct FractionalVotingPower(Ratio<u64>);
 
 impl From<&FractionalVotingPower> for (u64, u64) {
@@ -163,5 +163,31 @@ mod tests {
                 46, 13, 62, 203, 243
             ])
         );
+    }
+
+    #[test]
+    fn test_fractional_voting_power() {
+        // this test is exercising the underlying library we use for fractions
+        // we want to make sure operators work as expected with our
+        // FractionalVotingPower type itself
+        assert!(
+            FractionalVotingPower((2, 3).into())
+                > FractionalVotingPower((1, 4).into())
+        );
+        assert!(
+            FractionalVotingPower((1, 3).into())
+                > FractionalVotingPower((1, 4).into())
+        );
+        assert!(
+            FractionalVotingPower((1, 3).into())
+                == FractionalVotingPower((2, 6).into())
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_fractional_voting_power_panics() {
+        FractionalVotingPower((0, 0).into());
+        FractionalVotingPower((1, 0).into());
     }
 }


### PR DESCRIPTION
Relates to #1171. Based on changes to the spec incoming in https://github.com/anoma/specs/pull/104

- [x] `EthereumEvent::hash` method
- [x] Remove enum variant for wrapped native ETH
- [x] Ensure `EthereumEvent` type has a nonce (so that we can always derive a unique hash per `EthereumEvent`)
- [x] Update `MultiSignedEthEvent` to use a better voting power type