### PR TITLE
Murisi/update ci rebased

### DIFF
--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -6,6 +6,7 @@
 # - mix-env: The environment to build the release for.
 # - elixir-version: The version of Elixir to use.
 # - otp-version: The version of OTP to use.
+# - os: The operating system to build for.
 name: Build Release
 on:
   workflow_call:
@@ -22,47 +23,67 @@ on:
       release_name:
         required: true
         type: string
+      os:
+        required: true
+        type: string
 jobs:
   build_release:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.os }}
     steps:
-      - name: checkout the repository
-        uses: actions/checkout@v4
-
-      - name: setup deps and _build cache
-        uses: actions/cache@v4
+      - uses: actions/checkout@v4
         with:
-          path: |
-            ${{ github.workspace }}/deps
-            ${{ github.workspace }}/_build
-          key: ${{ runner.os }}-build-${{ inputs.mix-env }}-${{ hashFiles('mix.lock') }}
-
-      - name: setup elixir
-        uses: ./.github/actions/elixir_setup
+          fetch-depth: 50
+      - uses: erlef/setup-beam@v1.18.2
+        if: startsWith(runner.os, 'Linux') || startsWith(runner.os, 'Windows')
         with:
-          elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}
-
-      - name: install apt packages
-        uses: ./.github/actions/os_setup
-
-      #---------------------------------------------------------------------------
-      # Create binaries
-      #
-      # This part of the action generates all the binaries that are necessary
-      # for a release.
-      # If these need to be compiled for different elixir versions, the matrix
-      # should be put in the on_release.yml file.
-
-      - name: create the client binary
-        continue-on-error: false
+          elixir-version: ${{ inputs.elixir-version }}
+      - name: Install system dependencies
+        shell: bash
+        if: startsWith(runner.os, 'Linux')
+        run: sudo apt install -y libsodium-dev protobuf-compiler
+      - name: Install system dependencies
+        shell: bash
+        if: startsWith(runner.os, 'macOS')
+        run: brew install elixir protobuf
+      - name: Install system dependencies
+        shell: pwsh
+        if: startsWith(runner.os, 'Windows')
+        run: |
+          choco install protoc
+          vcpkg install libsodium
+      - name: Install Elixir dependencies
         shell: bash
         run: |
-          MIX_ENV=prod mix do --app anoma_client escript.build
-          mv "apps/anoma_client/anoma_client" "apps/anoma_client/anoma_client-elixir-${{ inputs.elixir-version }}-otp-${{ inputs.otp-version }}"
-
-      - name: create artifact of the client binary
+          mix deps.get --force
+          mix escript.install hex protobuf --force
+      - name: Build Anoma release
+        if: startsWith(runner.os, 'Linux') || startsWith(runner.os, 'macOS')
+        shell: bash
+        run: |
+          export PATH="$PATH:$HOME/.mix/escripts"
+          mix release
+      - name: Build Anoma release
+        if: startsWith(runner.os, 'Windows')
+        shell: pwsh
+        run: |
+          & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1" -Arch amd64 -SkipAutomaticLocation
+          $env:PATH += $env:USERPROFILE + '\.mix\escripts;'
+          $env:INCLUDE += ';' + $env:VCPKG_INSTALLATION_ROOT + '\packages\libsodium_x64-windows\include'
+          $env:LIB += ';' + $env:VCPKG_INSTALLATION_ROOT + '\packages\libsodium_x64-windows\lib'
+          mix release
+      - name: Compute SHA hashes
+        shell: pwsh
+        run: |
+          cd _build/dev/rel/
+          tar czf anoma.tar.gz anoma
+          shasum -a 1 anoma.tar.gz > anoma.tar.gz.sha1sum
+          shasum -a 256 anoma.tar.gz > anoma.tar.gz.sha256sum
+      - name: Create Anoma release artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: anoma_client-elixir-${{ inputs.elixir-version }}-otp-${{ inputs.otp-version }}
-          path: "apps/anoma_client/anoma_client-elixir-${{ inputs.elixir-version }}-otp-${{ inputs.otp-version }}"
+          name: anoma-${{ github.ref_name }}-${{ runner.os }}-${{ runner.arch }}
+          path: |
+            _build/dev/rel/anoma.tar.gz
+            _build/dev/rel/anoma.tar.gz.sha1sum
+            _build/dev/rel/anoma.tar.gz.sha256sum

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,6 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-      # 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -50,8 +49,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      
-      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)." 
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)."
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,60 @@
+#
+name: Create and publish a Docker image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  push:
+    tags:
+      - v*
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+      # 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)." 
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -64,11 +64,17 @@ jobs:
     needs: [compile, lint, test, docs]
     strategy:
       matrix:
