### PR TITLE
Make sure the nullifiers and commitments are binary when interfacing Nock

### DIFF
--- a/apps/anoma_lib/lib/anoma/transparent_resource/action.ex
+++ b/apps/anoma_lib/lib/anoma/transparent_resource/action.ex
@@ -102,10 +102,18 @@ defmodule Anoma.TransparentResource.Action do
     with {:ok, proofs} <- from_noun_proofs(proofs) do
       {:ok,
        %Action{
-         commitments: MapSet.new(Noun.list_nock_to_erlang(commits)),
-         nullifiers: MapSet.new(Noun.list_nock_to_erlang(nulls)),
+         commitments:
+           MapSet.new(
+             Noun.list_nock_to_erlang(commits),
+             &Noun.atom_integer_to_binary/1
+           ),
+         nullifiers:
+           MapSet.new(
+             Noun.list_nock_to_erlang(nulls),
+             &Noun.atom_integer_to_binary/1
+           ),
          proofs: proofs,
-         app_data: app_data
+         app_data: Noun.atom_integer_to_binary(app_data)
        }}
     end
   end

--- a/apps/anoma_lib/lib/anoma/transparent_resource/logic_proof.ex
+++ b/apps/anoma_lib/lib/anoma/transparent_resource/logic_proof.ex
@@ -86,8 +86,17 @@ defmodule Anoma.TransparentResource.LogicProof do
       {:ok,
        %LogicProof{
          resource: self_resource,
-         commitments: MapSet.new(Noun.list_nock_to_erlang(commits)),
-         nullifiers: MapSet.new(Noun.list_nock_to_erlang(nulls)),
+         # THEY MUST BE BINARY
+         commitments:
+           MapSet.new(
+             Noun.list_nock_to_erlang(commits),
+             &Noun.atom_integer_to_binary/1
+           ),
+         nullifiers:
+           MapSet.new(
+             Noun.list_nock_to_erlang(nulls),
+             &Noun.atom_integer_to_binary/1
+           ),
          self_tag: tag,
          other_public: other_public,
          committed_plaintexts: committed_plaintexts,


### PR DESCRIPTION
The aura around these values may be incorrect and be integers, thus we ensure they are binary.

This may be paranoid of me, but when I compose transactions, this may cause issues, thus I do this as safety assurances