### PR TITLE
fix header hash

### DIFF
--- a/apps/src/lib/node/ledger/shims/abcipp_shim.rs
+++ b/apps/src/lib/node/ledger/shims/abcipp_shim.rs
@@ -158,7 +158,6 @@ impl AbcippShim {
                         self.begin_block_request.take().unwrap().into();
                     let hash = self.get_hash();
                     end_block_request.hash = BlockHash::from(hash.clone());
-                    end_block_request.header.hash = hash;
                     end_block_request.txs = txs;
                     self.service
                         .call(Request::FinalizeBlock(end_block_request))

--- a/apps/src/lib/node/ledger/shims/abcipp_shim_types.rs
+++ b/apps/src/lib/node/ledger/shims/abcipp_shim_types.rs
@@ -260,7 +260,8 @@ pub mod shim {
                 FinalizeBlock {
                     hash: BlockHash::default(),
                     header: Header {
-                        hash: Hash::default(),
+                        hash: Hash::try_from(header.app_hash.as_slice())
+                            .unwrap_or_default(),
                         time: DateTimeUtc::try_from(header.time.unwrap())
                             .unwrap(),
                         next_validators_hash: Hash::try_from(


### PR DESCRIPTION
Fix the hash (merkle tree's root) of a header

IBC proof verification for consensus state failed due to the wrong hash.