### PR TITLE
Add newline to the end of action proof verification messages

### DIFF
--- a/apps/anoma_lib/lib/anoma/transparent_resource/action.ex
+++ b/apps/anoma_lib/lib/anoma/transparent_resource/action.ex
@@ -75,12 +75,12 @@ defmodule Anoma.TransparentResource.Action do
 
             not verify_action_resources_correspond_to_proofs?(action, proof) ->
               "Either the action's commitments:\n" <>
-                "#{inspect(action.commitments, pretty: true)}" <>
-                "does not match the proof's commitments:" <>
-                "#{inspect(proof.commitments, pretty: true)}" <>
-                "or the action's nullifiers:" <>
-                "#{inspect(action.nullifiers, pretty: true)}" <>
-                "does not match the proof's nullifiers:" <>
+                "#{inspect(action.commitments, pretty: true)}\n" <>
+                "does not match the proof's commitments:\n" <>
+                "#{inspect(proof.commitments, pretty: true)}\n" <>
+                "or the action's nullifiers:\n" <>
+                "#{inspect(action.nullifiers, pretty: true)}\n" <>
+                "does not match the proof's nullifiers:\n" <>
                 "#{inspect(proof.nullifiers, pretty: true)}"
 
             true ->


### PR DESCRIPTION
These newlines are needed for readability

Either the action's commitments:
MapSet.new([
  <<67, 77, 95, 89, 177, 105, 28, 103, 6, 160, 223, 208, 111, 74, 125, 253, 204,
    102, 132, 105, 77, 147, 70, 153, 88, 160, 103, 30, 191, 157, 50, 159, 67,
    170, 6, 185, 216, 64, 185, 25, 186, 122, 29, 131>>
])does not match the proof's commitments:MapSet.new([
  <<67, 77, 95, 89, 177, 105, 28, 103, 6, 160, 223, 208, 111, 74, 125, 253, 204,
    102, 132, 105, 77, 147, 70, 153, 88, 160, 103, 30, 191, 157, 50, 159, 67,
    170, 6, 185, 216, 64, 185, 25, 186, 122, 29, 131>>
])or the action's nullifiers:MapSet.new([])does not match the proof's nullifiers:MapSet.new([
  <<78, 70, 95, 89, 177, 105, 28, 103, 6, 64, 0, 246, 46, 142, 236, 190, 10, 48,
    245, 253, 11, 228, 246, 45, 76, 191, 73, 11, 123, 67, 235, 68, 47, 10, 8,
    200, 231, 166, 93, 183, 149, 87, 241, 49, 8>>
])

becomes:

The following correspondence proofs failed:
Either the action's commitments:
MapSet.new([
  <<67, 77, 95, 89, 177, 105, 28, 103, 6, 160, 223, 208, 111, 74, 125, 253, 204,
    102, 132, 105, 77, 147, 70, 153, 88, 160, 103, 30, 191, 157, 50, 159, 67,
    170, 6, 185, 216, 64, 185, 25, 186, 122, 29, 131>>
])
does not match the proof's commitments:
MapSet.new([
  <<67, 77, 95, 89, 177, 105, 28, 103, 6, 160, 223, 208, 111, 74, 125, 253, 204,
    102, 132, 105, 77, 147, 70, 153, 88, 160, 103, 30, 191, 157, 50, 159, 67,
    170, 6, 185, 216, 64, 185, 25, 186, 122, 29, 131>>
])
or the action's nullifiers:
MapSet.new([])
does not match the proof's nullifiers:
MapSet.new([
  <<78, 70, 95, 89, 177, 105, 28, 103, 6, 64, 0, 246, 46, 142, 236, 190, 10, 48,
    245, 253, 11, 228, 246, 45, 76, 191, 73, 11, 123, 67, 235, 68, 47, 10, 8,
    200, 231, 166, 93, 183, 149, 87, 241, 49, 8>>
])