### PR TITLE
Run run_nock/2 instead of prove/2 in EClient

### DIFF
--- a/apps/anoma_client/lib/examples/e_client.ex
+++ b/apps/anoma_client/lib/examples/e_client.ex
@@ -252,8 +252,7 @@ defmodule Anoma.Client.Examples.EClient do
 
     assert {:ok,
             %RunNock.Response{
-              result: {:output, <<240, 61>>},
-              __unknown_fields__: []
+              result: {:output, <<240, 61>>}
             }} = Intents.Stub.run_nock(conn.channel, request)
   end
 
@@ -282,8 +281,7 @@ defmodule Anoma.Client.Examples.EClient do
 
     assert {:ok,
             %RunNock.Response{
-              result: {:output, <<240, 61>>},
-              __unknown_fields__: []
+              result: {:output, <<240, 61>>}
             }} = Intents.Stub.run_nock(conn.channel, request)
   end
 end

--- a/apps/anoma_client/lib/examples/e_client.ex
+++ b/apps/anoma_client/lib/examples/e_client.ex
@@ -250,7 +250,11 @@ defmodule Anoma.Client.Examples.EClient do
       inputs: inputs
     }
 
-    {:ok, _reply} = Intents.Stub.prove(conn.channel, request)
+    assert {:ok,
+            %RunNock.Response{
+              result: {:output, <<240, 61>>},
+              __unknown_fields__: []
+            }} = Intents.Stub.run_nock(conn.channel, request)
   end
 
   @doc """
@@ -276,6 +280,10 @@ defmodule Anoma.Client.Examples.EClient do
       inputs: inputs
     }
 
-    {:ok, _reply} = Intents.Stub.prove(conn.channel, request)
+    assert {:ok,
+            %RunNock.Response{
+              result: {:output, <<240, 61>>},
+              __unknown_fields__: []
+            }} = Intents.Stub.run_nock(conn.channel, request)
   end
 end


### PR DESCRIPTION
I noticed a small discrepancy. It seems the intention was to test the `run_nock/2` function. Is it correct?