### PR TITLE
#1568 - Extend IntentPool to track and filter intents with known nullifiers

### DIFF
--- a/apps/anoma_lib/lib/anoma/rm/intent.ex
+++ b/apps/anoma_lib/lib/anoma/rm/intent.ex
@@ -8,6 +8,9 @@ defprotocol Anoma.RM.Intent do
 
   @spec verify(t()) :: true | {:error, any()}
   def verify(intent)
+
+  @spec nullifiers(t()) :: MapSet.t()
+  def nullifiers(intent)
 end
 
 defimpl Anoma.RM.Intent, for: Anoma.RM.DumbIntent do
@@ -21,5 +24,10 @@ defimpl Anoma.RM.Intent, for: Anoma.RM.DumbIntent do
   @impl true
   def verify(%DumbIntent{} = intent) do
     intent.value == 0
+  end
+
+  @impl true
+  def nullifiers(%DumbIntent{}) do
+    MapSet.new([])
   end
 end

--- a/apps/anoma_lib/lib/anoma/transparent_resource/transaction.ex
+++ b/apps/anoma_lib/lib/anoma/transparent_resource/transaction.ex
@@ -238,4 +238,9 @@ defimpl Anoma.RM.Intent, for: Anoma.TransparentResource.Transaction do
   def verify(tx = %Transaction{}) do
     Transaction.verify(tx)
   end
+
+  @impl true
+  def nullifiers(tx = %Transaction{}) do
+    Transaction.nullifiers(tx)
+  end
 end

--- a/apps/anoma_node/lib/examples/eintent_pool.ex
+++ b/apps/anoma_node/lib/examples/eintent_pool.ex
@@ -8,7 +8,11 @@ defmodule Anoma.Node.Examples.EIntentPool do
 
   alias Anoma.Node.Intents.IntentPool
   alias Anoma.RM.DumbIntent
+  alias Anoma.RM.Intent
   alias Anoma.Node.Examples.ENode
+  alias Anoma.Node
+
+  require Node.Event
 
   ############################################################
   #                           Scenarios                      #
@@ -89,6 +93,49 @@ defmodule Anoma.Node.Examples.EIntentPool do
     )
 
     assert enode.node_id |> IntentPool.intents() |> Enum.empty?()
+
+    enode
+  end
+
+  @doc """
+  I check that adding an intent with nullifiers already known in the nlfs_set
+  does not add the intent to the pool.
+  """
+  @spec add_intent_with_known_nullifiers(ENode.t()) :: ENode.t()
+  def add_intent_with_known_nullifiers(enode \\ ENode.start_node()) do
+    intent = Examples.ETransparent.ETransaction.nullify_intent_eph()
+    nlfs_set = Intent.nullifiers(intent)
+
+    new_nullifiers_event(enode, nlfs_set)
+
+    node_id = enode.node_id
+    IntentPool.new_intent(node_id, intent)
+
+    # the intent will not be present in the mapset
+    assert IntentPool.intents(node_id) == MapSet.new([])
+
+    enode
+  end
+
+  @doc """
+  I submit a nullifier event to the node.
+  """
+  @spec new_nullifiers_event(ENode.t(), MapSet.t()) :: ENode.t()
+  def new_nullifiers_event(
+        enode \\ ENode.start_node(),
+        nlfs_set \\ MapSet.new()
+      ) do
+    node_id = enode.node_id
+
+    event =
+      Node.Event.new_with_body(
+        node_id,
+        %Anoma.Node.Transaction.Backends.NullifierEvent{
+          nullifiers: nlfs_set
+        }
+      )
+
+    EventBroker.event(event)
 
     enode
   end

--- a/apps/anoma_node/test/intent_pool_test.exs
+++ b/apps/anoma_node/test/intent_pool_test.exs
@@ -7,5 +7,17 @@ defmodule IntentPoolTest do
     EIntentPool.list_intents(ENode.start_node(node_id: "IP_test1"))
     EIntentPool.add_intent(ENode.start_node(node_id: "IP_test2"))
     EIntentPool.remove_intent(ENode.start_node(node_id: "IP_test3"))
+
+    EIntentPool.add_intent_transaction_nullifier(
+      ENode.start_node(node_id: "IP_test3")
+    )
+
+    EIntentPool.remove_intents_with_nulllified_resources(
+      ENode.start_node(node_id: "IP_test3")
+    )
+
+    EIntentPool.add_intent_with_known_nullifiers(
+      ENode.start_node(node_id: "IP_test3")
+    )
   end
 end


### PR DESCRIPTION
This PR enhances the Anoma.Node.Intents.IntentPool module by introducing nullifier tracking to improve intent validation. The IntentPool now maintains a set of known nullifiers and filters out any new intents that contain an already known nullifier.

It's partially solving https://github.com/anoma/anoma/issues/1568.

This PR is based on `artem+mariari/examples-intent-handle-nulfs` therefore, I'm setting it as the target branch.