### PR TITLE
Fix copy-paste error in Nock example comment

### DIFF
--- a/apps/anoma_lib/lib/examples/enock.ex
+++ b/apps/anoma_lib/lib/examples/enock.ex
@@ -925,7 +925,7 @@ defmodule Examples.ENock do
   end
 
   @doc """
-  I represent the sum gate call as a 2-argument gate.
+  I represent the cmp gate call as a 2-argument gate.
 
   Can be obtained by defining
 


### PR DESCRIPTION
A trivial fix for what appears to be a copy/paste error in a header comment to a Nock example.