### PR TITLE
Fix LogicProof.verify/1 computation

### DIFF
--- a/apps/anoma_lib/lib/anoma/transparent_resource/logic_proof.ex
+++ b/apps/anoma_lib/lib/anoma/transparent_resource/logic_proof.ex
@@ -36,7 +36,7 @@ defmodule Anoma.TransparentResource.LogicProof do
   def verify(proof = %LogicProof{}) do
     args = []
 
-    result = Nock.nock(proof.resource.logic, [9, 2, 10, [6 | args], 0 | 1])
+    result = Nock.nock(proof.resource.logic, [9, 2, 10, [6, 1 | args], 0 | 1])
 
     case result do
       {:ok, zero} when zero in [0, <<>>, <<0>>, []] -> true


### PR DESCRIPTION
Before it would just call [6 | args], however this is invalid, as the args would have to be [1 | arguments]! this patch fixes it so the real arguments are just put in the 6 slot