### PR TITLE
eth-bridge-integration: clean up branch

### DIFF
--- a/apps/src/lib/node/ledger/ethereum_node/oracle.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/oracle.rs
@@ -115,9 +115,9 @@ pub mod oracle_process {
                 }
                 if !oracle.connected() {
                     tracing::info!(
-                    "Ethereum oracle could not send events to the ledger; the \
-                     receiver has hung up. Shutting down"
-                );
+                        "Ethereum oracle could not send events to the ledger; \
+                         the receiver has hung up. Shutting down"
+                    );
                     return;
                 }
             };
@@ -125,19 +125,23 @@ pub mod oracle_process {
             if Uint256::from(MIN_CONFIRMATIONS) > latest_block {
                 if !oracle.connected() {
                     tracing::info!(
-                    "Ethereum oracle could not send events to the ledger; the \
-                     receiver has hung up. Shutting down"
-                );
+                        "Ethereum oracle could not send events to the ledger; \
+                         the receiver has hung up. Shutting down"
+                    );
                     return;
                 }
                 continue;
             }
-            let block_to_check = latest_block.clone() - MIN_CONFIRMATIONS.into();
-            // check for events with at least `[MIN_CONFIRMATIONS]` confirmations.
+            let block_to_check =
+                latest_block.clone() - MIN_CONFIRMATIONS.into();
+            // check for events with at least `[MIN_CONFIRMATIONS]`
+            // confirmations.
             for sig in signatures::SIGNATURES {
                 let addr: Address = match signatures::SigType::from(sig) {
                     signatures::SigType::Bridge => MINT_CONTRACT.0.into(),
-                    signatures::SigType::Governance => GOVERNANCE_CONTRACT.0.into(),
+                    signatures::SigType::Governance => {
+                        GOVERNANCE_CONTRACT.0.into()
+                    }
                 };
                 // fetch the events for matching the given signature
                 let mut events = loop {
@@ -157,7 +161,7 @@ pub mod oracle_process {
                                         block_to_check.clone(),
                                         log.data.0.as_slice(),
                                     )
-                                        .ok()
+                                    .ok()
                                 })
                                 .collect::<Vec<PendingEvent>>()
                         })
@@ -166,18 +170,18 @@ pub mod oracle_process {
                     }
                     if !oracle.connected() {
                         tracing::info!(
-                        "Ethereum oracle could not send events to the ledger; \
-                         the receiver has hung up. Shutting down"
-                    );
+                            "Ethereum oracle could not send events to the \
+                             ledger; the receiver has hung up. Shutting down"
+                        );
                         return;
                     }
                 };
                 pending.append(&mut events);
                 if !oracle.send(process_queue(&latest_block, &mut pending)) {
                     tracing::info!(
-                    "Ethereum oracle could not send events to the ledger; the \
-                     receiver has hung up. Shutting down"
-                );
+                        "Ethereum oracle could not send events to the ledger; \
+                         the receiver has hung up. Shutting down"
+                    );
                     return;
                 }
             }