-        beam_versions:
-          - otp: "27.1"
-            elixir: "1.17"
-          # - otp: "26.2.5.5"
-          #   elixir: "1.17"
+        include:
+          - otp_version: "27.1"
+            os: macos-latest
+            elixir_version: "1.17"
+          - otp_version: "27.1"
+            os: ubuntu-latest
+            elixir_version: "1.17"
+          - otp_version: "27.1"
+            os: windows-latest
+            elixir_version: "1.17"
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: write
       id-token: write
@@ -76,8 +82,9 @@ jobs:
     uses: ./.github/workflows/build_release.yaml
     with:
       mix-env: "prod"
-      elixir-version: "${{ matrix.beam_versions.elixir }}"
-      otp-version: "${{ matrix.beam_versions.otp }}"
+      elixir-version: "${{ matrix.elixir_version }}"
+      otp-version: "${{ matrix.otp_version }}"
+      os: "${{ matrix.os }}"
       release_name: ${{ github.ref_name }}
 
   publish_release:

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ Further see the Known issues section if you encounter an issue.
 ## Docker images
 To work with Docker images, do the following:
 1. Install [Docker](https://docs.docker.com/engine/install/), this is necessary for both building and running Docker images
-2. Build the Anoma image from the repository root: `docker build -t <IMAGE> .`
+2. If using the official Anoma image, download it using [the package instructions](https://github.com/anoma/anoma/pkgs/container/anoma)
+3. If building the Anoma image instead, then run from the repository root: `docker build -t <IMAGE> .`
     * `<IMAGE>` is your chosen image name
 4. Run the Anoma image: `docker run -it --network host <IMAGE> <SUBCOMMAND>`
     * `<IMAGE>` is the name of Anoma Docker image to be run

--- a/mix.exs
+++ b/mix.exs
@@ -43,17 +43,12 @@ defmodule Anoma.MixProject do
 
   def releases do
     [
-      anoma_client: [
-        include_executables_for: [:unix],
-        applications: [
-          {:anoma_client, :permanent}
-        ]
-      ],
       anoma: [
         include_executables_for: [:unix, :windows],
         applications: [
           anoma_node: :permanent,
-          event_broker: :permanent
+          event_broker: :permanent,
+          anoma_client: :permanent
         ]
       ]
     ]
@@ -146,7 +141,7 @@ defmodule Anoma.MixProject do
 
   def escript do
     [
-      main_module: Anoma.Cli,
+      main_module: Anoma.Client.CLI,
       name: "anoma",
       app: nil
     ]


### PR DESCRIPTION
An attempt to resolve https://github.com/anoma/anoma/issues/1426 . This PR expands the existing repository actions to build Anoma releases for macOS, Windows, and Linux. These release artifacts would have names like `anoma-v5-Linux-X64.tar.gz` and `anoma-v5-Windows-X64.tar.gz`. Furthermore, an action (essentially from https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images#publishing-images-to-github-packages) is introduced to build an Anoma Docker image and the README has been amended to reflect its usage.

See https://github.com/murisi/anoma/releases/tag/v8 and https://github.com/murisi/anoma/pkgs/container/anoma for demonstrations of how the CI changes would behave.