### PR TITLE
Fixup the logic check on action_proof correspondence

### DIFF
--- a/apps/anoma_lib/lib/anoma/transparent_resource/action.ex
+++ b/apps/anoma_lib/lib/anoma/transparent_resource/action.ex
@@ -58,12 +58,14 @@ defmodule Anoma.TransparentResource.Action do
       # that they are the same context. I could technically make it
       # lie if I constructed it to lie, no?
       action.proofs
-      |> Enum.all?(fn %LogicProof{resource: resource} ->
-        commitment = resource |> Resource.commitment()
-        nullifier = resource |> Resource.nullifier()
+      |> Enum.all?(fn
+        %LogicProof{resource: resource, self_tag: {:committed, commitment}} ->
+          Resource.commitment(resource) == commitment &&
+            MapSet.member?(action.commitments, commitment)
 
-        MapSet.member?(action.commitments, commitment) ||
-          MapSet.member?(action.nullifiers, nullifier)
+        %LogicProof{resource: resource, self_tag: {:nullified, nullifier}} ->
+          Resource.nullifier(resource) == nullifier &&
+            MapSet.member?(action.nullifiers, nullifier)
       end)
     end
   end

--- a/apps/compile_protoc/lib/mix/tasks/compile/protoc.ex
+++ b/apps/compile_protoc/lib/mix/tasks/compile/protoc.ex
@@ -33,7 +33,10 @@ defmodule Mix.Tasks.Compile.Protoc do
         # find the protoc executable
         protoc_bin = protoc_executable()
 
-        # make the output directory
+        unless output_files == [] do
+          Enum.map(output_files, &File.rm!/1)
+        end
+
         File.mkdir_p!(compiler_opts[:elixir_out])
 
         # run the protoc command


### PR DESCRIPTION
Before I would only check that the resource exists in the commitment
or nullifier set, now we are more discerning, we look if the resource
is actually being consumed and checking the nullifier and commitments
are created properly.