### PR TITLE
Fix a bug where an empty_nullifier_plain_text would be empty

### DIFF
--- a/apps/anoma_lib/lib/anoma/transparent_resource/logic_proof.ex
+++ b/apps/anoma_lib/lib/anoma/transparent_resource/logic_proof.ex
@@ -143,6 +143,10 @@ defmodule Anoma.TransparentResource.LogicProof do
   end
 
   @spec from_noun_plaintext(Noun.t()) :: {:ok, MapSet.t(Resource.t())}
+  defp from_noun_plaintext(noun) when noun in @empty do
+    {:ok, MapSet.new([])}
+  end
+
   defp from_noun_plaintext(noun) when is_list(noun) do
     maybe_resources =
       Enum.map(Noun.list_nock_to_erlang(noun), &Resource.from_noun/1)


### PR DESCRIPTION
iex(mariari@Gensokyo)178> LogicProof.from_noun_plaintext(nullified_plain) :error
iex(mariari@Gensokyo)179> nullified_plain
0

This is incorrect as the empty list is 0, and should be considered valid