### PR TITLE
Replace transaction examples' dirty reads with transactional reads

### DIFF
--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -272,6 +272,11 @@ defmodule Anoma.Node.Examples.ETransaction do
 
     :mnesia.unsubscribe({:table, Storage.blocks_table(node_id), :simple})
 
+    {:atomic, block} =
+      :mnesia.transaction(fn ->
+        :mnesia.read({Storage.blocks_table(node_id), 0})
+      end)
+
     [
       {^blocks_table, 0,
        [
@@ -282,7 +287,7 @@ defmodule Anoma.Node.Examples.ETransaction do
            tx_result: {:ok, [[^key | 0]]}
          }
        ]}
-    ] = :mnesia.dirty_read({Storage.blocks_table(node_id), 0})
+    ] = block
   end
 
   def inc_counter_submit_with_zero(node_id \\ Node.example_random_id()) do
@@ -305,6 +310,9 @@ defmodule Anoma.Node.Examples.ETransaction do
 
     :mnesia.unsubscribe({:table, blocks_table, :simple})
 
+    {:atomic, block} =
+      :mnesia.transaction(fn -> :mnesia.read({blocks_table, 0}) end)
+
     [
       {^blocks_table, 0,
        [
@@ -321,7 +329,7 @@ defmodule Anoma.Node.Examples.ETransaction do
            tx_result: {:ok, [[^key | 1]]}
          }
        ]}
-    ] = :mnesia.dirty_read({blocks_table, 0})
+    ] = block
   end
 
   def inc_counter_submit_after_zero(node_id \\ Node.example_random_id()) do
@@ -340,6 +348,9 @@ defmodule Anoma.Node.Examples.ETransaction do
 
     :mnesia.unsubscribe({:table, blocks_table, :simple})
 
+    {:atomic, block} =
+      :mnesia.transaction(fn -> :mnesia.read({blocks_table, 1}) end)
+
     [
       {^blocks_table, 1,
        [
@@ -350,7 +361,7 @@ defmodule Anoma.Node.Examples.ETransaction do
            tx_result: {:ok, [[^key | 1]]}
          }
        ]}
-    ] = :mnesia.dirty_read({blocks_table, 1})
+    ] = block
   end
 
   def inc_counter_submit_after_read(node_id \\ Node.example_random_id()) do
@@ -372,6 +383,9 @@ defmodule Anoma.Node.Examples.ETransaction do
 
     :mnesia.unsubscribe({:table, blocks_table, :simple})
 
+    {:atomic, block} =
+      :mnesia.transaction(fn -> :mnesia.read({blocks_table, 1}) end)
+
     [
       {^blocks_table, 1,
        [
@@ -388,7 +402,7 @@ defmodule Anoma.Node.Examples.ETransaction do
            tx_result: {:ok, [[^key | 1]]}
          }
        ]}
-    ] = :mnesia.dirty_read({blocks_table, 1})
+    ] = block
   end
 
   def bluf() do

--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -411,6 +411,9 @@ defmodule Anoma.Node.Examples.ETransaction do
 
     :mnesia.unsubscribe({:table, blocks_table, :simple})
 
+    {:atomic, block} =
+      :mnesia.transaction(fn -> :mnesia.read({blocks_table, 0}) end)
+
     [
       {^blocks_table, 0,
        [
@@ -421,7 +424,7 @@ defmodule Anoma.Node.Examples.ETransaction do
            tx_result: :error
          }
        ]}
-    ] = :mnesia.dirty_read({blocks_table, 0})
+    ] = block
   end
 
   def read_txs_write_nothing(node_id \\ Node.example_random_id()) do


### PR DESCRIPTION
@agureev worked out that the cause of #1534 was probably that the transaction example was doing a dirty read rather than a transactional read.  He provided 58312434bebbd6de01525969bab5d848781b6516 to illustrate how to replace the dirty read with a transactional read.

Several other examples have the same problem, but his system doesn't reproduce it so he asked me to try fixing the others and testing the fixes.

In this PR I try to apply the same style of change to all the `dirty_read` calls in the transaction examples.  So far my tests have passed a couple hundred iterations without failures, which is more than they ever did before the changes.  I'll continue letting them run for a while, but I think they're probably worth a review by now.