### PR TITLE
Create a with_subscription Macro 

### DIFF
--- a/apps/anoma_node/lib/examples/e_logging.ex
+++ b/apps/anoma_node/lib/examples/e_logging.ex
@@ -242,8 +242,9 @@ defmodule Anoma.Node.Examples.ELogging do
     end)
 
     write_consensus_leave_one_out(node_id)
+    filter = [%Mempool.TxFilter{}]
 
-    EventBroker.subscribe_me([])
+    EventBroker.subscribe_me(filter)
 
     Logging.restart_with_replay(node_id)
 
@@ -264,7 +265,9 @@ defmodule Anoma.Node.Examples.ELogging do
     write_consensus_leave_one_out(node_id)
     replay_ensure_created_tables(node_id)
 
-    EventBroker.subscribe_me([])
+    filter = [%Mempool.TxFilter{}]
+
+    EventBroker.subscribe_me(filter)
 
     Logging.restart_with_replay(node_id)
 
@@ -287,7 +290,11 @@ defmodule Anoma.Node.Examples.ELogging do
     write_several_consensus(node_id)
     replay_ensure_created_tables(node_id)
 
-    EventBroker.subscribe_me([])
+    txfilter = [%Mempool.TxFilter{}]
+    consensus_filter = [%Mempool.ConsensusFilter{}]
+
+    EventBroker.subscribe_me(txfilter)
+    EventBroker.subscribe_me(consensus_filter)
 
     Logging.restart_with_replay(node_id)
 
@@ -308,7 +315,11 @@ defmodule Anoma.Node.Examples.ELogging do
     write_consensus_with_several_tx(node_id)
     replay_ensure_created_tables(node_id)
 
-    EventBroker.subscribe_me([])
+    txfilter = [%Mempool.TxFilter{}]
+    consensus_filter = [%Mempool.ConsensusFilter{}]
+
+    EventBroker.subscribe_me(txfilter)
+    EventBroker.subscribe_me(consensus_filter)
 
     Logging.restart_with_replay(node_id)
 
@@ -326,7 +337,11 @@ defmodule Anoma.Node.Examples.ELogging do
     write_consensus(node_id)
     replay_ensure_created_tables(node_id)
 
-    EventBroker.subscribe_me([])
+    txfilter = [%Mempool.TxFilter{}]
+    consensus_filter = [%Mempool.ConsensusFilter{}]
+
+    EventBroker.subscribe_me(txfilter)
+    EventBroker.subscribe_me(consensus_filter)
 
     Logging.restart_with_replay(node_id)
 
@@ -341,7 +356,9 @@ defmodule Anoma.Node.Examples.ELogging do
     write_several_tx(node_id)
     replay_ensure_created_tables(node_id)
 
-    EventBroker.subscribe_me([])
+    txfilter = [%Mempool.TxFilter{}]
+
+    EventBroker.subscribe_me(txfilter)
 
     Logging.restart_with_replay(node_id)
 
@@ -356,7 +373,9 @@ defmodule Anoma.Node.Examples.ELogging do
     write_tx(node_id)
     replay_ensure_created_tables(node_id)
 
-    EventBroker.subscribe_me([])
+    txfilter = [%Mempool.TxFilter{}]
+
+    EventBroker.subscribe_me(txfilter)
 
     {:ok, _pid} = Logging.restart_with_replay(node_id)
 

--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -118,6 +118,32 @@ defmodule Anoma.Node.Examples.ETransaction do
     {:ok, ^appended_set} = Storage.read(node_id, {2, :set})
   end
 
+  def add_rewrites(node_id \\ Node.example_random_id()) do
+    write_then_read(node_id)
+
+    Storage.add(
+      node_id,
+      {2, %{write: [{["abc"], 234}], append: [{:set, "value1"}]}}
+    )
+
+    {:ok, 234} = Storage.read(node_id, {2, ["abc"]})
+    new_set = MapSet.new(["value1"])
+    {:ok, ^new_set} = Storage.read(node_id, {2, :set})
+  end
+
+  def add_append(node_id \\ Node.example_random_id()) do
+    append_then_read(node_id)
+
+    Storage.add(
+      node_id,
+      {2, %{write: [{["abc"], 234}], append: [{:set, "new_value"}]}}
+    )
+
+    {:ok, 234} = Storage.read(node_id, {2, ["abc"]})
+    new_set = MapSet.new(["new_value", "value"])
+    {:ok, ^new_set} = Storage.read(node_id, {2, :set})
+  end
+
   def complicated_storage(node_id \\ Node.example_random_id()) do
     start_storage(node_id)
     task1 = Task.async(fn -> Storage.read(node_id, {3, ["abc"]}) end)

