### PR TITLE
Fix the return type of read_in_past

### DIFF
--- a/apps/anoma_client/lib/client.ex
+++ b/apps/anoma_client/lib/client.ex
@@ -12,12 +12,17 @@ defmodule Anoma.Client do
   @doc """
   I connect to a remote node over GRPC.
   """
-  @spec connect(String.t(), integer()) :: {:ok, Anoma.Client.t()} | {:error, term()}
+  @spec connect(String.t(), integer()) ::
+          {:ok, Anoma.Client.t()} | {:error, term()}
   def connect(host, port) do
     spec =
-      {Anoma.Client.Connection.Supervisor, [host: host, port: port, type: :grpc]}
+      {Anoma.Client.Connection.Supervisor,
+       [host: host, port: port, type: :grpc]}
 
-    case DynamicSupervisor.start_child(Anoma.Client.ConnectionSupervisor, spec) do
+    case DynamicSupervisor.start_child(
+           Anoma.Client.ConnectionSupervisor,
+           spec
+         ) do
       {:ok, pid} ->
         {:ok, %__MODULE__{type: :grpc, supervisor: pid}}
 

--- a/apps/anoma_client/lib/client/client_connection/grpc_proxy.ex
+++ b/apps/anoma_client/lib/client/client_connection/grpc_proxy.ex
@@ -56,7 +56,8 @@ defmodule Anoma.Client.Connection.GRPCProxy do
   #                      Public RPC API                      #
   ############################################################
 
-  @spec list_intents() :: {:ok, Anoma.Protobuf.IntentPool.ListIntents.Response.t()}
+  @spec list_intents() ::
+          {:ok, Anoma.Protobuf.IntentPool.ListIntents.Response.t()}
   def list_intents() do
     GenServer.call(__MODULE__, {:list_intents})
   end
@@ -67,7 +68,8 @@ defmodule Anoma.Client.Connection.GRPCProxy do
     GenServer.call(__MODULE__, {:add_intent, intent})
   end
 
-  @spec list_nullifiers() :: {:ok, Anoma.Protobuf.Indexer.Nullifiers.Response.t()}
+  @spec list_nullifiers() ::
+          {:ok, Anoma.Protobuf.Indexer.Nullifiers.Response.t()}
   def list_nullifiers() do
     GenServer.call(__MODULE__, {:list_nullifiers})
   end

--- a/apps/anoma_client/test/proxy_test.exs
+++ b/apps/anoma_client/test/proxy_test.exs
@@ -1,16 +1,16 @@
 defmodule ProxyTest do
   use ExUnit.Case
 
-#  alias Anoma.Client.Examples.EProxy
+  #  alias Anoma.Client.Examples.EProxy
 
-# for now, commented out until it can be fixed and made an example
-#  test "proxy tests" do
-#    excluded = [start_proxy_for: 0, start_proxy_for: 1]
-#
-#    EProxy.__info__(:functions)
-#    |> Enum.filter(&(&1 in excluded))
-#    |> Enum.each(fn {func, _arity} ->
-#      apply(EProxy, func, [])
-#    end)
-#  end
+  # for now, commented out until it can be fixed and made an example
+  #  test "proxy tests" do
+  #    excluded = [start_proxy_for: 0, start_proxy_for: 1]
+  #
+  #    EProxy.__info__(:functions)
+  #    |> Enum.filter(&(&1 in excluded))
+  #    |> Enum.each(fn {func, _arity} ->
+  #      apply(EProxy, func, [])
+  #    end)
+  #  end
 end

--- a/apps/anoma_node/lib/examples/e_registry.ex
+++ b/apps/anoma_node/lib/examples/e_registry.ex
@@ -237,9 +237,11 @@ defmodule Anoma.Node.Examples.ERegistry do
     assert Kernel.match?({:error, :no_node_running}, Registry.local_node_id())
 
     # start one node and assert the node is returned
-    node_id = "londo_mollari" <>
-              (:crypto.strong_rand_bytes(16)
-               |> Base.url_encode64())
+    node_id =
+      "londo_mollari" <>
+        (:crypto.strong_rand_bytes(16)
+         |> Base.url_encode64())
+
     %ENode{} = ENode.start_node(node_id: node_id)
 
     assert {:ok, node_id} == Registry.local_node_id()

--- a/apps/anoma_node/lib/node/transaction/storage.ex
+++ b/apps/anoma_node/lib/node/transaction/storage.ex
@@ -327,7 +327,7 @@ defmodule Anoma.Node.Transaction.Storage do
             :absent
 
           _ ->
-            {:ok, Map.get(state.uncommitted, {update_height, key}, :error)}
+            Map.fetch(state.uncommitted, {update_height, key})
         end
     end
   end


### PR DESCRIPTION
Before it may return {:ok, :error} if {update_height, key} was not in the map.

Now it does the proper fetch type removing {:ok, :error} from the possible return values