### PR TITLE
Improvements to e2e logging

### DIFF
--- a/.changelog/unreleased/improvements/1202-expectrl-logging.md
+++ b/.changelog/unreleased/improvements/1202-expectrl-logging.md
@@ -1,0 +1,3 @@
+- Better logging for end-to-end tests, and logs are
+  stored to disk in the test's temporary working directory
+  ([#1202](https://github.com/anoma/anoma/pull/1202))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,6 +273,7 @@ dependencies = [
  "pretty_assertions",
  "proptest",
  "prost 0.9.0",
+ "rand 0.8.5",
  "serde_json",
  "sha2 0.9.9",
  "tempfile",

--- a/Makefile
+++ b/Makefile
@@ -132,50 +132,51 @@ audit:
 test: test-unit test-e2e test-wasm
 
 test-e2e:
-	RUST_BACKTRACE=1 $(cargo) test e2e -- --test-threads=1
+	RUST_BACKTRACE=1 $(cargo) test e2e -- --test-threads=1 -Z unstable-options --report-time
 
 test-e2e-abci-plus-plus:
 	RUST_BACKTRACE=1 $(cargo) test e2e \
 		--manifest-path ./tests/Cargo.toml \
 		--no-default-features \
 		--features "wasm-runtime ABCI-plus-plus anoma_apps/ABCI-plus-plus" \
-		-- --test-threads=1
+		-- --test-threads=1 -Z unstable-options --report-time
 
 test-unit-abci-plus-plus:
 	$(cargo) test \
 		--manifest-path ./apps/Cargo.toml \
 		--no-default-features \
-		--features "testing std ABCI-plus-plus" && \
+		--features "testing std ABCI-plus-plus" -- -Z unstable-options --report-time && \
 	$(cargo) test --manifest-path ./proof_of_stake/Cargo.toml \
 		--features "testing" && \
 	$(cargo) test \
 		--manifest-path ./shared/Cargo.toml \
 		--no-default-features \
-		--features "testing wasm-runtime ABCI-plus-plus ibc-mocks" && \
+		--features "testing wasm-runtime ABCI-plus-plus ibc-mocks" -- -Z unstable-options --report-time && \
 	$(cargo) test \
 		--manifest-path ./tests/Cargo.toml \
 		--no-default-features \
 		--features "wasm-runtime ABCI-plus-plus anoma_apps/ABCI-plus-plus" \
-		-- --skip e2e && \
+		-- --skip e2e -Z unstable-options --report-time && \
 	$(cargo) test \
 		--manifest-path ./vm_env/Cargo.toml \
 		--no-default-features \
 		--features "ABCI-plus-plus"
+		-- -Z unstable-options --report-time
 
 test-unit:
 	$(cargo) test --no-default-features \
 		--features "wasm-runtime ABCI ibc-mocks-abci" \
-		-- --skip e2e
+		-- --skip e2e -Z unstable-options --report-time
 
 test-wasm:
-	make -C $(wasms) test
+	make -C $(wasms) test -- -Z unstable-options --report-time
 
 test-wasm-template = $(cargo) test --manifest-path $(wasm)/Cargo.toml
 test-wasm-templates:
 	$(foreach wasm,$(wasm_templates),$(test-wasm-template) && ) true
 
 test-debug:
-	$(debug-cargo) test -- --nocapture
+	$(debug-cargo) test -- --nocapture -- -Z unstable-options --report-time
 
 fmt-wasm = $(cargo) +$(nightly) fmt --manifest-path $(wasm)/Cargo.toml
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ test-unit:
 		-- --skip e2e -- -Z unstable-options --report-time
 
 test-wasm:
-	make -C $(wasms) test -- -Z unstable-options --report-time
+	make -C $(wasms) test
 
 test-wasm-template = $(cargo) test --manifest-path $(wasm)/Cargo.toml -- -Z unstable-options --report-time
 test-wasm-templates:

--- a/Makefile
+++ b/Makefile
@@ -132,51 +132,75 @@ audit:
 test: test-unit test-e2e test-wasm
 
 test-e2e:
-	RUST_BACKTRACE=1 $(cargo) test e2e -- --test-threads=1 -- -Z unstable-options --report-time
+	RUST_BACKTRACE=1 $(cargo) test e2e \
+		-- \
+		--test-threads=1 \
+		-Z unstable-options --report-time
 
 test-e2e-abci-plus-plus:
 	RUST_BACKTRACE=1 $(cargo) test e2e \
 		--manifest-path ./tests/Cargo.toml \
 		--no-default-features \
 		--features "wasm-runtime ABCI-plus-plus anoma_apps/ABCI-plus-plus" \
-		-- --test-threads=1 -- -Z unstable-options --report-time
+			-- \
+			--test-threads=1 \
+			-Z unstable-options --report-time
 
 test-unit-abci-plus-plus:
 	$(cargo) test \
 		--manifest-path ./apps/Cargo.toml \
 		--no-default-features \
-		--features "testing std ABCI-plus-plus" -- -Z unstable-options --report-time && \
-	$(cargo) test --manifest-path ./proof_of_stake/Cargo.toml \
-		--features "testing" -- -Z unstable-options --report-time && \
+		--features "testing std ABCI-plus-plus" \
+			-- \
+			-Z unstable-options --report-time && \
+	$(cargo) test \
+		--manifest-path \
+		./proof_of_stake/Cargo.toml \
+		--features "testing" \
+			-- \
+			-Z unstable-options --report-time && \
 	$(cargo) test \
 		--manifest-path ./shared/Cargo.toml \
 		--no-default-features \
-		--features "testing wasm-runtime ABCI-plus-plus ibc-mocks" -- -Z unstable-options --report-time && \
+		--features "testing wasm-runtime ABCI-plus-plus ibc-mocks" \
+			-- \
+			-Z unstable-options --report-time && \
 	$(cargo) test \
 		--manifest-path ./tests/Cargo.toml \
 		--no-default-features \
 		--features "wasm-runtime ABCI-plus-plus anoma_apps/ABCI-plus-plus" \
-		-- --skip e2e -- -Z unstable-options --report-time && \
+			-- \
+			--skip e2e \
+			-Z unstable-options --report-time && \
 	$(cargo) test \
 		--manifest-path ./vm_env/Cargo.toml \
 		--no-default-features \
 		--features "ABCI-plus-plus" \
-		-- -Z unstable-options --report-time
+			-- \
+			-Z unstable-options --report-time
 
 test-unit:
 	$(cargo) test --no-default-features \
 		--features "wasm-runtime ABCI ibc-mocks-abci" \
-		-- --skip e2e -- -Z unstable-options --report-time
+			-- \
+			--skip e2e \
+			-Z unstable-options --report-time
 
 test-wasm:
 	make -C $(wasms) test
 
-test-wasm-template = $(cargo) test --manifest-path $(wasm)/Cargo.toml -- -Z unstable-options --report-time
+test-wasm-template = $(cargo) test \
+	--manifest-path $(wasm)/Cargo.toml \
+		-- \
+		-Z unstable-options --report-time
 test-wasm-templates:
 	$(foreach wasm,$(wasm_templates),$(test-wasm-template) && ) true
 
 test-debug:
-	$(debug-cargo) test -- --nocapture -- -Z unstable-options --report-time
+	$(debug-cargo) test \
+		-- \
+		--nocapture \
+		-Z unstable-options --report-time
 
 fmt-wasm = $(cargo) +$(nightly) fmt --manifest-path $(wasm)/Cargo.toml
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -132,14 +132,14 @@ audit:
 test: test-unit test-e2e test-wasm
 
 test-e2e:
-	RUST_BACKTRACE=1 $(cargo) test e2e -- --test-threads=1 -Z unstable-options --report-time
+	RUST_BACKTRACE=1 $(cargo) test e2e -- --test-threads=1 -- -Z unstable-options --report-time
 
 test-e2e-abci-plus-plus:
 	RUST_BACKTRACE=1 $(cargo) test e2e \
 		--manifest-path ./tests/Cargo.toml \
 		--no-default-features \
 		--features "wasm-runtime ABCI-plus-plus anoma_apps/ABCI-plus-plus" \
-		-- --test-threads=1 -Z unstable-options --report-time
+		-- --test-threads=1 -- -Z unstable-options --report-time
 
 test-unit-abci-plus-plus:
 	$(cargo) test \
@@ -147,7 +147,7 @@ test-unit-abci-plus-plus:
 		--no-default-features \
 		--features "testing std ABCI-plus-plus" -- -Z unstable-options --report-time && \
 	$(cargo) test --manifest-path ./proof_of_stake/Cargo.toml \
-		--features "testing" && \
+		--features "testing" -- -Z unstable-options --report-time && \
 	$(cargo) test \
 		--manifest-path ./shared/Cargo.toml \
 		--no-default-features \
@@ -156,22 +156,22 @@ test-unit-abci-plus-plus:
 		--manifest-path ./tests/Cargo.toml \
 		--no-default-features \
 		--features "wasm-runtime ABCI-plus-plus anoma_apps/ABCI-plus-plus" \
-		-- --skip e2e -Z unstable-options --report-time && \
+		-- --skip e2e -- -Z unstable-options --report-time && \
 	$(cargo) test \
 		--manifest-path ./vm_env/Cargo.toml \
 		--no-default-features \
-		--features "ABCI-plus-plus"
+		--features "ABCI-plus-plus" \
 		-- -Z unstable-options --report-time
 
 test-unit:
 	$(cargo) test --no-default-features \
 		--features "wasm-runtime ABCI ibc-mocks-abci" \
-		-- --skip e2e -Z unstable-options --report-time
+		-- --skip e2e -- -Z unstable-options --report-time
 
 test-wasm:
 	make -C $(wasms) test -- -Z unstable-options --report-time
 
-test-wasm-template = $(cargo) test --manifest-path $(wasm)/Cargo.toml
+test-wasm-template = $(cargo) test --manifest-path $(wasm)/Cargo.toml -- -Z unstable-options --report-time
 test-wasm-templates:
 	$(foreach wasm,$(wasm_templates),$(test-wasm-template) && ) true
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -59,6 +59,7 @@ libp2p = "0.38.0"
 pretty_assertions = "0.7.2"
 # A fork with state machine testing
 proptest = {git = "https://github.com/heliaxdev/proptest", branch = "tomas/sm"}
+rand = "0.8"
 toml = "0.5.9"
 
 # This is used to enable logging from tests

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -697,7 +697,6 @@ where
             "--mode",
             mode,
         ])