--- a/apps/anoma_node/lib/node/transaction/mempool.ex
+++ b/apps/anoma_node/lib/node/transaction/mempool.ex
@@ -13,6 +13,7 @@ defmodule Anoma.Node.Transaction.Mempool do
   require Node.Event
   require Logger
 
+  use EventBroker.DefFilter
   use GenServer
   use TypedStruct
 
@@ -51,6 +52,30 @@ defmodule Anoma.Node.Transaction.Mempool do
     )
 
     field(:round, non_neg_integer(), default: 0)
+  end
+
+  deffilter TxFilter do
+    %EventBroker.Event{body: %Node.Event{body: %Mempool.TxEvent{}}} ->
+      true
+
+    _ ->
+      false
+  end
+
+  deffilter ConsensusFilter do
+    %EventBroker.Event{body: %Node.Event{body: %Mempool.ConsensusEvent{}}} ->
+      true
+
+    _ ->
+      false
+  end
+
+  deffilter BlockFilter do
+    %EventBroker.Event{body: %Node.Event{body: %Mempool.BlockEvent{}}} ->
+      true
+
+    _ ->
+      false
   end
 
   @spec start_link([startup_options()]) :: GenServer.on_start()

--- a/apps/anoma_node/lib/node/transaction/mempool.ex
+++ b/apps/anoma_node/lib/node/transaction/mempool.ex
@@ -236,14 +236,6 @@ defmodule Anoma.Node.Transaction.Mempool do
     EventBroker.event(consensus_event)
   end
 
-  def worker_module_filter() do
-    %EventBroker.Filters.SourceModule{module: Anoma.Node.Transaction.Backends}
-  end
-
-  def filter_for_mempool() do
-    %Backends.ForMempoolFilter{}
-  end
-
   @spec process_execution(t(), [{:ok | :error, binary()}]) ::
           {[Mempool.Tx.t()], %{binary() => Mempool.Tx.t()}}
   defp process_execution(state, execution_list) do
@@ -254,5 +246,17 @@ defmodule Anoma.Node.Transaction.Mempool do
 
         {[Map.put(tx_struct, :tx_result, tx_res) | lst], map}
     end
+  end
+
+  ############################################################
+  #                      Public Filters                      #
+  ############################################################
+
+  def worker_module_filter() do
+    %EventBroker.Filters.SourceModule{module: Anoma.Node.Transaction.Backends}
+  end
+
+  def filter_for_mempool() do
+    %Backends.ForMempoolFilter{}
   end
 end

--- a/apps/anoma_node/lib/node/transaction/ordering.ex
+++ b/apps/anoma_node/lib/node/transaction/ordering.ex
@@ -14,6 +14,10 @@ defmodule Anoma.Node.Transaction.Ordering do
 
   require Node.Event
 
+  ############################################################
+  #                         State                            #
+  ############################################################
+
   @typep startup_options() :: {:node_id, String.t()}
 
   typedstruct enforce: true do
@@ -39,6 +43,10 @@ defmodule Anoma.Node.Transaction.Ordering do
     GenServer.start_link(__MODULE__, args, name: name)
   end
 
+  ############################################################
+  #                    Genserver Helpers                     #
+  ############################################################
+
   @spec init([startup_options()]) :: {:ok, t()}
   def init(args) do
     Process.set_label(__MODULE__)
@@ -48,100 +56,9 @@ defmodule Anoma.Node.Transaction.Ordering do
     {:ok, state}
   end
 
