### PR TITLE
Add TRM Event

### DIFF
--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -1,6 +1,6 @@
 defmodule Anoma.Node.Examples.ETransaction do
   alias Anoma.Node
-  alias Node.Transaction.{Storage, Ordering, Mempool}
+  alias Node.Transaction.{Storage, Ordering, Mempool, Backends}
   alias Anoma.TransparentResource.Transaction
 
   alias Examples.{ENock, ETransparent.ETransaction}
@@ -291,14 +291,11 @@ defmodule Anoma.Node.Examples.ETransaction do
     assert {:ok, base_swap |> Transaction.nullifiers()} ==
              Storage.read(node_id, {1, :nullifiers})
 
-    assert {:ok, base_swap |> Transaction.commitments()} ==
-             Storage.read(node_id, {1, :commitments})
+    cms = base_swap |> Transaction.commitments()
 
-    {tree, anchor} =
-      Examples.ECommitmentTree.memory_backed_ct_with_trivial_swap()
+    assert {:ok, cms} == Storage.read(node_id, {1, :commitments})
 
-    assert {:ok, tree} == Storage.read(node_id, {1, :ct})
-    assert {:ok, anchor} == Storage.read(node_id, {1, :anchor})
+    assert {:ok, Backends.value(cms)} == Storage.read(node_id, {1, :anchor})
 
     EventBroker.unsubscribe_me([])
 

--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -81,49 +81,49 @@ defmodule Anoma.Node.Examples.ETransaction do
   def append_then_read(node_id \\ Node.example_random_id()) do
     start_storage(node_id)
     new_set = MapSet.new(["value"])
-    Storage.append(node_id, {1, [{:set, new_set}]})
-    {:ok, ^new_set} = Storage.read(node_id, {1, :set})
+    Storage.append(node_id, {1, [{["set"], new_set}]})
+    {:ok, ^new_set} = Storage.read(node_id, {1, ["set"]})
   end
 
   def append_then_read_same(node_id \\ Node.example_random_id()) do
     start_storage(node_id)
     new_set = MapSet.new(["value"])
-    Storage.append(node_id, {1, [{:set, new_set}, {:set, new_set}]})
-    {:ok, ^new_set} = Storage.read(node_id, {1, :set})
+    Storage.append(node_id, {1, [{["set"], new_set}, {["set"], new_set}]})
+    {:ok, ^new_set} = Storage.read(node_id, {1, ["set"]})
   end
 
   def append_then_read_several(node_id \\ Node.example_random_id()) do
     start_storage(node_id)
     set1 = MapSet.new(["value1"])
     set2 = MapSet.new(["value2"])
-    Storage.append(node_id, {1, [{:set, set1}, {:set, set2}]})
+    Storage.append(node_id, {1, [{["set"], set1}, {["set"], set2}]})
     new_set = MapSet.new(["value1", "value2"])
-    {:ok, ^new_set} = Storage.read(node_id, {1, :set})
+    {:ok, ^new_set} = Storage.read(node_id, {1, ["set"]})
   end
 
   def append_twice_then_read(node_id \\ Node.example_random_id()) do
     start_storage(node_id)
     set1 = MapSet.new(["value1"])
-    Storage.append(node_id, {1, [{:set, set1}]})
-    {:ok, ^set1} = Storage.read(node_id, {1, :set})
+    Storage.append(node_id, {1, [{["set"], set1}]})
+    {:ok, ^set1} = Storage.read(node_id, {1, ["set"]})
     set2 = MapSet.new(["value2"])
-    Storage.append(node_id, {2, [{:set, set2}]})
+    Storage.append(node_id, {2, [{["set"], set2}]})
     appended_set = MapSet.new(["value1", "value2"])
-    {:ok, ^appended_set} = Storage.read(node_id, {2, :set})
+    {:ok, ^appended_set} = Storage.read(node_id, {2, ["set"]})
   end
 
   def append_twice_then_read_with_commit(node_id \\ Node.example_random_id()) do
     start_storage(node_id)
     set1 = MapSet.new(["value1"])
-    Storage.append(node_id, {1, [{:set, set1}]})
-    {:ok, ^set1} = Storage.read(node_id, {1, :set})
+    Storage.append(node_id, {1, [{["set"], set1}]})
+    {:ok, ^set1} = Storage.read(node_id, {1, ["set"]})
 
     Storage.commit(node_id, 1, nil)
 
     set2 = MapSet.new(["value2"])
-    Storage.append(node_id, {2, [{:set, set2}]})
+    Storage.append(node_id, {2, [{["set"], set2}]})
     appended_set = MapSet.new(["value1", "value2"])
