### PR TITLE
Fix Delta negation Logic

### DIFF
--- a/apps/anoma_lib/lib/anoma/transparent_resource/delta.ex
+++ b/apps/anoma_lib/lib/anoma/transparent_resource/delta.ex
@@ -17,8 +17,7 @@ defmodule Anoma.TransparentResource.Delta do
   end
 
   def sub(d1 = %{}, d2 = %{}) do
-    Map.merge(d1, d2, fn _k, v1, v2 -> v1 - v2 end)
-    |> make_sane()
+    add(d1, negate(d2))
   end
 
   def negate(d = %{}) do


### PR DESCRIPTION
This bug was introduced in:

96448e983760b09cde21f0d535352c91df12e297

However I'm basing it off of:

f2b9ffd4e87ace88759ae0d75d6dbb2456865b2f

because it introduces the negate/1 function.

This bug can be seen in the following way:

iex(mariari@Gensokyo)79> Map.merge(%{}, %{:a => 3}, fn _k, v1, v2 -> v1 - v2 end) %{a: 3}
iex(mariari@Gensokyo)80> Map.merge(%{:a => 1}, %{:a => 3}, fn _k, v1, v2 -> v1 - v2 end) %{a: -2}

What was likely meant was:

iex(mariari@Gensokyo)86> Map.merge(%{}, negate(%{:a => 3}), fn _k, v1, v2 -> v1 + v2 end) %{a: -3}

Which is what the logic now is