-        .stderr(std::process::Stdio::inherit())
         .args(args);
     let args: String =
         run_cmd.get_args().map(|s| s.to_string_lossy()).join(" ");

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -551,7 +551,7 @@ impl Drop for AnomaCmd {
         // attempt to clean up the process
         println!(
             "{}: {}",
-            "Waiting for command to finish".underline().yellow(),
+            "Sending Ctrl+C to command".underline().yellow(),
             self.cmd_str,
         );
         let _result = self.send_control('c');
@@ -559,7 +559,7 @@ impl Drop for AnomaCmd {
             Err(error) => {
                 eprintln!(
                     "\n{}: {}\n{}: {}",
-                    "Error waiting for command to finish".underline().red(),
+                    "Error ensuring command is finished".underline().red(),
                     self.cmd_str,
                     "Error".underline().red(),
                     error,

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str::FromStr;
 use std::sync::Once;
+use std::time::{SystemTime, UNIX_EPOCH};
 use std::{env, fs, mem, thread, time};
 
 use anoma::types::chain::ChainId;
@@ -719,7 +720,15 @@ where
         let mut rng = rand::thread_rng();
         let log_dir = base_dir.as_ref().join("logs");
         fs::create_dir_all(&log_dir)?;
-        log_dir.join(&format!("{}-{}.log", bin_name, rng.gen::<u64>()))
+        log_dir.join(&format!(
+            "{}-{}-{}.log",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_micros(),
+            bin_name,
+            rng.gen::<u64>()
+        ))
     };
     let logger = OpenOptions::new()
         .write(true)

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -661,6 +661,7 @@ where
 
     run_cmd
         .env("ANOMA_LOG", "anoma=info")
+        .env("ANOMA_LOG_COLOR", "false")
         .current_dir(working_dir)
         .args(&[
             "--base-dir",

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -703,7 +703,7 @@ where
     let cmd_str =
         format!("{} {}", run_cmd.get_program().to_string_lossy(), args);
 
-    let mut session = Session::spawn(run_cmd).map_err(|e| {
+    let session = Session::spawn(run_cmd).map_err(|e| {
         eyre!(
             "\n\n{}: {}\n{}: {}\n{}: {}",
             "Failed to run".underline().red(),
@@ -714,7 +714,6 @@ where
             e
         )
     })?;
-    session.set_expect_timeout(timeout_sec.map(std::time::Duration::from_secs));
 
     let log_path = {
         let mut rng = rand::thread_rng();
@@ -726,8 +725,10 @@ where
         .write(true)
         .create_new(true)
         .open(&log_path)?;
+    let mut session = session.with_log(logger).unwrap();
 
-    let session = session.with_log(logger).unwrap();
+    session.set_expect_timeout(timeout_sec.map(std::time::Duration::from_secs));
+
     let mut cmd_process = AnomaCmd {
         session,
         cmd_str,

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -417,7 +417,7 @@ impl Display for AnomaCmd {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{}\n(logs at: {})",
+            "{}\nLogs: {}",
             self.cmd_str,
             self.log_path.to_string_lossy()
         )

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -17,6 +17,7 @@ use escargot::CargoBuild;
 use expectrl::session::Session;
 use expectrl::{Eof, WaitStatus};
 use eyre::eyre;
+use itertools::Itertools;
 use tempfile::{tempdir, TempDir};
 
 /// For `color_eyre::install`, which fails if called more than once in the same
@@ -669,8 +670,12 @@ where
             "--mode",
             mode,
         ])
+        .stderr(std::process::Stdio::inherit())
         .args(args);
-    let cmd_str = format!("{:?}", run_cmd);
+    let args: String =
+        run_cmd.get_args().map(|s| s.to_string_lossy()).join(" ");
+    let cmd_str =
+        format!("{} {}", run_cmd.get_program().to_string_lossy(), args);
 
     println!("{}: {}", "Running".underline().green(), cmd_str);
     let mut session = Session::spawn(run_cmd).map_err(|e| {

--- a/wasm/wasm_source/Makefile
+++ b/wasm/wasm_source/Makefile
@@ -59,7 +59,9 @@ $(patsubst %,check_%,$(wasms)): check_%:
 
 # `cargo test` one of the wasms, e.g. `make test_tx_transfer`
 $(patsubst %,test_%,$(wasms)): test_%:
-	$(cargo) test --features $* -- -Z unstable-options --report-time
+	$(cargo) test --features $* \
+		-- \
+		-Z unstable-options --report-time
 
 # `cargo watch` one of the wasms, e.g. `make watch_tx_transfer`
 $(patsubst %,watch_%,$(wasms)): watch_%:

--- a/wasm/wasm_source/Makefile
+++ b/wasm/wasm_source/Makefile
@@ -59,7 +59,7 @@ $(patsubst %,check_%,$(wasms)): check_%:
 
 # `cargo test` one of the wasms, e.g. `make test_tx_transfer`
 $(patsubst %,test_%,$(wasms)): test_%:
-	$(cargo) test --features $*
+	$(cargo) test --features $* -- -Z unstable-options --report-time
 
 # `cargo watch` one of the wasms, e.g. `make watch_tx_transfer`
 $(patsubst %,watch_%,$(wasms)): watch_%:

--- a/wasm_for_tests/wasm_source/Makefile
+++ b/wasm_for_tests/wasm_source/Makefile
@@ -55,7 +55,7 @@ $(patsubst %,check_%,$(wasms)): check_%:
 
 # `cargo test` one of the wasms, e.g. `make test_tx_no_op`
 $(patsubst %,test_%,$(wasms)): test_%:
-	$(cargo) test --features $*
+	$(cargo) test --features $* -- -Z unstable-options --report-time
 
 # `cargo watch` one of the wasms, e.g. `make watch_tx_no_op`
 $(patsubst %,watch_%,$(wasms)): watch_%:

--- a/wasm_for_tests/wasm_source/Makefile
+++ b/wasm_for_tests/wasm_source/Makefile
@@ -55,7 +55,9 @@ $(patsubst %,check_%,$(wasms)): check_%:
 
 # `cargo test` one of the wasms, e.g. `make test_tx_no_op`
 $(patsubst %,test_%,$(wasms)): test_%:
-	$(cargo) test --features $* -- -Z unstable-options --report-time
+	$(cargo) test --features $* \
+		-- \
+		-Z unstable-options --report-time
 
 # `cargo watch` one of the wasms, e.g. `make watch_tx_no_op`
 $(patsubst %,watch_%,$(wasms)): watch_%:


### PR DESCRIPTION
Relates to anoma/namada#150

- For any command we run during e2e tests, log all output to a file in the temporary directory
- explicitly mention we send `Ctrl+C` to commands rather than just passively waiting for them to finish
- ensure `AnomaCmd` expect failures log the command that the failure happened for
- record timings for all tests (closes https://github.com/anoma/namada/issues/147, from https://github.com/anoma/anoma/pull/1188)

If a failure happens, log command
```
Error:
   0: Reached a timeout for expect type of command
      Command: /opt/workspace/heliax/repos/anoma/abcipp/target/debug/anomac --base-dir /var/folders/cy/fxxsxwd56yg67d68vxj6l52h0000gn/T/.tmpq7k0N2 --mode full transfer --source Bertha --target Albert --token XAN --amount 10.1 --fee-amount 0 --gas-limit 0 --fee-token XAN --ledger-address 127.0.0.1:28657
       Needle: Transaction applied

Location:
   tests/src/e2e/setup.rs:487

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                ⋮ 10 frames hidden ⋮
  11: anoma_tests::e2e::setup::AnomaCmd::exp_string::{{closure}}::h7a448153db6d5ac3
      at /opt/workspace/heliax/repos/anoma/abcipp/tests/src/e2e/setup.rs:487
  12: core::result::Result<T,E>::map_err::h173d24cf5428418f
      at /rustc/cacc75c82ebe15cf63d31034fcf7f1016cddf0e2/library/core/src/result.rs:855
  13: anoma_tests::e2e::setup::AnomaCmd::exp_string::h12e21a8761bc416f
      at /opt/workspace/heliax/repos/anoma/abcipp/tests/src/e2e/setup.rs:486
  14: anoma_tests::e2e::ledger_tests::ledger_many_txs_in_a_block::{{closure}}::{{closure}}::h974d35ab3a39a1b6
      at /opt/workspace/heliax/repos/anoma/abcipp/tests/src/e2e/ledger_tests.rs:999
                                ⋮ 13 frames hidden ⋮
```

In any case, log the command being run
```
> Running:
/opt/workspace/heliax/repos/anoma/abcipp/target/debug/anomac --base-dir /var/folders/cy/fxxsxwd56yg67d68vxj6l52h0000gn/T/.tmpq7k0N2 --mode full transfer --source Bertha --target Albert --token XAN --amount 10.1 --fee-amount 0 --gas-limit 0 --fee-token XAN --ledger-address 127.0.0.1:28657
```