-  def handle_call({:read, {tx_id, key}}, from, state) do
-    with {:ok, height} <- Map.fetch(state.tx_id_to_height, tx_id) do
-      Task.start(fn ->
-        GenServer.reply(from, Storage.read(state.node_id, {height - 1, key}))
-      end)
-
-      {:noreply, state}
-    else
-      _ ->
-        node_id = state.node_id
-
-        block_spawn(
-          tx_id,
-          fn ->
-            blocking_read(node_id, {tx_id, key}, from)
-          end,
-          node_id
-        )
-
-        {:noreply, state}
-    end
-  end
-
-  def handle_call({write_opt, {tx_id, args}}, from, state)
-      when write_opt in [:write, :append, :add] do
-    call =
-      case write_opt do
-        :write -> &Storage.write(state.node_id, &1)
-        :append -> &Storage.append(state.node_id, &1)
-        :add -> &Storage.add(state.node_id, &1)
-      end
-
-    with {:ok, height} <- Map.fetch(state.tx_id_to_height, tx_id) do
-      Task.start(fn ->
-        GenServer.reply(from, call.({height, args}))
-      end)
-
-      {:noreply, state}
-    else
-      _ ->
-        node_id = state.node_id
-
-        block_spawn(
-          tx_id,
-          fn ->
-            blocking_write(node_id, {tx_id, args}, from)
-          end,
-          node_id
-        )
-
-        {:noreply, state}
-    end
-  end
-
-  def handle_call(_msg, _from, state) do
-    {:reply, :ok, state}
-  end
-
-  def handle_cast({:order, tx_id_list}, state) do
-    {map, next_order} =
-      for tx_id <- tx_id_list,
-          reduce: {state.tx_id_to_height, state.next_height} do
-        {map, order} ->
-          order_event =
-            Node.Event.new_with_body(state.node_id, %__MODULE__.OrderEvent{
-              tx_id: tx_id
-            })
-
-          EventBroker.event(order_event)
-          {Map.put(map, tx_id, order), order + 1}
-      end
-
-    {:noreply,
-     %__MODULE__{state | tx_id_to_height: map, next_height: next_order}}
-  end
-
-  def handle_cast(_msg, state) do
-    {:noreply, state}
-  end
-
-  def handle_info(_info, state) do
-    {:noreply, state}
-  end
-
-  def block_spawn(id, call, node_id) do
-    {:ok, pid} =
-      Task.start(call)
-
-    EventBroker.subscribe(pid, [
-      Node.Event.node_filter(node_id),
-      this_module_filter(),
-      tx_id_filter(id)
-    ])
-  end
+  ############################################################
+  #                      Public RPC API                      #
+  ############################################################
 
   @spec read(String.t(), {binary(), any()}) :: any()
   def read(node_id, {id, key}) do
@@ -184,14 +101,161 @@ defmodule Anoma.Node.Transaction.Ordering do
     GenServer.cast(Registry.via(node_id, __MODULE__), {:order, txs})
   end
 
