### PR TITLE
Read Only Backend

### DIFF
--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -1,6 +1,6 @@
 defmodule Anoma.Node.Examples.ETransaction do
   alias Anoma.Node
-  alias Node.Transaction.{Storage, Ordering, Mempool}
+  alias Node.Transaction.{Storage, Ordering, Mempool, Executor}
   alias Anoma.TransparentResource.Transaction
 
   alias Examples.{ENock, ETransparent.ETransaction}
@@ -434,44 +434,7 @@ defmodule Anoma.Node.Examples.ETransaction do
     ] = :mnesia.dirty_read({blocks_table, 1})
   end
 
-  def inc_counter_submit_after_read(node_id \\ Node.example_random_id()) do
-    blocks_table = Storage.blocks_table(node_id)
-
-    key = "key"
-    zero_counter_submit(node_id)
-    {:debug_term_storage, zero} = zero(key)
-    {back, inc} = inc(key)
-    Mempool.tx(node_id, {{:debug_read_term, self()}, zero}, "id 2")
-    Mempool.tx(node_id, inc(key), "id 3")
-    :mnesia.subscribe({:table, blocks_table, :simple})
-    Mempool.execute(node_id, ["id 2", "id 3"])
-
-    assert_receive(
-      {:mnesia_table_event, {:write, {^blocks_table, 1, _}, _}},
-      5000
-    )
-
-    :mnesia.unsubscribe({:table, blocks_table, :simple})
-
-    [
-      {^blocks_table, 1,
-       [
-         %Mempool.Tx{
-           code: ^zero,
-           backend: {:debug_read_term, _},
-           vm_result: {:ok, [[^key | 0] | 0]},
-           tx_result: {:ok, {:read_value, [[^key | 0] | 0]}}
-         },
-         %Mempool.Tx{
-           code: ^inc,
-           backend: ^back,
-           vm_result: {:ok, [[^key | 1] | 0]},
-           tx_result: {:ok, [[^key | 1]]}
-         }
-       ]}
-    ] = :mnesia.dirty_read({blocks_table, 1})
-  end
-
+  @spec bluf() :: Noun.t()
   def bluf() do
     [0 | 0]
   end
@@ -506,24 +469,57 @@ defmodule Anoma.Node.Examples.ETransaction do
   end
 
   def read_txs_write_nothing(node_id \\ Node.example_random_id()) do
-    blocks_table = Storage.blocks_table(node_id)
     key = "key"
     start_tx_module(node_id)
     {_backend, code} = zero(key)
 
-    Mempool.tx(node_id, {{:debug_read_term, self()}, code}, "id 1")
+    Executor.launch(node_id, {{:read_only, self()}, code}, node_id)
+
+    assert_receive({0, [[^key | 0] | 0]}, 5000)
+
+    [] = :mnesia.dirty_all_keys(Storage.values_table(node_id))
+    [] = :mnesia.dirty_all_keys(Storage.updates_table(node_id))
+    node_id
+  end
+
+  @spec inc_counter_submit_after_bluff(String.t()) :: String.t()
+  def inc_counter_submit_after_bluff(node_id \\ Node.example_random_id()) do
+    blocks_table = Storage.blocks_table(node_id)
+    key = "key"
+
+    zero_counter_submit(node_id)
+    {back, inc} = inc(key)
+    Mempool.tx(node_id, {:debug_term_storage, bluf()}, "id 2")
+    Mempool.tx(node_id, inc(key), "id 3")
     :mnesia.subscribe({:table, blocks_table, :simple})
-    Mempool.execute(node_id, ["id 1"])
+    Mempool.execute(node_id, ["id 2", "id 3"])
 
     assert_receive(
-      {:mnesia_table_event, {:write, {^blocks_table, 0, _}, _}},
+      {:mnesia_table_event, {:write, {^blocks_table, 1, _}, _}},
       5000
     )
 
     :mnesia.unsubscribe({:table, blocks_table, :simple})
 
