### PR TITLE
 Fix duplicate table location

### DIFF
--- a/apps/anoma_client/lib/client.ex
+++ b/apps/anoma_client/lib/client.ex
@@ -12,12 +12,17 @@ defmodule Anoma.Client do
   @doc """
   I connect to a remote node over GRPC.
   """
-  @spec connect(String.t(), integer()) :: {:ok, Anoma.Client.t()} | {:error, term()}
+  @spec connect(String.t(), integer()) ::
+          {:ok, Anoma.Client.t()} | {:error, term()}
   def connect(host, port) do
     spec =
-      {Anoma.Client.Connection.Supervisor, [host: host, port: port, type: :grpc]}
+      {Anoma.Client.Connection.Supervisor,
+       [host: host, port: port, type: :grpc]}
 
-    case DynamicSupervisor.start_child(Anoma.Client.ConnectionSupervisor, spec) do
+    case DynamicSupervisor.start_child(
+           Anoma.Client.ConnectionSupervisor,
+           spec
+         ) do
       {:ok, pid} ->
         {:ok, %__MODULE__{type: :grpc, supervisor: pid}}
 

--- a/apps/anoma_client/lib/client/client_connection/grpc_proxy.ex
+++ b/apps/anoma_client/lib/client/client_connection/grpc_proxy.ex
@@ -56,7 +56,8 @@ defmodule Anoma.Client.Connection.GRPCProxy do
   #                      Public RPC API                      #
   ############################################################
 
-  @spec list_intents() :: {:ok, Anoma.Protobuf.IntentPool.ListIntents.Response.t()}
+  @spec list_intents() ::
+          {:ok, Anoma.Protobuf.IntentPool.ListIntents.Response.t()}
   def list_intents() do
     GenServer.call(__MODULE__, {:list_intents})
   end
@@ -67,7 +68,8 @@ defmodule Anoma.Client.Connection.GRPCProxy do
     GenServer.call(__MODULE__, {:add_intent, intent})
   end
 
-  @spec list_nullifiers() :: {:ok, Anoma.Protobuf.Indexer.Nullifiers.Response.t()}
+  @spec list_nullifiers() ::
+          {:ok, Anoma.Protobuf.Indexer.Nullifiers.Response.t()}
   def list_nullifiers() do
     GenServer.call(__MODULE__, {:list_nullifiers})
   end

--- a/apps/anoma_client/test/proxy_test.exs
+++ b/apps/anoma_client/test/proxy_test.exs
@@ -1,16 +1,16 @@
 defmodule ProxyTest do
   use ExUnit.Case
 
-#  alias Anoma.Client.Examples.EProxy
+  #  alias Anoma.Client.Examples.EProxy
 
-# for now, commented out until it can be fixed and made an example
-#  test "proxy tests" do
-#    excluded = [start_proxy_for: 0, start_proxy_for: 1]
-#
-#    EProxy.__info__(:functions)
-#    |> Enum.filter(&(&1 in excluded))
-#    |> Enum.each(fn {func, _arity} ->
-#      apply(EProxy, func, [])
-#    end)
-#  end
+  # for now, commented out until it can be fixed and made an example
+  #  test "proxy tests" do
+  #    excluded = [start_proxy_for: 0, start_proxy_for: 1]
+  #
+  #    EProxy.__info__(:functions)
+  #    |> Enum.filter(&(&1 in excluded))
+  #    |> Enum.each(fn {func, _arity} ->
+  #      apply(EProxy, func, [])
+  #    end)
+  #  end
 end

--- a/apps/anoma_node/lib/examples/e_registry.ex
+++ b/apps/anoma_node/lib/examples/e_registry.ex
@@ -237,9 +237,11 @@ defmodule Anoma.Node.Examples.ERegistry do
     assert Kernel.match?({:error, :no_node_running}, Registry.local_node_id())
 
     # start one node and assert the node is returned
