### PR TITLE
Remove Bug Repeating Set Writes

### DIFF
--- a/apps/anoma_node/lib/node/transaction/storage.ex
+++ b/apps/anoma_node/lib/node/transaction/storage.ex
@@ -231,7 +231,7 @@ defmodule Anoma.Node.Transaction.Storage do
   def abwrite(flag, {height, kvlist}, state) do
     {new_state, event_writes} =
       for {key, value} <- kvlist,
-          reduce: {%__MODULE__{state | uncommitted_height: height}, kvlist} do
+          reduce: {%__MODULE__{state | uncommitted_height: height}, []} do
         {state_acc, list} ->
           key_old_updates = Map.get(state_acc.uncommitted_updates, key, [])
           key_new_updates = [height | key_old_updates]


### PR DESCRIPTION
Currently when we append to set, we produce a writes messages which includes the original kv-list we write. This should be removed in favour of just broadcasting the full sets we have written.