### PR TITLE
Indexer Filters

### DIFF
--- a/apps/anoma_node/lib/examples/e_indexer.ex
+++ b/apps/anoma_node/lib/examples/e_indexer.ex
@@ -1,10 +1,11 @@
 defmodule Anoma.Node.Examples.EIndexer do
-  alias Anoma.Node.Examples.{ETransaction}
-  alias Anoma.Node.Transaction.Storage
-  alias Anoma.Node.Utility.Indexer
+  alias Anoma.Node
+  alias Node.Examples.{ETransaction, ENode}
+  alias Node.Transaction.Storage
+  alias Node.Utility.Indexer
   alias Anoma.TransparentResource.Resource
 
-  def indexer_reads_height(node_id \\ "londo_mollari") do
+  def indexer_reads_height(node_id \\ Node.example_random_id()) do
     ETransaction.inc_counter_submit_after_read(node_id)
     Indexer.start_link(node_id: node_id)
     1 = Indexer.get(node_id, :blocks)
@@ -12,8 +13,8 @@ defmodule Anoma.Node.Examples.EIndexer do
     node_id
   end
 
-  def indexer_reads_nullifier(node_id \\ "londo_mollari") do
-    ETransaction.restart_storage(node_id)
+  def indexer_reads_nullifier(node_id \\ Node.example_random_id()) do
+    ENode.start_node(node_id: node_id)
     Indexer.start_link(node_id: node_id)
     updates = Storage.updates_table(node_id)
     values = Storage.values_table(node_id)
@@ -28,8 +29,8 @@ defmodule Anoma.Node.Examples.EIndexer do
     node_id
   end
 
-  def indexer_reads_nullifiers(node_id \\ "londo_mollari") do
-    ETransaction.restart_storage(node_id)
+  def indexer_reads_nullifiers(node_id \\ Node.example_random_id()) do
+    ENode.start_node(node_id: node_id)
     Indexer.start_link(node_id: node_id)
     updates = Storage.updates_table(node_id)
     values = Storage.values_table(node_id)
@@ -45,8 +46,8 @@ defmodule Anoma.Node.Examples.EIndexer do
     node_id
   end
 
-  def indexer_reads_commitments(node_id \\ "londo_mollari") do
-    ETransaction.restart_storage(node_id)
+  def indexer_reads_commitments(node_id \\ Node.example_random_id()) do
+    ENode.start_node(node_id: node_id)
     Indexer.start_link(node_id: node_id)
     updates = Storage.updates_table(node_id)
     values = Storage.values_table(node_id)
@@ -62,8 +63,8 @@ defmodule Anoma.Node.Examples.EIndexer do
     node_id
   end
 
-  def indexer_does_not_read_revealed(node_id \\ "londo_mollari") do
-    ETransaction.restart_storage(node_id)
+  def indexer_does_not_read_revealed(node_id \\ Node.example_random_id()) do
+    ENode.start_node(node_id: node_id)
     Indexer.start_link(node_id: node_id)
     updates = Storage.updates_table(node_id)
     values = Storage.values_table(node_id)
@@ -82,8 +83,8 @@ defmodule Anoma.Node.Examples.EIndexer do
     node_id
   end
 
-  def indexer_reads_unrevealed(node_id \\ "londo_mollari") do
-    ETransaction.restart_storage(node_id)
+  def indexer_reads_unrevealed(node_id \\ Node.example_random_id()) do
+    ENode.start_node(node_id: node_id)
     Indexer.start_link(node_id: node_id)
     updates = Storage.updates_table(node_id)
     values = Storage.values_table(node_id)

--- a/apps/anoma_node/lib/examples/e_indexer.ex
+++ b/apps/anoma_node/lib/examples/e_indexer.ex
@@ -8,7 +8,7 @@ defmodule Anoma.Node.Examples.EIndexer do
   def indexer_reads_height(node_id \\ Node.example_random_id()) do
     ETransaction.inc_counter_submit_after_read(node_id)
     Indexer.start_link(node_id: node_id)
-    1 = Indexer.get(node_id, :blocks)
+    1 = Indexer.get(node_id, :height)
 
     node_id
   end

--- a/apps/anoma_node/lib/examples/e_indexer.ex
+++ b/apps/anoma_node/lib/examples/e_indexer.ex
@@ -168,6 +168,34 @@ defmodule Anoma.Node.Examples.EIndexer do
     node_id
   end
 