-    node_id = "londo_mollari" <>
-              (:crypto.strong_rand_bytes(16)
-               |> Base.url_encode64())
+    node_id =
+      "londo_mollari" <>
+        (:crypto.strong_rand_bytes(16)
+         |> Base.url_encode64())
+
     %ENode{} = ENode.start_node(node_id: node_id)
 
     assert {:ok, node_id} == Registry.local_node_id()

--- a/apps/anoma_node/lib/node/transaction/storage.ex
+++ b/apps/anoma_node/lib/node/transaction/storage.ex
@@ -46,24 +46,11 @@ defmodule Anoma.Node.Transaction.Storage do
 
     node_id = keylist[:node_id]
 
-    values_table =
-      String.to_atom("#{__MODULE__.Values}_#{:erlang.phash2(node_id)}")
+    :mnesia.create_table(values_table(node_id), attributes: [:key, :value])
+    :mnesia.create_table(updates_table(node_id), attributes: [:key, :value])
+    :mnesia.create_table(blocks_table(node_id), attributes: [:round, :block])
 
-    updates_table =
-      String.to_atom("#{__MODULE__.Updates}_#{:erlang.phash2(node_id)}")
-
-    blocks_table =
-      String.to_atom("#{__MODULE__.Blocks}_#{:erlang.phash2(node_id)}")
-
-    :mnesia.create_table(values_table, attributes: [:key, :value])
-    :mnesia.create_table(updates_table, attributes: [:key, :value])
-    :mnesia.create_table(blocks_table, attributes: [:round, :block])
-
-    state =
-      struct(__MODULE__, Enum.into(args, %{}))
-      |> Map.put(:values_table, values_table)
-      |> Map.put(:updates_table, updates_table)
-      |> Map.put(:blocks_table, blocks_table)
+    state = struct(__MODULE__, Enum.into(args, %{}))
 
     {:ok, state}
   end
@@ -75,15 +62,15 @@ defmodule Anoma.Node.Transaction.Storage do
   def handle_call({:commit, round, writes, _}, _from, state) do
     mnesia_tx = fn ->
       for {key, value} <- state.uncommitted do
-        :mnesia.write({state.values_table, key, value})
+        :mnesia.write({values_table(state.node_id), key, value})
       end
 
       for {key, value} <- state.uncommitted_updates do
         {:atomic, res} =
-          fn -> :mnesia.read(state.updates_table, key) end
+          fn -> :mnesia.read(updates_table(state.node_id), key) end
           |> :mnesia.transaction()
 
-        updates_table = state.updates_table
+        updates_table = updates_table(state.node_id)
 
         new_updates =
           case res do
@@ -91,10 +78,10 @@ defmodule Anoma.Node.Transaction.Storage do
             [{^updates_table, _key, list}] -> value ++ list
           end
 
-        :mnesia.write({state.updates_table, key, new_updates})
+        :mnesia.write({updates_table(state.node_id), key, new_updates})
       end
 
-      :mnesia.write({state.blocks_table, round, writes})
+      :mnesia.write({blocks_table(state.node_id), round, writes})
     end
 
     :mnesia.transaction(mnesia_tx)
@@ -286,16 +273,16 @@ defmodule Anoma.Node.Transaction.Storage do
   def read_in_past(height, key, state) do
     case Map.get(state.uncommitted_updates, key) do
       nil ->
-        tx1 = fn -> :mnesia.read(state.updates_table, key) end
+        tx1 = fn -> :mnesia.read(updates_table(state.node_id), key) end
 
         {:atomic, tx1_result} = :mnesia.transaction(tx1)
 
-        updates_table = state.updates_table
+        updates_table = updates_table(state.node_id)
 
         case tx1_result do
           [{^updates_table, _key, height_upds}] ->
             height = height_upds |> Enum.find(fn a -> a <= height end)
-            values_table = state.values_table
+            values_table = values_table(state.node_id)
 
             case height do
               nil ->


### PR DESCRIPTION
The previous code would compute the values_table from the state,
however this is not declared in the type signature as it's derived
from the node_id. Thus this code removes this contradiction and keeps
it computable