### PR TITLE
Fix typo on comited to comitted

### DIFF
--- a/apps/anoma_lib/lib/anoma/transparent_resource/action.ex
+++ b/apps/anoma_lib/lib/anoma/transparent_resource/action.ex
@@ -15,7 +15,7 @@ defmodule Anoma.TransparentResource.Action do
 
   def precis(%Action{proofs: proofs}) do
     for proof <- proofs,
-        reduce: %{commited: MapSet.new(), nullified: MapSet.new()} do
+        reduce: %{committed: MapSet.new(), nullified: MapSet.new()} do
       %{committed: committed, nullified: nullified} ->
         case proof.polarity do
           :committed ->


### PR DESCRIPTION
This causes the following during testing:

```elixir
iex(mariari@Gensokyo)134> EAction.empty |> Action.delta ** (MatchError) no match of right hand side value: %{commited: MapSet.new([]), nullified: MapSet.new([])}
    (anoma_lib 0.24.1) lib/anoma/transparent_resource/action.ex:33: Anoma.TransparentResource.Action.delta/1
    iex:134: (file)
```