+  ############################################################
+  #                      Public Filters                      #
+  ############################################################
+
+  def tx_id_filter(tx_id) do
+    %__MODULE__.TxIdFilter{tx_id: tx_id}
+  end
+
+  ############################################################
+  #                    Genserver Behavior                    #
+  ############################################################
+
+  def handle_call({write_opt, {tx_id, args}}, from, state)
+      when write_opt in [:write, :append, :add] do
+    handle_write(write_opt, {tx_id, args}, from, state)
+
+    {:noreply, state}
+  end
+
+  def handle_call({:read, {tx_id, key}}, from, state) do
+    handle_read({tx_id, key}, from, state)
+    {:noreply, state}
+  end
+
+  def handle_call(_msg, _from, state) do
+    {:reply, :ok, state}
+  end
+
+  def handle_cast({:order, tx_id_list}, state) do
+    {:noreply, handle_order(tx_id_list, state)}
+  end
+
+  def handle_cast(_msg, state) do
+    {:noreply, state}
+  end
+
+  def handle_info(_info, state) do
+    {:noreply, state}
+  end
+
+  ############################################################
+  #                 Genserver Implementation                 #
+  ############################################################
+
+  @spec handle_write(
+          Storage.write_opts(),
+          {binary(), [any()]},
+          GenServer.from(),
+          t()
+        ) :: any()
+  defp handle_write(write_opt, {tx_id, args}, from, state) do
+    call = &chose_write_function(write_opt).(state.node_id, &1)
+
+    with {:ok, height} <- Map.fetch(state.tx_id_to_height, tx_id) do
+      Task.start(fn ->
+        GenServer.reply(from, call.({height, args}))
+      end)
+    else
+      _ ->
+        node_id = state.node_id
+
+        block_spawn(
+          tx_id,
+          fn ->
+            blocking_write(node_id, {tx_id, args}, from)
+          end,
+          node_id
+        )
+    end
+  end
+
+  @spec handle_read({binary(), any()}, GenServer.from(), t()) :: any()
+  defp handle_read({tx_id, key}, from, state) do
+    with {:ok, height} <- Map.fetch(state.tx_id_to_height, tx_id) do
+      Task.start(fn ->
+        GenServer.reply(from, Storage.read(state.node_id, {height - 1, key}))
+      end)
+
+      {:noreply, state}
+    else
+      _ ->
+        node_id = state.node_id
+
+        block_spawn(
+          tx_id,
+          fn ->
+            blocking_read(node_id, {tx_id, key}, from)
+          end,
+          node_id
+        )
+
+        {:noreply, state}
+    end
+  end
+
+  @spec handle_order(list(binary()), t()) :: t()
+  defp handle_order(tx_id_list, state) do
+    {map, next_order} =
+      for tx_id <- tx_id_list,
+          reduce: {state.tx_id_to_height, state.next_height} do
+        {map, order} ->
+          order_event =
+            Node.Event.new_with_body(state.node_id, %__MODULE__.OrderEvent{
+              tx_id: tx_id
+            })
+
+          EventBroker.event(order_event)
+          {Map.put(map, tx_id, order), order + 1}
+      end
+
+    %__MODULE__{state | tx_id_to_height: map, next_height: next_order}
+  end
+
+  ############################################################
+  #                           Helpers                        #
+  ############################################################
+
+  @spec chose_write_function(Storage.write_opts()) ::
+          (String.t(), {non_neg_integer(), list() | map()} ->
+             any())
+  defp chose_write_function(:write), do: &Storage.write/2
+  defp chose_write_function(:append), do: &Storage.append/2
+  defp chose_write_function(:add), do: &Storage.add/2
+
+  ############################################################
+  #                      Private Filters                     #
+  ############################################################
+
+  defp this_module_filter() do
+    %EventBroker.Filters.SourceModule{module: __MODULE__}
+  end
+
+  ############################################################
+  #                    Blocking Operations                   #
+  ############################################################
+
+  defp block_spawn(id, call, node_id) do
+    {:ok, pid} =
+      Task.start(call)
+
+    EventBroker.subscribe(pid, [
+      Node.Event.node_filter(node_id),
+      this_module_filter(),
+      tx_id_filter(id)
+    ])
+  end
+
   @spec blocking_read(String.t(), {binary(), any()}, GenServer.from()) :: :ok
-  def blocking_read(node_id, {id, key}, from) do
+  defp blocking_read(node_id, {id, key}, from) do
     block(from, id, fn -> read(node_id, {id, key}) end, node_id)
   end
 
   @spec blocking_write(String.t(), {binary(), [any()]}, GenServer.from()) ::
           :ok
-  def blocking_write(node_id, {id, kvlist}, from) do
+  defp blocking_write(node_id, {id, kvlist}, from) do
     block(
       from,
       id,
@@ -203,7 +267,7 @@ defmodule Anoma.Node.Transaction.Ordering do
   end
 
   @spec block(GenServer.from(), binary(), (-> any()), String.t()) :: :ok
-  def block(from, tx_id, call, node_id) do
+  defp block(from, tx_id, call, node_id) do
     receive do
       %EventBroker.Event{
         body: %Node.Event{body: %__MODULE__.OrderEvent{tx_id: ^tx_id}}
@@ -220,13 +284,5 @@ defmodule Anoma.Node.Transaction.Ordering do
       this_module_filter(),
       tx_id_filter(tx_id)
     ])
-  end
-
-  def this_module_filter() do
-    %EventBroker.Filters.SourceModule{module: __MODULE__}
-  end
-
-  def tx_id_filter(tx_id) do
-    %__MODULE__.TxIdFilter{tx_id: tx_id}
   end
 end

