### PR TITLE
dialyzer: enable -Werror_handling

### DIFF
--- a/apps/anoma_lib/lib/examples/enock.ex
+++ b/apps/anoma_lib/lib/examples/enock.ex
@@ -2675,6 +2675,7 @@ defmodule Examples.ENock do
   ##                          Scry Crash                            ##
   ####################################################################
 
+  @dialyzer({:nowarn_function, nock_scry_crash: 0})
   @spec nock_scry_crash() :: Noun.t()
   def nock_scry_crash() do
     code = [12, [1 | 0] | [1 | 0]]

--- a/mix.exs
+++ b/mix.exs
@@ -17,6 +17,8 @@ defmodule Anoma.MixProject do
         plt_local_path: "plts/anoma.plt",
         plt_core_path: "plts/core.plt",
         flags: [
+          # Checks for functions which can only return via an exception.
+          "-Werror_handling",
           # Turn off the warning for improper lists, because we use
           # bare cons frequently and deliberately.
           "-Wno_improper_lists"


### PR DESCRIPTION
This warning checks for functions which can only return via an
exception.