-    {:ok, ^appended_set} = Storage.read(node_id, {2, :set})
+    {:ok, ^appended_set} = Storage.read(node_id, {2, ["set"]})
   end
 
   def add_rewrites(node_id \\ Node.example_random_id()) do
@@ -132,11 +132,11 @@ defmodule Anoma.Node.Examples.ETransaction do
 
     Storage.add(
       node_id,
-      {2, %{write: [{["abc"], 234}], append: [{:set, new_set}]}}
+      {2, %{write: [{["abc"], 234}], append: [{["set"], new_set}]}}
     )
 
     {:ok, 234} = Storage.read(node_id, {2, ["abc"]})
-    {:ok, ^new_set} = Storage.read(node_id, {2, :set})
+    {:ok, ^new_set} = Storage.read(node_id, {2, ["set"]})
   end
 
   def add_append(node_id \\ Node.example_random_id()) do
@@ -145,12 +145,12 @@ defmodule Anoma.Node.Examples.ETransaction do
 
     Storage.add(
       node_id,
-      {2, %{write: [{["abc"], 234}], append: [{:set, new_value_set}]}}
+      {2, %{write: [{["abc"], 234}], append: [{["set"], new_value_set}]}}
     )
 
     {:ok, 234} = Storage.read(node_id, {2, ["abc"]})
     new_set = MapSet.new(["new_value", "value"])
-    {:ok, ^new_set} = Storage.read(node_id, {2, :set})
+    {:ok, ^new_set} = Storage.read(node_id, {2, ["set"]})
   end
 
   def complicated_storage(node_id \\ Node.example_random_id()) do
@@ -289,13 +289,17 @@ defmodule Anoma.Node.Examples.ETransaction do
     base_swap = ETransaction.swap_from_actions()
 
     assert {:ok, base_swap |> Transaction.nullifiers()} ==
-             Storage.read(node_id, {1, :nullifiers})
+             Storage.read(node_id, {1, ["anoma", "nullifiers"]})
+
+    assert {:ok, base_swap |> Transaction.commitments()} ==
+             Storage.read(node_id, {1, ["anoma", "commitments"]})
 
     cms = base_swap |> Transaction.commitments()
 
-    assert {:ok, cms} == Storage.read(node_id, {1, :commitments})
+    assert {:ok, cms} == Storage.read(node_id, {1, ["anoma", "commitments"]})
 
-    assert {:ok, Backends.value(cms)} == Storage.read(node_id, {1, :anchor})
+    assert {:ok, Backends.value(cms)} ==
+             Storage.read(node_id, {1, ["anoma", "anchor"]})
 
     EventBroker.unsubscribe_me([])
 

--- a/apps/anoma_node/lib/node/intents/intent_pool.ex
+++ b/apps/anoma_node/lib/node/intents/intent_pool.ex
@@ -53,7 +53,7 @@ defmodule Anoma.Node.Intents.IntentPool do
 
     EventBroker.subscribe_me([
       Node.Event.node_filter(node_id),
-      nullifier_filter()
+      trm_filter()
     ])
 
     {:ok, %IntentPool{node_id: args[:node_id]}}
@@ -116,7 +116,7 @@ defmodule Anoma.Node.Intents.IntentPool do
   @impl true
   def handle_info(
         %EventBroker.Event{
-          body: %Node.Event{body: %Backends.NullifierEvent{nullifiers: set}}
+          body: %Node.Event{body: %Backends.TRMEvent{nullifiers: set}}
         },
         state
       ) do
@@ -204,9 +204,9 @@ defmodule Anoma.Node.Intents.IntentPool do
   #                         Helpers                          #
   ############################################################
 
-  deffilter NullifierFilter do
+  deffilter TRMFilter do
     %EventBroker.Event{
-      body: %Anoma.Node.Event{body: %Backends.NullifierEvent{}}
+      body: %Anoma.Node.Event{body: %Backends.TRMEvent{}}
     } ->
       true
 
@@ -214,7 +214,7 @@ defmodule Anoma.Node.Intents.IntentPool do
       false
   end
 
-  defp nullifier_filter() do
-    %__MODULE__.NullifierFilter{}
+  defp trm_filter() do
+    %__MODULE__.TRMFilter{}
   end
 end

--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -381,4 +381,58 @@ defmodule Anoma.Node.Transaction.Backends do
 
     EventBroker.event(event)
   end
