### PR TITLE
Give a default in the Enum.reduce to avoid an empty error

### DIFF
--- a/apps/anoma_lib/lib/anoma/transparent_resource/transaction.ex
+++ b/apps/anoma_lib/lib/anoma/transparent_resource/transaction.ex
@@ -40,7 +40,7 @@ defmodule Anoma.TransparentResource.Transaction do
     number_of = fn x -> x |> Stream.map(&MapSet.size/1) |> Enum.sum() end
 
     uniq_number_of = fn x ->
-      x |> Enum.reduce(&MapSet.union/2) |> MapSet.size()
+      x |> Enum.reduce(MapSet.new(), &MapSet.union/2) |> MapSet.size()
     end
 
     {comm_size, uniq_comm_size} = {number_of.(comms), uniq_number_of.(comms)}


### PR DESCRIPTION
If an empty transaction is sent this code will error on the Enum.reduce

```elixir
iex(mariari@Gensokyo)88> Transaction.verify_tx_action_distinctness(%Transaction{}) ** (Enum.EmptyError) empty error
    (elixir 1.17.3) lib/enum.ex:2474: Enum.reduce/2
    (anoma_lib 0.24.0) lib/anoma/transparent_resource/transaction.ex:45: anonymous fn/1 in Anoma.TransparentResource.Transaction.verify_tx_action_distinctness/1
    (anoma_lib 0.24.0) lib/anoma/transparent_resource/transaction.ex:48: Anoma.TransparentResource.Transaction.verify_tx_action_distinctness/1
    iex:88: (file)
```