### PR TITLE
make: add recipes to build wasm in debug

### DIFF
--- a/.changelog/unreleased/miscellaneous/1243-debug-wasm-build.md
+++ b/.changelog/unreleased/miscellaneous/1243-debug-wasm-build.md
@@ -1,0 +1,2 @@
+- Added a make recipe to build WASM in debug mode with `make debug-wasm-scripts`
+  ([#1243](https://github.com/anoma/anoma/pull/1243))

--- a/Makefile
+++ b/Makefile
@@ -210,9 +210,18 @@ build-wasm-image-docker:
 build-wasm-scripts-docker: build-wasm-image-docker
 	docker run --rm -v ${PWD}:/usr/local/rust/wasm anoma-wasm make build-wasm-scripts
 
+debug-wasm-scripts-docker: build-wasm-image-docker
+	docker run --rm -v ${PWD}:/usr/local/rust/wasm anoma-wasm make debug-wasm-scripts
+
 # Build the validity predicate, transactions, matchmaker and matchmaker filter wasm
 build-wasm-scripts:
 	make -C $(wasms)
+	make opt-wasm
+	make checksum-wasm
+
+# Debug build the validity predicate, transactions, matchmaker and matchmaker filter wasm
+debug-wasm-scripts:
+	make -C $(wasms) debug
 	make opt-wasm
 	make checksum-wasm
 
@@ -242,4 +251,4 @@ test-miri:
 	MIRIFLAGS="-Zmiri-disable-isolation" $(cargo) +$(nightly) miri test
 
 
-.PHONY : build check build-release clippy install run-ledger run-gossip reset-ledger test test-debug fmt watch clean build-doc doc build-wasm-scripts-docker build-wasm-scripts clean-wasm-scripts dev-deps test-miri
+.PHONY : build check build-release clippy install run-ledger run-gossip reset-ledger test test-debug fmt watch clean build-doc doc build-wasm-scripts-docker debug-wasm-scripts-docker build-wasm-scripts debug-wasm-scripts clean-wasm-scripts dev-deps test-miri

--- a/tx_prelude/src/lib.rs
+++ b/tx_prelude/src/lib.rs
@@ -8,14 +8,26 @@
 
 pub use anoma_vm_env::tx_prelude::*;
 
-/// Log a string in a debug build. The message will be printed at the
-/// `tracing::Level::Info`. Any `debug_log!` statements are only enabled in
-/// non optimized builds by default. An optimized build will not execute
-/// `debug_log!` statements unless `-C debug-assertions` is passed to the
-/// compiler.
+/// Format and log a string in a debug build.
+///
+/// In WASM target debug build, the message will be printed at the
+/// `tracing::Level::Info` when executed in the VM. An optimized build will
+/// omit any `debug_log!` statements unless `-C debug-assertions` is passed to
+/// the compiler.
+///
+/// In non-WASM target, the message is simply printed out to stdout.
 #[macro_export]
 macro_rules! debug_log {
     ($($arg:tt)*) => {{
-        (if cfg!(debug_assertions) { log_string(format!($($arg)*)) })
-    }}
+        (
+            if cfg!(target_arch = "wasm32") {
+                if cfg!(debug_assertions)
+                {
+                    log_string(format!($($arg)*));
+                }
+            } else {
+                println!($($arg)*);
+            }
+        )
+    }};
 }

--- a/vp_prelude/src/lib.rs
+++ b/vp_prelude/src/lib.rs
@@ -33,14 +33,26 @@ pub fn is_vp_whitelisted(vp_bytes: &[u8]) -> bool {
     whitelist.is_empty() || whitelist.contains(&vp_hash.to_string())
 }
 
-/// Log a string in a debug build. The message will be printed at the
-/// `tracing::Level::Info`. Any `debug_log!` statements are only enabled in
-/// non optimized builds by default. An optimized build will not execute
-/// `debug_log!` statements unless `-C debug-assertions` is passed to the
-/// compiler.
+/// Format and log a string in a debug build.
+///
+/// In WASM target debug build, the message will be printed at the
+/// `tracing::Level::Info` when executed in the VM. An optimized build will
+/// omit any `debug_log!` statements unless `-C debug-assertions` is passed to
+/// the compiler.
+///
+/// In non-WASM target, the message is simply printed out to stdout.
 #[macro_export]
 macro_rules! debug_log {
     ($($arg:tt)*) => {{
-        (if cfg!(debug_assertions) { log_string(format!($($arg)*)) })
-    }}
+        (
+            if cfg!(target_arch = "wasm32") {
+                if cfg!(debug_assertions)
+                {
+                    log_string(format!($($arg)*));
+                }
+            } else {
+                println!($($arg)*);
+            }
+        )
+    }};
 }

--- a/wasm/wasm_source/Makefile
+++ b/wasm/wasm_source/Makefile
@@ -23,8 +23,12 @@ wasms += vp_testnet_faucet
 wasms += vp_token
 wasms += vp_user
 
-# Build all wasms
+# Build all wasms in release mode
 all: $(wasms)
+
+# Build all wasms in debug mode
+debug:
+	$(foreach wasm,$(wasms),make debug_$(wasm) && ) true
 
 # `cargo check` all wasms
 check:
@@ -53,6 +57,11 @@ $(wasms): %:
 	RUSTFLAGS='-C link-arg=-s' $(cargo) build --release --target wasm32-unknown-unknown --features $@ && \
 	cp "./target/wasm32-unknown-unknown/release/anoma_wasm.wasm" ../$@.wasm
 
+# Build a selected wasm in debug mode
+$(patsubst %,debug_%,$(wasms)): debug_%:
+	RUSTFLAGS='-C link-arg=-s' $(cargo) build --target wasm32-unknown-unknown --features $* && \
+	cp "./target/wasm32-unknown-unknown/debug/anoma_wasm.wasm" ../$*.wasm
+
 # `cargo check` one of the wasms, e.g. `make check_tx_transfer`
 $(patsubst %,check_%,$(wasms)): check_%:
 	$(cargo) check --target wasm32-unknown-unknown --features $*
@@ -76,4 +85,4 @@ clean:
 deps:
 	$(rustup) target add wasm32-unknown-unknown
 
-.PHONY : all check test clippy fmt fmt-check clean deps
+.PHONY : all debug check test clippy fmt fmt-check clean deps

--- a/wasm/wasm_source/README.md
+++ b/wasm/wasm_source/README.md
@@ -13,7 +13,8 @@ make all
 
 # Each source that is included here can also be build and checked individually, e.g. for "tx_transfer" source:
 
-make tx_transfer         # build
+make tx_transfer         # optimized build (strips `debug_log!` statements)
+make debug_tx_transfer   # debug build
 make check_tx_transfer   # cargo check
 make test_tx_transfer    # cargo test
 make watch_tx_transfer   # cargo watch


### PR DESCRIPTION
closes anoma/namada#51, closes anoma/namada#52

This PR adds recipe `make debug-wasm-scripts` in the root that can be used to enable `debug_log!` expressions in WASM. In the `wasm/wasm_source`, one can debug build an individual tx or VP with e.g. `make debug_tx_transfer`.

Additionally, the `debug_log!` get printed to stdout in non-WASM build, which is handy for testing.