@@ -191,7 +195,8 @@ pub mod oracle_process {
         latest_block: &Uint256,
         pending: &mut Vec<PendingEvent>,
     ) -> Vec<EthereumEvent> {
-        let mut pending_tmp: Vec<PendingEvent> = Vec::with_capacity(pending.len());
+        let mut pending_tmp: Vec<PendingEvent> =
+            Vec::with_capacity(pending.len());
         std::mem::swap(&mut pending_tmp, pending);
         let mut confirmed = vec![];
         for item in pending_tmp.into_iter() {
@@ -226,7 +231,8 @@ pub mod oracle_process {
         /// Set up an oracle with a mock web3 client that we can contr
         fn setup() -> TestPackage {
             let (admin_channel, client) = Web3::setup();
-            let (eth_sender, eth_receiver) = tokio::sync::mpsc::unbounded_channel();
+            let (eth_sender, eth_receiver) =
+                tokio::sync::mpsc::unbounded_channel();
             let (abort, abort_recv) = channel();
             TestPackage {
                 oracle: Oracle {
@@ -361,7 +367,7 @@ pub mod oracle_process {
                 name: "Test".to_string(),
                 address: EthAddress([0; 20]),
             }
-                .encode();
+            .encode();
             admin_channel
                 .send(TestCmd::NewEvent {
                     event_type: MockEventType::NewContract,
@@ -420,7 +426,7 @@ pub mod oracle_process {
                 name: "Test".to_string(),
                 address: EthAddress([0; 20]),
             }
-                .encode();
+            .encode();
 
             // confirmed after 75 blocks
             let second_event = RawTransfersToEthereum {
@@ -450,7 +456,8 @@ pub mod oracle_process {
                 })
                 .expect("Test failed");
 
-            // increase block height so first event is confirmed but second is not.
+            // increase block height so first event is confirmed but second is
+            // not.
             admin_channel
                 .send(TestCmd::NewHeight(Uint256::from(102u32)))
                 .expect("Test failed");
@@ -476,7 +483,9 @@ pub mod oracle_process {
                 .expect("Test failed");
             // check correct event is received
             let event = eth_recv.blocking_recv().expect("Test failed");
-            if let EthereumEvent::TransfersToEthereum { mut transfers, .. } = event
+            if let EthereumEvent::TransfersToEthereum {
+                mut transfers, ..
+            } = event
             {
                 assert_eq!(transfers.len(), 1);
                 let transfer = transfers.remove(0);

--- a/wasm/tx_template/Cargo.lock
+++ b/wasm/tx_template/Cargo.lock
@@ -1090,10 +1090,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if 1.0.0",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1258,7 +1256,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.12.0"
-source = "git+https://github.com/heliaxdev/ibc-rs?branch=yuji/v0.12.0_tm_v0.23.5#e14560ecfc3f275a63b5702e038cbabd2797b2b6"
+source = "git+https://github.com/heliaxdev/ibc-rs?branch=murisi/jsfix#7d7570f2db008fc8476e4f0cacfc48d281139aa5"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1285,7 +1283,7 @@ dependencies = [
 [[package]]
 name = "ibc-proto"
 version = "0.16.0"
-source = "git+https://github.com/heliaxdev/ibc-rs?branch=yuji/v0.12.0_tm_v0.23.5#e14560ecfc3f275a63b5702e038cbabd2797b2b6"
+source = "git+https://github.com/heliaxdev/ibc-rs?branch=murisi/jsfix#7d7570f2db008fc8476e4f0cacfc48d281139aa5"
 dependencies = [
  "bytes",
  "prost",
@@ -2603,7 +2601,7 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/rebase_v0.23.5#a1439b37ac64fbcaf508021fc1e1aff07c18147e"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=murisi/jsfix#d2615b9c8133c61b70d28ce7a34b51cbe623f1a4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2631,7 +2629,7 @@ dependencies = [
 [[package]]
 name = "tendermint-config"
 version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/rebase_v0.23.5#a1439b37ac64fbcaf508021fc1e1aff07c18147e"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=murisi/jsfix#d2615b9c8133c61b70d28ce7a34b51cbe623f1a4"
 dependencies = [
  "flex-error",
  "serde",
@@ -2644,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client-verifier"
 version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/rebase_v0.23.5#a1439b37ac64fbcaf508021fc1e1aff07c18147e"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=murisi/jsfix#d2615b9c8133c61b70d28ce7a34b51cbe623f1a4"
 dependencies = [
  "derive_more",
  "flex-error",
@@ -2657,7 +2655,7 @@ dependencies = [
 [[package]]
 name = "tendermint-proto"
 version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/rebase_v0.23.5#a1439b37ac64fbcaf508021fc1e1aff07c18147e"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=murisi/jsfix#d2615b9c8133c61b70d28ce7a34b51cbe623f1a4"
 dependencies = [
  "bytes",
  "flex-error",
@@ -2674,7 +2672,7 @@ dependencies = [
 [[package]]
 name = "tendermint-rpc"
 version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/rebase_v0.23.5#a1439b37ac64fbcaf508021fc1e1aff07c18147e"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=murisi/jsfix#d2615b9c8133c61b70d28ce7a34b51cbe623f1a4"
 dependencies = [
  "bytes",
  "flex-error",
@@ -2698,7 +2696,7 @@ dependencies = [
 [[package]]
 name = "tendermint-testgen"
 version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/rebase_v0.23.5#a1439b37ac64fbcaf508021fc1e1aff07c18147e"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=murisi/jsfix#d2615b9c8133c61b70d28ce7a34b51cbe623f1a4"
 dependencies = [
  "ed25519-dalek",
  "gumdrop",

--- a/wasm_for_tests/wasm_source/Cargo.lock
+++ b/wasm_for_tests/wasm_source/Cargo.lock
@@ -1112,10 +1112,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if 1.0.0",
- "js-sys",
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1289,7 +1287,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.12.0"
-source = "git+https://github.com/heliaxdev/ibc-rs?branch=yuji/v0.12.0_tm_v0.23.5#e14560ecfc3f275a63b5702e038cbabd2797b2b6"
+source = "git+https://github.com/heliaxdev/ibc-rs?branch=murisi/jsfix#7d7570f2db008fc8476e4f0cacfc48d281139aa5"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1316,7 +1314,7 @@ dependencies = [
 [[package]]
 name = "ibc-proto"
 version = "0.16.0"
-source = "git+https://github.com/heliaxdev/ibc-rs?branch=yuji/v0.12.0_tm_v0.23.5#e14560ecfc3f275a63b5702e038cbabd2797b2b6"
+source = "git+https://github.com/heliaxdev/ibc-rs?branch=murisi/jsfix#7d7570f2db008fc8476e4f0cacfc48d281139aa5"
 dependencies = [
  "bytes",
  "prost",
@@ -2635,7 +2633,7 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/rebase_v0.23.5#a1439b37ac64fbcaf508021fc1e1aff07c18147e"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=murisi/jsfix#d2615b9c8133c61b70d28ce7a34b51cbe623f1a4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2663,7 +2661,7 @@ dependencies = [
 [[package]]
 name = "tendermint-config"
 version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/rebase_v0.23.5#a1439b37ac64fbcaf508021fc1e1aff07c18147e"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=murisi/jsfix#d2615b9c8133c61b70d28ce7a34b51cbe623f1a4"
 dependencies = [
  "flex-error",
  "serde",
@@ -2676,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client-verifier"
 version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/rebase_v0.23.5#a1439b37ac64fbcaf508021fc1e1aff07c18147e"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=murisi/jsfix#d2615b9c8133c61b70d28ce7a34b51cbe623f1a4"
 dependencies = [
  "derive_more",
  "flex-error",
@@ -2689,7 +2687,7 @@ dependencies = [
 [[package]]
 name = "tendermint-proto"
 version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/rebase_v0.23.5#a1439b37ac64fbcaf508021fc1e1aff07c18147e"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=murisi/jsfix#d2615b9c8133c61b70d28ce7a34b51cbe623f1a4"
 dependencies = [
  "bytes",
  "flex-error",
@@ -2706,7 +2704,7 @@ dependencies = [
 [[package]]
 name = "tendermint-rpc"
 version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/rebase_v0.23.5#a1439b37ac64fbcaf508021fc1e1aff07c18147e"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=murisi/jsfix#d2615b9c8133c61b70d28ce7a34b51cbe623f1a4"
 dependencies = [
  "bytes",
  "flex-error",
@@ -2730,7 +2728,7 @@ dependencies = [
 [[package]]
 name = "tendermint-testgen"
 version = "0.23.5"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=yuji/rebase_v0.23.5#a1439b37ac64fbcaf508021fc1e1aff07c18147e"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=murisi/jsfix#d2615b9c8133c61b70d28ce7a34b51cbe623f1a4"
 dependencies = [
  "ed25519-dalek",
  "gumdrop",


### PR DESCRIPTION
`eth-bridge-integration` was failing CI in https://ci.heliax.dev/anoma/anoma/4271

(`cargo fmt` and `cargo clippy` aren't run in CI for PRs against `eth-bridge-integration` currently)

- run make fmt
- ensure Cargo.lock are synced