### PR TITLE
Fix incorrect Enum.into calling Map.new

### DIFF
--- a/apps/anoma_node/lib/node/transaction/intent_pool.ex
+++ b/apps/anoma_node/lib/node/transaction/intent_pool.ex
@@ -195,7 +195,7 @@ defmodule Anoma.Node.Transaction.IntentPool do
         end)
         |> Enum.any?(&MapSet.member?(nlfs_set, &1))
       end)
-      |> Enum.into(&MapSet.new/1)
+      |> MapSet.new()
 
     %__MODULE__{state | intents: new_intents}
   end


### PR DESCRIPTION
The call fails, it's replaced with a working one