+  def indexer_filters_owner(node_id \\ Node.example_random_id()) do
+    ENode.start_node(node_id: node_id)
+    Indexer.start_link(node_id: node_id)
+    updates = Storage.updates_table(node_id)
+    values = Storage.values_table(node_id)
+
+    res1 = %Resource{rseed: "random1", nullifier_key: "jeremy"}
+    res2 = %Resource{rseed: "random2", nullifier_key: "michael"}
+    list = [res1, res2]
+
+    write_new(
+      updates,
+      values,
+      [1],
+      nil,
+      list |> Enum.map(&Resource.commitment/1) |> MapSet.new()
+    )
+
+    jeremy = Noun.atom_binary_to_integer("jeremy")
+    michael = Noun.atom_binary_to_integer("michael")
+
+    2 = Indexer.get(node_id, {:filter, []}) |> MapSet.size()
+    1 = Indexer.get(node_id, {:filter, [{:owner, jeremy}]}) |> MapSet.size()
+    1 = Indexer.get(node_id, {:filter, [{:owner, michael}]}) |> MapSet.size()
+
+    node_id
+  end
+
   defp write_new(updates, values, heights, nlfs, coms) do
     :mnesia.transaction(fn ->
       if nlfs do

--- a/apps/anoma_node/lib/node/utility/indexer.ex
+++ b/apps/anoma_node/lib/node/utility/indexer.ex
@@ -26,14 +26,14 @@ defmodule Anoma.Node.Utility.Indexer do
     {:ok, state}
   end
 
-  @spec get(String.t(), :nlfs | :cms | :unrevealed | :resources | :blocks) ::
+  @spec get(String.t(), :nlfs | :cms | :unrevealed | :resources | :height) ::
           any()
   def get(node_id, flag) do
     name = Registry.via(node_id, __MODULE__)
     GenServer.call(name, flag)
   end
 
-  def handle_call(:blocks, _from, state) do
+  def handle_call(:height, _from, state) do
     table = Storage.blocks_table(state.node_id)
 
     {:atomic, res} =

--- a/apps/anoma_node/lib/node/utility/indexer.ex
+++ b/apps/anoma_node/lib/node/utility/indexer.ex
@@ -37,23 +37,17 @@ defmodule Anoma.Node.Utility.Indexer do
 
   @spec get(String.t(), index_type) ::
           any()
+  def get(node_id, :latest_block) do
+    get(node_id, {:after, get_height(node_id) - 1})
+  end
+
   def get(node_id, flag) do
     name = Registry.via(node_id, __MODULE__)
     GenServer.call(name, flag)
   end
 
   def handle_call(:height, _from, state) do
-    table = Storage.blocks_table(state.node_id)
-
-    {:atomic, res} =
-      :mnesia.transaction(fn ->
-        case :mnesia.all_keys(table) |> Enum.sort(:desc) do
-          [] -> :absent
-          [hd | _tl] -> hd
-        end
-      end)
-
-    {:reply, res, state}
+    {:reply, get_height(state.node_id), state}
   end
 
   def handle_call(:nlfs, _from, state) do
@@ -142,5 +136,20 @@ defmodule Anoma.Node.Utility.Indexer do
       end)
 
     set
+  end
+
+  @spec get_height(String.t()) :: non_neg_integer()
+  defp get_height(node_id) do
+    table = Storage.blocks_table(node_id)
+
+    {:atomic, res} =
+      :mnesia.transaction(fn ->
+        case :mnesia.all_keys(table) |> Enum.sort(:desc) do
+          [] -> :absent
+          [hd | _tl] -> hd
+        end
+      end)
+
+    res
   end
 end

--- a/apps/anoma_node/test/indexer_test.exs
+++ b/apps/anoma_node/test/indexer_test.exs
@@ -14,5 +14,6 @@ defmodule IndexerTest do
     EIndexer.indexer_reads_commitments()
     EIndexer.indexer_does_not_read_revealed()
     EIndexer.indexer_reads_unrevealed()
+    EIndexer.indexer_filters_owner()
   end
 end

--- a/apps/anoma_node/test/indexer_test.exs
+++ b/apps/anoma_node/test/indexer_test.exs
@@ -6,6 +6,9 @@ defmodule IndexerTest do
   test "indexing examples" do
     # commented out until multihoming
     # EIndexer.indexer_reads_height()
+    EIndexer.indexer_reads_before()
+    EIndexer.indexer_reads_after()
+    EIndexer.indexer_reads_latest()
     EIndexer.indexer_reads_nullifier()
     EIndexer.indexer_reads_nullifiers()
     EIndexer.indexer_reads_commitments()


### PR DESCRIPTION
Indexer now accepts a list of filters to filter unspent resources by and returns a set of noun-ized Resources.

Filters are currently Kudos-specific and given by the Applications team. We currently have two filters: the ownership filter and the kind filter. Both are added to the indexer on startup.