+
+  @doc """
+  I am the commitment accumulator add function for the transparent resource
+  machine.
+
+  Given the commitment set, I add a commitment to it.
+  """
+
+  @spec add(MapSet.t(), binary()) :: MapSet.t()
+  def add(acc, cm) do
+    MapSet.put(acc, cm)
+  end
+
+  @doc """
+  I am the commitment accumulator witness function for the transparent
+  resource machine.
+
+  Given the commitment set and a commitment, I return the original set if
+  the commitment is a member of the former. Otherwise, I return nil
+  """
+
+  @spec witness(MapSet.t(), binary()) :: MapSet.t() | nil
+  def witness(acc, cm) do
+    if MapSet.member?(acc, cm) do
+      acc
+    end
+  end
+
+  @doc """
+  I am the commitment accumulator value function for the transparent
+  resource machine.
+
+  Given the commitment set, I turn it to binary and then hash it using
+  sha-256.
+  """
+
+  @spec value(MapSet.t()) :: binary()
+  def value(acc) do
+    :crypto.hash(:sha256, :erlang.term_to_binary(acc))
+  end
+
+  @doc """
+  I am the commitment accumulator verify function for the transparent
+  resource machine.
+
+  Given the commitment, a witness (i.e. a set) and a commitment value, I
+  output true iff the witness's value is the same as the provided value and
+  the commitment is indeed in the set.
+  """
+
+  @spec verify(binary(), MapSet.t(), binary()) :: bool()
+  def verify(cm, w, val) do
+    val == value(w) and MapSet.member?(w, cm)
+  end
 end

--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -10,7 +10,6 @@ defmodule Anoma.Node.Transaction.Backends do
   alias Anoma.TransparentResource
   alias Anoma.TransparentResource.Transaction, as: TTransaction
   alias Anoma.TransparentResource.Resource, as: TResource
-  alias CommitmentTree.Spec
 
   import Nock
   require Noun
@@ -151,15 +150,6 @@ defmodule Anoma.Node.Transaction.Backends do
             }
         end
 
-      ct =
-        case Ordering.read(node_id, {id, :ct}) do
-          :absent -> CommitmentTree.new(Spec.cm_tree_spec(), nil)
-          val -> val
-        end
-
-      {ct_new, anchor} =
-        CommitmentTree.add(ct, map.commitments |> MapSet.to_list())
-
       Ordering.add(
         node_id,
         {id,
@@ -168,7 +158,7 @@ defmodule Anoma.Node.Transaction.Backends do
              {:nullifiers, map.nullifiers},
              {:commitments, map.commitments}
            ],
-           write: [{:anchor, anchor}, {:ct, ct_new}]
+           write: [{:anchor, value(map.commitments)}]
          }}
       )
 

--- a/apps/anoma_node/lib/node/transaction/storage.ex
+++ b/apps/anoma_node/lib/node/transaction/storage.ex
@@ -185,7 +185,7 @@ defmodule Anoma.Node.Transaction.Storage do
     {:noreply, state}
   end
 
-  @spec read(String.t(), {non_neg_integer(), any()}) :: :absent | any()
+  @spec read(String.t(), {non_neg_integer(), bare_key()}) :: :absent | any()
   def read(node_id, {height, key}) do
     GenServer.call(
       Registry.via(node_id, __MODULE__),
@@ -194,6 +194,14 @@ defmodule Anoma.Node.Transaction.Storage do
     )
   end
 
+  @spec add(
+          String.t(),
+          {non_neg_integer(),
+           %{
+             write: list({bare_key(), any()}),
+             append: list({bare_key(), MapSet.t()})
+           }}
+        ) :: term()
   def add(node_id, args = {_height, %{write: _writes, append: _appends}}) do
     GenServer.call(
       Registry.via(node_id, __MODULE__),
@@ -202,7 +210,8 @@ defmodule Anoma.Node.Transaction.Storage do
     )
   end
 
-  @spec write(String.t(), {non_neg_integer(), list(any())}) :: :ok
+  @spec write(String.t(), {non_neg_integer(), list({bare_key(), any()})}) ::
+          :ok
   def write(node_id, {height, kvlist}) do
     GenServer.call(
       Registry.via(node_id, __MODULE__),
@@ -211,8 +220,10 @@ defmodule Anoma.Node.Transaction.Storage do
     )
   end
 
-  @spec append(String.t(), {non_neg_integer(), list({any(), MapSet.t()})}) ::
-          :ok
+  @spec append(
+          String.t(),
+          {non_neg_integer(), list({bare_key(), MapSet.t()})}
+        ) :: :ok
   def append(node_id, {height, kvlist}) do
     GenServer.call(
       Registry.via(node_id, __MODULE__),


### PR DESCRIPTION
Before, a transparent resource transaction execution emmitted only the
nullifiers. However, we also need to emit the commitment accumilator.

Instead of providing a separate event, use a joint TRM event.