-    [] = :mnesia.dirty_all_keys(Storage.values_table(node_id))
-    [] = :mnesia.dirty_all_keys(Storage.updates_table(node_id))
+    [
+      {^blocks_table, 1,
+       [
+         %Mempool.Tx{
+           code: [0 | 0],
+           backend: :debug_term_storage,
+           vm_result: :vm_error,
+           tx_result: :error
+         },
+         %Mempool.Tx{
+           code: ^inc,
+           backend: ^back,
+           vm_result: {:ok, [[^key | 1] | 0]},
+           tx_result: {:ok, [[^key | 1]]}
+         }
+       ]}
+    ] = :mnesia.dirty_read({blocks_table, 1})
+
+    node_id
   end
 
   def bluff_txs_write_nothing(node_id \\ Node.example_random_id()) do

--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -482,6 +482,38 @@ defmodule Anoma.Node.Examples.ETransaction do
     node_id
   end
 
+  @spec read_txs_actually_read(String.t()) :: String.t()
+  def read_txs_actually_read(node_id \\ Node.example_random_id()) do
+    read_txs_write_nothing(node_id)
+    key = "key"
+
+    {_backend, code} = inc(key)
+
+    zero_counter_submit(node_id)
+
+    Executor.launch(node_id, {{:read_only, self()}, code}, node_id)
+
+    assert_receive({1, [[^key | 1] | 0]}, 5000)
+
+    node_id
+  end
+
+  @spec read_txs_read_recent(String.t()) :: String.t()
+  def read_txs_read_recent(node_id \\ Node.example_random_id()) do
+    read_txs_write_nothing(node_id)
+    key = "key"
+
+    {_backend, code} = inc(key)
+
+    inc_counter_submit_with_zero(node_id)
+
+    Executor.launch(node_id, {{:read_only, self()}, code}, node_id)
+
+    assert_receive({2, [[^key | 2] | 0]}, 5000)
+
+    node_id
+  end
+
   @spec inc_counter_submit_after_bluff(String.t()) :: String.t()
   def inc_counter_submit_after_bluff(node_id \\ Node.example_random_id()) do
     blocks_table = Storage.blocks_table(node_id)

--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -28,7 +28,7 @@ defmodule Anoma.Node.Transaction.Backends do
 
   @type backend() ::
           :debug_term_storage
-          | {:debug_read_term, pid}
+          | {:read_only, pid}
           | :debug_bloblike
           | :transparent_resource
 
@@ -101,7 +101,7 @@ defmodule Anoma.Node.Transaction.Backends do
 
   First, I execute the transaction code on the Anoma VM. Next, I apply processing
   logic to the resulting value, dependent on the selected backend.
-  - For read-only backend, the value is transmitted as a Result Event.
+  - For read-only backend, the value is sent directly to specified recepient.
   - For the key-value and blob store executions, the obtained value is stored
   and a Complete Event is issued.
   - For the transparent Resource Machine (RM) execution, I verify the
@@ -114,13 +114,22 @@ defmodule Anoma.Node.Transaction.Backends do
              node_id: String.t(),
              back: backend()
   def execute(node_id, {backend, tx_code}, id) do
-    env = %Nock{scry_function: fn a -> Ordering.read(node_id, a) end}
+    time = Storage.current_time(node_id)
+
+    scry =
+      case backend do
+        {:read_only, _pid} -> &Storage.read(node_id, {time, elem(&1, 1)})
+        _ -> &Ordering.read(node_id, &1)
+      end
+
+    env = %Nock{scry_function: scry}
     vm_result = vm_execute(tx_code, env, id)
     result_event(id, vm_result, node_id, backend)
 
     res =
       with {:ok, vm_res} <- vm_result,
-           {:ok, backend_res} <- backend_logic(backend, node_id, id, vm_res) do
+           {:ok, backend_res} <-
+             backend_logic(backend, node_id, id, vm_res, time: time) do
         {:ok, backend_res}
       else
         _e ->
@@ -162,21 +171,21 @@ defmodule Anoma.Node.Transaction.Backends do
   #                     Backend Execution                    #
   ############################################################
 
-  @spec backend_logic(backend(), String.t(), binary(), Noun.t()) ::
+  @spec backend_logic(backend(), String.t(), binary(), Noun.t(), list()) ::
           :error | {:ok, any()}
-  defp backend_logic(:debug_term_storage, node_id, id, vm_res) do
+  defp backend_logic(:debug_term_storage, node_id, id, vm_res, _opts) do
     store_value(node_id, id, vm_res)
   end
 
-  defp backend_logic({:debug_read_term, pid}, node_id, id, vm_res) do
-    send_value(node_id, id, vm_res, pid)
+  defp backend_logic({:read_only, pid}, _node_id, _id, vm_res, opts) do
+    send_value(vm_res, pid, opts)
   end
 