--- a/apps/anoma_node/lib/node/transaction/storage.ex
+++ b/apps/anoma_node/lib/node/transaction/storage.ex
@@ -11,8 +11,13 @@ defmodule Anoma.Node.Transaction.Storage do
   use TypedStruct
   require Node.Event
 
+  ############################################################
+  #                         State                            #
+  ############################################################
+
   @type bare_key() :: list(String.t())
   @type qualified_key() :: {integer(), bare_key()}
+  @type write_opts() :: :append | :write | :add
   @typep startup_options() :: {:node_id, String.t()}
 
   typedstruct enforce: true do
@@ -20,7 +25,7 @@ defmodule Anoma.Node.Transaction.Storage do
     field(:uncommitted, %{qualified_key() => term()}, default: %{})
     # the most recent height written.
     # starts at 0 because nothing has been written.
-    field(:uncommitted_height, integer(), default: 0)
+    field(:uncommitted_height, non_neg_integer(), default: 0)
     # reverse-ordered list of heights at which a key was updated.
     field(:uncommitted_updates, %{bare_key() => list(integer())},
       default: %{}
@@ -28,7 +33,7 @@ defmodule Anoma.Node.Transaction.Storage do
   end
 
   typedstruct enforce: true, module: WriteEvent do
-    field(:height, integer())
+    field(:height, non_neg_integer())
     field(:writes, list({Anoma.Node.Transaction.Storage.bare_key(), term()}))
   end
 
@@ -36,6 +41,10 @@ defmodule Anoma.Node.Transaction.Storage do
     %EventBroker.Event{body: %Node.Event{body: %{height: ^height}}} -> true
     _ -> false
   end
+
+  ############################################################
+  #                    Genserver Helpers                     #
+  ############################################################
 
   @spec start_link() :: GenServer.on_start()
   @spec start_link(list(startup_options())) :: GenServer.on_start()
@@ -66,11 +75,134 @@ defmodule Anoma.Node.Transaction.Storage do
     {:ok, state}
   end
 
+  ############################################################
+  #                      Public RPC API                      #
+  ############################################################
+
+  @spec read(String.t(), {non_neg_integer(), any()}) :: :absent | any()
+  def read(node_id, {height, key}) do
+    GenServer.call(
+      Registry.via(node_id, __MODULE__),
+      {:read, {height, key}},
+      :infinity
+    )
+  end
+
+  @spec add(
+          String.t(),
+          {non_neg_integer(),
+           %{write: list({any(), any()}), append: list({any(), any()})}}
+        ) :: term()
+  def add(node_id, args = {_height, %{write: _writes, append: _appends}}) do
+    GenServer.call(
+      Registry.via(node_id, __MODULE__),
+      {:add, args},
+      :infinity
+    )
+  end
+
+  @spec write(String.t(), {non_neg_integer(), list({any(), any()})}) :: :ok
+  def write(node_id, {height, kvlist}) do
+    GenServer.call(
+      Registry.via(node_id, __MODULE__),
+      {:write, {height, kvlist}},
+      :infinity
+    )
+  end
+
+  @spec append(String.t(), {non_neg_integer(), list({any(), any()})}) :: :ok
+  def append(node_id, {height, kvlist}) do
+    GenServer.call(
+      Registry.via(node_id, __MODULE__),
+      {:append, {height, kvlist}},
+      :infinity
+    )
+  end
+
+  @spec commit(
+          String.t(),
+          non_neg_integer(),
+          list(Anoma.Node.Transaction.Mempool.Tx.t()) | nil
+        ) :: :ok
+  def commit(node_id, block_round, writes) do
+    GenServer.call(
+      Registry.via(node_id, __MODULE__),
+      {:commit, block_round, writes, self()}
+    )
+  end
+
   def terminate(_reason, state) do
     {:ok, state}
   end
 
+  ############################################################
+  #                      Public Filters                      #
+  ############################################################
+
+  def height_filter(height) do
+    %__MODULE__.HeightFilter{height: height}
+  end
+
+  ############################################################
+  #                       User Calling API                   #
+  ############################################################
+
+  def blocks_table(node_id) do
+    String.to_atom("#{__MODULE__.Blocks}_#{:erlang.phash2(node_id)}")
+  end
+
+  def values_table(node_id) do
+    String.to_atom("#{__MODULE__.Values}_#{:erlang.phash2(node_id)}")
+  end
+
+  def updates_table(node_id) do
+    String.to_atom("#{__MODULE__.Updates}_#{:erlang.phash2(node_id)}")
+  end
+
+  ############################################################
+  #                    Genserver Behavior                    #
+  ############################################################
+
   def handle_call({:commit, round, writes, _}, _from, state) do
+    handle_commit(round, writes, state)
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:read, {0, _key}}, _from, state) do
+    {:reply, :absent, state}
+  end
+
+  def handle_call({:read, {height, key}}, from, state) do
+    handle_read({height, key}, from, state)
+  end
+
+  def handle_call({write_opt, {height, args}}, from, state)
+      when write_opt in [:write, :append, :add] do
+    handle_write(write_opt, {height, args}, from, state)
+  end
+
+  def handle_call(_msg, _from, state) do
+    {:reply, :ok, state}
+  end
+
+  def handle_cast(_msg, state) do
+    {:noreply, state}
+  end
+
+  def handle_info(_info, state) do
+    {:noreply, state}
+  end
+
+  ############################################################
+  #                 Genserver Implementation                 #
+  ############################################################
+
+  @spec handle_commit(
+          non_neg_integer(),
+          list(Anoma.Node.Transaction.Mempool.Tx.t()),
+          t()
+        ) :: t()
+  defp handle_commit(round, writes, state = %__MODULE__{}) do
     mnesia_tx = fn ->
       for {key, value} <- state.uncommitted do
         :mnesia.write({values_table(state.node_id), key, value})
