### PR TITLE
compile_protoc: remove old .pb.ex outputs

### DIFF
--- a/apps/compile_protoc/lib/mix/tasks/compile/protoc.ex
+++ b/apps/compile_protoc/lib/mix/tasks/compile/protoc.ex
@@ -33,7 +33,10 @@ defmodule Mix.Tasks.Compile.Protoc do
         # find the protoc executable
         protoc_bin = protoc_executable()
 
-        # make the output directory
+        unless output_files == [] do
+          Enum.map(output_files, &File.rm!/1)
+        end
+
         File.mkdir_p!(compiler_opts[:elixir_out])
 
         # run the protoc command


### PR DESCRIPTION
This is in case a message type is removed, or something similar. They
will dangle as Elixir modules locally and possibly cause confusion or
issues if they're referenced.
