### PR TITLE
Node Tests Use Examples Macro

### DIFF
--- a/apps/anoma_node/test/intent_pool_test.exs
+++ b/apps/anoma_node/test/intent_pool_test.exs
@@ -1,11 +1,4 @@
 defmodule IntentPoolTest do
   use ExUnit.Case, async: false
-
-  alias Anoma.Node.Examples.{EIntentPool, ENode}
-
-  test "intentpool examples" do
-    EIntentPool.list_intents(ENode.start_node(node_id: "IP_test1"))
-    EIntentPool.add_intent(ENode.start_node(node_id: "IP_test2"))
-    EIntentPool.remove_intent(ENode.start_node(node_id: "IP_test3"))
-  end
+  use TestHelper.GenerateExampleTests, for: Anoma.Node.Examples.EIntentPool
 end

--- a/apps/anoma_node/test/solver_test.exs
+++ b/apps/anoma_node/test/solver_test.exs
@@ -3,12 +3,4 @@ defmodule SolverTest do
 
   use TestHelper.GenerateExampleTests,
     for: Anoma.Node.Examples.ESolver
-
-  alias Anoma.Node.Examples.{ESolver, ENode}
-
-  test "intentpool examples" do
-    ESolver.solvable_transaction_via_intent_pool(
-      ENode.start_node(node_id: "S_test3")
-    )
-  end
 end


### PR DESCRIPTION
Previously Intent Pool and Solver tests did not use Examples macro generating tests automatically.

This gets rid of tests written by hand.