### PR TITLE
Use Existing Functions to Get Commitments and Nullifiers in TRM

### DIFF
--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -141,15 +141,10 @@ defmodule Anoma.Node.Transaction.Backends do
 
     with {:ok, tx} <- TransparentResource.Transaction.from_noun(result),
          true <- TransparentResource.Transaction.verify(tx, verify_options) do
-      map =
-        for action <- tx.actions,
-            reduce: %{commitments: MapSet.new(), nullifiers: MapSet.new()} do
-          %{commitments: cms, nullifiers: nlfs} ->
-            %{
-              commitments: MapSet.union(cms, action.commitments),
-              nullifiers: MapSet.union(nlfs, action.nullifiers)
-            }
-        end
+      map = %{
+        commitments: TTransaction.commitments(tx),
+        nullifiers: TTransaction.nullifiers(tx)
+      }
 
       ct =
         case Ordering.read(node_id, {id, :ct}) do


### PR DESCRIPTION
TRM processing gathered commitments and nullifiers manually, instead, we should use already abstracted functionality.