### PR TITLE
Remove sleep from EConsensus.execution_continues/0

### DIFF
--- a/apps/anoma_node/lib/examples/e_consensus.ex
+++ b/apps/anoma_node/lib/examples/e_consensus.ex
@@ -74,8 +74,6 @@ defmodule Anoma.Node.Examples.EConsensus do
       end
     end)
 
-    Process.sleep(5000)
-
     node_id =
       ("londo_mollari" <> :crypto.strong_rand_bytes(16))
       |> Base.url_encode64()


### PR DESCRIPTION
Sleeping is bad, but even worse, Supversior.stop is synchronous so this achieves nothing