### PR TITLE
print tendermint log to stdout only if `ANOMA_TM_STDOUT=true`

### DIFF
--- a/.changelog/unreleased/improvements/1239-hide-tm-log.md
+++ b/.changelog/unreleased/improvements/1239-hide-tm-log.md
@@ -1,0 +1,3 @@
+- Hidden the stdout of Tendermint process by default. To include
+  it in the node's output, run with `ANOMA_TM_STDOUT=true`
+  ([#1239](https://github.com/anoma/anoma/pull/1239))

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -371,6 +371,7 @@ async fn run_aux(config: config::Ledger, wasm_dir: PathBuf) {
     };
 
     // Construct our ABCI application.
+    let tendermint_mode = config.tendermint.tendermint_mode.clone();
     let ledger_address = config.shell.ledger_address;
     let (shell, abci_service) = AbcippShim::new(
         config,
@@ -402,6 +403,14 @@ async fn run_aux(config: config::Ledger, wasm_dir: PathBuf) {
     let shell_handler = thread_builder
         .spawn(move || {
             tracing::info!("Anoma ledger node started.");
+            match tendermint_mode {
+                TendermintMode::Validator => {
+                    tracing::info!("This node is a validator");
+                }
+                TendermintMode::Full | TendermintMode::Seed => {
+                    tracing::info!("This node is not a validator");
+                }
+            }
             shell.run()
         })
         .expect("Must be able to start a thread for the shell");

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -244,12 +244,6 @@ fn ledger_txs_and_queries() -> Result<()> {
         run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(40))?;
 
     ledger.exp_string("Anoma ledger node started")?;
-    if !cfg!(feature = "ABCI") {
-        ledger.exp_string("started node")?;
-    } else {
-        ledger.exp_string("Started node")?;
-    }
-
     let _bg_ledger = ledger.background();
 
     let vp_user = wasm_abs_path(VP_USER_WASM);
@@ -423,11 +417,6 @@ fn invalid_transactions() -> Result<()> {
     let mut ledger =
         run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(40))?;
     ledger.exp_string("Anoma ledger node started")?;
-    if !cfg!(feature = "ABCI") {
-        ledger.exp_string("started node")?;
-    } else {
-        ledger.exp_string("Started node")?;
-    }
     // Wait to commit a block
     ledger.exp_regex(r"Committed block hash.*, height: [0-9]+")?;
 
@@ -583,11 +572,6 @@ fn pos_bonds() -> Result<()> {
         run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(40))?;
 
     ledger.exp_string("Anoma ledger node started")?;
-    if !cfg!(feature = "ABCI") {
-        ledger.exp_string("started node")?;
-    } else {
-        ledger.exp_string("Started node")?;
-    }
     let _bg_ledger = ledger.background();
 
     let validator_one_rpc = get_actor_rpc(&test, &Who::Validator(0));
@@ -781,11 +765,6 @@ fn pos_init_validator() -> Result<()> {
         run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(40))?;
 
     ledger.exp_string("Anoma ledger node started")?;
-    if !cfg!(feature = "ABCI") {
-        ledger.exp_string("started node")?;
-    } else {
-        ledger.exp_string("Started node")?;
-    }
     let _bg_ledger = ledger.background();
 
     let validator_one_rpc = get_actor_rpc(&test, &Who::Validator(0));
@@ -948,11 +927,6 @@ fn ledger_many_txs_in_a_block() -> Result<()> {
         run_as!(*test, Who::Validator(0), Bin::Node, &["ledger"], Some(40))?;
 
     ledger.exp_string("Anoma ledger node started")?;
-    if !cfg!(feature = "ABCI") {
-        ledger.exp_string("started node")?;
-    } else {
-        ledger.exp_string("Started node")?;
-    }
 
     // Wait to commit a block
     ledger.exp_regex(r"Committed block hash.*, height: [0-9]+")?;
@@ -1043,11 +1017,6 @@ fn proposal_submission() -> Result<()> {
         run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(40))?;
 
     ledger.exp_string("Anoma ledger node started")?;
-    if !cfg!(feature = "ABCI") {
-        ledger.exp_string("started node")?;
-    } else {
-        ledger.exp_string("Started node")?;
-    }
     let _bg_ledger = ledger.background();
 
     let validator_one_rpc = get_actor_rpc(&test, &Who::Validator(0));
@@ -1395,11 +1364,6 @@ fn proposal_offline() -> Result<()> {
         run_as!(test, Who::Validator(0), Bin::Node, &["ledger"], Some(20))?;
 
     ledger.exp_string("Anoma ledger node started")?;
-    if !cfg!(feature = "ABCI") {
-        ledger.exp_string("started node")?;
-    } else {
-        ledger.exp_string("Started node")?;
-    }
     let _bg_ledger = ledger.background();
 
     let validator_one_rpc = get_actor_rpc(&test, &Who::Validator(0));


### PR DESCRIPTION
trying to hide the TM stdout to see if it maybe helps a bit with flakiness in our e2e tests.

Repeatedly running the CI, we got 19 e2e successes and 1 failure.