@@ -97,21 +229,17 @@ defmodule Anoma.Node.Transaction.Storage do
 
     :mnesia.transaction(mnesia_tx)
 
-    state = %{
+    %__MODULE__{
       state
       | uncommitted: %{},
         uncommitted_updates: %{},
         uncommitted_height: state.uncommitted_height
     }
-
-    {:reply, :ok, state}
   end
 
-  def handle_call({:read, {0, _key}}, _from, state) do
-    {:reply, :absent, state}
-  end
-
-  def handle_call({:read, {height, key}}, from, state) do
+  @spec handle_read({non_neg_integer(), any()}, GenServer.from(), t()) ::
+          {:noreply, t()} | {:reply, any(), t()}
+  defp handle_read({height, key}, from, state) do
     if height <= state.uncommitted_height do
       # relies on this being a reverse-ordered list
       result =
@@ -133,8 +261,13 @@ defmodule Anoma.Node.Transaction.Storage do
     end
   end
 
-  def handle_call({write_opt, {height, args}}, from, state)
-      when write_opt in [:write, :append, :add] do
+  @spec handle_write(
+          write_opts(),
+          {non_neg_integer(), any()},
+          GenServer.from(),
+          t()
+        ) :: {:noreply, t()} | {:reply, :ok, t()}
+  defp handle_write(write_opt, {height, args}, from, state) do
     unless height == state.uncommitted_height + 1 do
       node_id = state.node_id
 
@@ -162,123 +295,61 @@ defmodule Anoma.Node.Transaction.Storage do
     end
   end
 
-  def handle_call(_msg, _from, state) do
-    {:reply, :ok, state}
-  end
+  ############################################################
+  #                           Helpers                        #
+  ############################################################
 
-  def block_spawn(height, call, node_id) do
-    {:ok, pid} =
-      Task.start(call)
+  ############################################################
+  #                        Initialization                    #
+  ############################################################
 
-    EventBroker.subscribe(pid, [
-      Node.Event.node_filter(node_id),
-      this_module_filter(),
-      height_filter(height)
-    ])
-  end
+  @spec init_tables(atom(), bool()) :: any()
+  defp init_tables(node_id, rocks) do
+    rocks_opt = Anoma.Utility.rock_opts(rocks)
 
-  def handle_cast(_msg, state) do
-    {:noreply, state}
-  end
+    :mnesia.create_table(
+      values_table(node_id),
+      rocks_opt ++ [attributes: [:key, :value]]
+    )
 
-  def handle_info(_info, state) do
-    {:noreply, state}
-  end
+    :mnesia.create_table(
+      updates_table(node_id),
+      rocks_opt ++ [attributes: [:key, :value]]
+    )
 
-  @spec read(String.t(), {non_neg_integer(), any()}) :: :absent | any()
-  def read(node_id, {height, key}) do
-    GenServer.call(
-      Registry.via(node_id, __MODULE__),
-      {:read, {height, key}},
-      :infinity
+    :mnesia.create_table(
+      blocks_table(node_id),
+      rocks_opt ++ [attributes: [:round, :block]]
     )
   end
 
-  def add(node_id, args = {_height, %{write: _writes, append: _appends}}) do
-    GenServer.call(
-      Registry.via(node_id, __MODULE__),
-      {:add, args},
-      :infinity
-    )
+  ############################################################
+  #                      Private Filters                     #
+  ############################################################
+
+  defp this_module_filter() do
+    %EventBroker.Filters.SourceModule{module: __MODULE__}
   end
 
-  @spec write(String.t(), {non_neg_integer(), list(any())}) :: :ok
-  def write(node_id, {height, kvlist}) do
-    GenServer.call(
-      Registry.via(node_id, __MODULE__),
-      {:write, {height, kvlist}},
-      :infinity
-    )
-  end
-
-  @spec append(String.t(), {non_neg_integer(), list(any())}) :: :ok
-  def append(node_id, {height, kvlist}) do
-    GenServer.call(
-      Registry.via(node_id, __MODULE__),
-      {:append, {height, kvlist}},
-      :infinity
-    )
-  end
-
-  @spec commit(
-          String.t(),
-          non_neg_integer(),
-          list(Anoma.Node.Transaction.Mempool.Tx.t()) | nil
-        ) :: :ok
-  def commit(node_id, block_round, writes) do
-    GenServer.call(
-      Registry.via(node_id, __MODULE__),
-      {:commit, block_round, writes, self()}
-    )
-  end
-
-  @spec blocking_read(String.t(), non_neg_integer(), any(), GenServer.from()) ::
-          :ok
-  defp blocking_read(node_id, height, key, from) do
-    receive do
-      # if the key we care about was written at exactly the height we
-      # care about, then we already have the value for free
-      %EventBroker.Event{
-        body: %Node.Event{
-          body: %__MODULE__.WriteEvent{height: ^height, writes: writes}
-        }
-      } ->
-        case Enum.find(writes, fn {keywrite, _value} -> key == keywrite end) do
-          # try reading in history instead
-          nil ->
-            GenServer.reply(from, read(node_id, {height, key}))
-
-          # return value
-          {_key, value} ->
-            GenServer.reply(from, {:ok, value})
-        end
-
-      _ ->
-        IO.puts("this should be unreachable")
-    end
-
-    EventBroker.unsubscribe_me([
-      Node.Event.node_filter(node_id),
-      this_module_filter(),
-      height_filter(height)
-    ])
-  end
+  ############################################################
+  #                      ABWrite Helpers                     #
+  ############################################################
 
   # todo: should exclude same key being overwritten at same height
   @spec abwrite(
-          :append | :write | :add,
+          write_opts(),
           {non_neg_integer(), list(any()) | %{write: list(), append: list()}},
           t()
         ) ::
           {t(), list()}
-  def abwrite(:add, {height, %{write: writes, append: appends}}, state) do
+  defp abwrite(:add, {height, %{write: writes, append: appends}}, state) do
     {new_state, updates1} = abwrite(:write, {height, writes}, state)
     {final_state, updates2} = abwrite(:append, {height, appends}, new_state)
 
     {final_state, updates1 ++ updates2}
   end
 
-  def abwrite(flag, {height, kvlist}, state) do
+  defp abwrite(flag, {height, kvlist}, state) do
     for {key, value} <- kvlist,
         reduce: {%__MODULE__{state | uncommitted_height: height}, kvlist} do
       {state_acc, list} ->
@@ -350,7 +421,7 @@ defmodule Anoma.Node.Transaction.Storage do
 
   @spec read_in_past(non_neg_integer(), any(), t()) ::
           :absent | :error | {:ok, term()}
-  def read_in_past(height, key, state) do
+  defp read_in_past(height, key, state) do
     case Map.get(state.uncommitted_updates, key) do
       nil ->
         tx1 = fn -> :mnesia.read(updates_table(state.node_id), key) end
@@ -399,6 +470,21 @@ defmodule Anoma.Node.Transaction.Storage do
     end
   end
 
+  ############################################################
+  #                    Blocking Operations                   #
+  ############################################################
+
+  defp block_spawn(height, call, node_id) do
+    {:ok, pid} =
+      Task.start(call)
+
+    EventBroker.subscribe(pid, [
+      Node.Event.node_filter(node_id),
+      this_module_filter(),
+      height_filter(height)
+    ])
+  end
+
   def blocking_write(node_id, height, kvlist, from) do
     awaited_height = height - 1
 
@@ -418,43 +504,35 @@ defmodule Anoma.Node.Transaction.Storage do
     ])
   end
 