-  defp backend_logic(:debug_bloblike, node_id, id, vm_res) do
+  defp backend_logic(:debug_bloblike, node_id, id, vm_res, _opts) do
     blob_store(node_id, id, vm_res)
   end
 
-  defp backend_logic(:transparent_resource, node_id, id, vm_res) do
+  defp backend_logic(:transparent_resource, node_id, id, vm_res, _opts) do
     transparent_resource_tx(node_id, id, vm_res)
   end
 
@@ -358,14 +367,11 @@ defmodule Anoma.Node.Transaction.Backends do
     nock_boolean in [0, <<>>, <<0>>, []]
   end
 
-  @spec send_value(String.t(), binary(), Noun.t(), pid()) ::
-          {:ok, any()} | :error
-  defp send_value(node_id, id, result, reply_to) do
-    # send the value to reply-to address and the topic
-    reply_msg = {:read_value, result}
-    send(reply_to, reply_msg)
-    Ordering.write(node_id, {id, []})
-    {:ok, reply_msg}
+  @spec send_value(Noun.t(), pid(), list()) ::
+          {:ok, any()}
+  defp send_value(result, reply_to, opts) do
+    send(reply_to, {opts[:time], result})
+    {:ok, result}
   end
 
   @spec blob_store(String.t(), binary(), Noun.t()) :: {:ok, any} | :error
@@ -395,6 +401,10 @@ defmodule Anoma.Node.Transaction.Backends do
   end
 
   @spec empty_write(backend(), String.t(), binary()) :: :ok
+  defp empty_write({:read_only, _}, _node_id, _id) do
+    :ok
+  end
+
   defp empty_write(_backend, node_id, id) do
     Ordering.write(node_id, {id, []})
   end
@@ -441,6 +451,10 @@ defmodule Anoma.Node.Transaction.Backends do
   end
 
   @spec event(backend(), EventBroker.Event.t()) :: :ok
+  defp event({:read_only, _}, _event) do
+    :ok
+  end
+
   defp event(_backend, event) do
     EventBroker.event(event)
   end

--- a/apps/anoma_node/lib/node/transaction/ordering.ex
+++ b/apps/anoma_node/lib/node/transaction/ordering.ex
@@ -52,7 +52,9 @@ defmodule Anoma.Node.Transaction.Ordering do
     Process.set_label(__MODULE__)
 
     args = Keyword.validate!(args, [:node_id, next_height: 1])
+
     state = struct(Ordering, Enum.into(args, %{}))
+
     {:ok, state}
   end
 

--- a/apps/anoma_node/lib/node/transaction/storage.ex
+++ b/apps/anoma_node/lib/node/transaction/storage.ex
@@ -323,6 +323,24 @@ defmodule Anoma.Node.Transaction.Storage do
     {:ok, state}
   end
 
+  @doc """
+  I am the Storage function for getting current time.
+
+  My main use is to coordinate latest-time reads from the user's side and
+  particularly to aid read-only transactions. Note that evidently there is
+  a possibility of clock desynchronization after the call. Hence it should
+  only be used for approximate-time getting such as require for RO
+  transactions.
+  """
+
+  @spec current_time(String.t()) :: non_neg_integer()
+  def current_time(node_id) do
+    GenServer.call(
+      Registry.via(node_id, __MODULE__),
+      :current_time
+    )
+  end
+
   ############################################################
   #                      Public Filters                      #
   ############################################################
@@ -390,6 +408,10 @@ defmodule Anoma.Node.Transaction.Storage do
 
   def handle_call({:read, {height, key}}, from, state) do
     handle_read({height, key}, from, state)
+  end
+
+  def handle_call(:current_time, _from, state) do
+    {:reply, state.uncommitted_height, state}
   end
 
   def handle_call({write_opt, {height, args}}, from, state)


### PR DESCRIPTION
Replace a debug read backend with a proper read only transaction
backend with following semantics:

1) RO Txs get launched directly through the executor
2) RO Txs only read and never write anything.
3) RO Txs get executed in the VM same any other transaction candidate.
4) RO Txs send the result of vm execution directly to the specified sender.
5) RO Txs read at most recent height
6) RO Txs other than the message specified in (4) do not send any
other messages