-  defp this_module_filter() do
-    %EventBroker.Filters.SourceModule{module: __MODULE__}
-  end
+  @spec blocking_read(String.t(), non_neg_integer(), any(), GenServer.from()) ::
+          :ok
+  defp blocking_read(node_id, height, key, from) do
+    receive do
+      # if the key we care about was written at exactly the height we
+      # care about, then we already have the value for free
+      %EventBroker.Event{
+        body: %Node.Event{
+          body: %__MODULE__.WriteEvent{height: ^height, writes: writes}
+        }
+      } ->
+        case Enum.find(writes, fn {keywrite, _value} -> key == keywrite end) do
+          # try reading in history instead
+          nil ->
+            GenServer.reply(from, read(node_id, {height, key}))
 
-  defp height_filter(height) do
-    %__MODULE__.HeightFilter{height: height}
-  end
+          # return value
+          {_key, value} ->
+            GenServer.reply(from, {:ok, value})
+        end
 
-  @spec init_tables(atom(), bool()) :: any()
-  def init_tables(node_id, rocks) do
-    rocks_opt = Anoma.Utility.rock_opts(rocks)
+      _ ->
+        IO.puts("this should be unreachable")
+    end
 
-    :mnesia.create_table(
-      values_table(node_id),
-      rocks_opt ++ [attributes: [:key, :value]]
-    )
-
-    :mnesia.create_table(
-      updates_table(node_id),
-      rocks_opt ++ [attributes: [:key, :value]]
-    )
-
-    :mnesia.create_table(
-      blocks_table(node_id),
-      rocks_opt ++ [attributes: [:round, :block]]
-    )
-  end
-
-  def blocks_table(node_id) do
-    String.to_atom("#{__MODULE__.Blocks}_#{:erlang.phash2(node_id)}")
-  end
-
-  def values_table(node_id) do
-    String.to_atom("#{__MODULE__.Values}_#{:erlang.phash2(node_id)}")
-  end
-
-  def updates_table(node_id) do
-    String.to_atom("#{__MODULE__.Updates}_#{:erlang.phash2(node_id)}")
+    EventBroker.unsubscribe_me([
+      Node.Event.node_filter(node_id),
+      this_module_filter(),
+      height_filter(height)
+    ])
   end
 end

--- a/apps/event_broker/lib/event_broker/with_subscription.ex
+++ b/apps/event_broker/lib/event_broker/with_subscription.ex
@@ -1,0 +1,30 @@
+defmodule EventBroker.WithSubscription do
+  @moduledoc """
+  I contain the with_subscription macro. Require me or use me to use with_subscription.
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      import EventBroker.WithSubscription
+    end
+  end
+
+  defmacro with_subscription(filter_spec_lists \\ [], do: logic) do
+    Task.async(fn ->
+      quote do
+        for filter <- unquote(filter_spec_lists) do
+          EventBroker.subscribe_me(filter)
+        end
+
+        res = unquote(logic)
+
+        for filter <- unquote(filter_spec_lists) do
+          EventBroker.unsubscribe_me(filter)
+        end
+
+        res
+      end
+    end)
+    |> Task.await()
+  end
+end


### PR DESCRIPTION
Make a macro spawning a new worker and asynchronously subscribing to
specified filters, executing the logic, unsubscribing, and then
removing the result.

Changes Logging examples to use the macro.