### PR TITLE
dialyzer: enable -Wmissing_return

### DIFF
--- a/apps/anoma_client/lib/client.ex
+++ b/apps/anoma_client/lib/client.ex
@@ -65,7 +65,7 @@ defmodule Anoma.Client do
   I run a Nock program with its inputs, and return the result.
   """
   @spec run_nock(Noun.t(), [Noun.t()]) ::
-          {:ok, Noun.t()} | {:error, any()}
+          {:ok, Noun.t(), [Noun.t()]} | {:error, any()}
   def run_nock(program, inputs) do
     Runner.prove(program, inputs)
   end

--- a/apps/anoma_client/lib/client/client_connection/connection.ex
+++ b/apps/anoma_client/lib/client/client_connection/connection.ex
@@ -165,7 +165,7 @@ defmodule Anoma.Client.Connection.TCP do
 
   # I encode the message into byts and push them onto the socket.
   # """
-  @spec handle_tcp_out(Envelope.t(), port()) :: :ok
+  @spec handle_tcp_out(Envelope.t(), port()) :: :ok | {:error, term()}
   defp handle_tcp_out(message, socket) do
     Logger.debug("tcp out :: #{inspect(self())} :: #{inspect(message)}")
     bytes = encode(message)

--- a/apps/anoma_client/lib/examples/e_client.ex
+++ b/apps/anoma_client/lib/examples/e_client.ex
@@ -71,7 +71,9 @@ defmodule Anoma.Client.Examples.EClient do
   I create a new node in the system, and ensure that that is the only node that is running
   by killing all other nodes.
   """
-  @spec create_single_example_node() :: ENode.t()
+  @spec create_single_example_node() ::
+          ENode.t()
+          | {:error, :failed_to_start_node}
   def create_single_example_node() do
     ENode.kill_all_nodes()
     ENode.start_node(grpc_port: 0)
@@ -105,7 +107,7 @@ defmodule Anoma.Client.Examples.EClient do
   @doc """
   I create an example stub to a given clients GRPC endpoint.
   """
-  @spec create_example_connection(t()) :: EConnection.t()
+  @spec create_example_connection(t()) :: EConnection.t() | {:error, term()}
   def create_example_connection(eclient \\ create_example_client()) do
     case GRPC.Stub.connect("localhost:#{eclient.client.grpc_port}") do
       {:ok, channel} ->
@@ -119,7 +121,7 @@ defmodule Anoma.Client.Examples.EClient do
   @doc """
   I create the setup necessary to run each example below without arguments.
   """
-  @spec setup() :: EConnection.t()
+  @spec setup() :: EConnection.t() | {:error, term()}
   def setup() do
     create_example_connection()
   end
@@ -372,15 +374,13 @@ defmodule Anoma.Client.Examples.EClient do
   @spec noun_program_tracing() :: Noun.t()
   def noun_program_tracing() do
     jammed_program_tracing()
-    |> Noun.Jam.cue()
-    |> elem(1)
+    |> Noun.Jam.cue!()
   end
 
-  @spec text_program_tracing() :: String.t()
+  @spec text_program_tracing() :: Noun.t()
   def text_program_tracing() do
     jammed_program_tracing()
-    |> Noun.Jam.cue()
-    |> elem(1)
+    |> Noun.Jam.cue!()
   end
 
   @spec jammed_program_juvix_squared() :: binary()
@@ -393,8 +393,7 @@ defmodule Anoma.Client.Examples.EClient do
   @spec noun_program_juvix_squared() :: Noun.t()
   def noun_program_juvix_squared() do
     jammed_program_juvix_squared()
-    |> Noun.Jam.cue()
-    |> elem(1)
+    |> Noun.Jam.cue!()
   end
 
   @spec text_program_example() :: binary()

--- a/apps/anoma_lib/lib/anoma/cairo_resource/resource.ex
+++ b/apps/anoma_lib/lib/anoma/cairo_resource/resource.ex
@@ -32,7 +32,7 @@ defmodule Anoma.CairoResource.Resource do
   end
 
   @spec from_json_object(Jason.OrderedObject.t()) ::
-          {:ok, t()}
+          t()
           | {:error, term()}
   def from_json_object(mp) do
     with {:ok, logic} <-

--- a/apps/anoma_lib/lib/anoma/cairo_resource/tree.ex
+++ b/apps/anoma_lib/lib/anoma/cairo_resource/tree.ex
@@ -59,12 +59,15 @@ defmodule Anoma.CairoResource.Tree do
   def set_path(json, path, path_name \\ "merkle_path") do
     with {:ok, decoded_json} <-
            Jason.decode(json, objects: :ordered_objects),
-         path_json_ob =
+         path_json_ob <-
            path
            |> Enum.map(fn {f, s} ->
              Jason.OrderedObject.new([{"fst", f}, {"snd", s}])
-           end) do
-      put_in(decoded_json[path_name], path_json_ob) |> Jason.encode()
+           end),
+         {:ok, encoded} <-
+           put_in(decoded_json[path_name], path_json_ob)
+           |> Jason.encode() do
+      {:ok, encoded}
     else
       _ -> :error
     end

--- a/apps/anoma_lib/lib/anoma/cairo_resource/workflow.ex
+++ b/apps/anoma_lib/lib/anoma/cairo_resource/workflow.ex
@@ -44,7 +44,7 @@ defmodule Anoma.CairoResource.Workflow do
   end
 
   @spec update_nk_commitment(Jason.OrderedObject.t(), binary()) ::
-          Jason.OrderedObject.t()
+          Jason.OrderedObject.t() | Keyword.t()
   defp update_nk_commitment(json, nf_key) do
     if Utils.json_object_has_nonempty_key(json, "nk_commitment") do
       json
@@ -59,7 +59,7 @@ defmodule Anoma.CairoResource.Workflow do
   end
 
   @spec update_nonce(Jason.OrderedObject.t(), binary()) ::
-          Jason.OrderedObject.t()
+          Jason.OrderedObject.t() | Keyword.t()
   defp update_nonce(json, input_nullifier) do
     if Utils.json_object_has_nonempty_key(json, "nonce") do
       json
@@ -198,7 +198,7 @@ defmodule Anoma.CairoResource.Workflow do
           binary(),
           list(Jason.OrderedObject.t())
         ) ::
-          Jason.OrderedObject.t()
+          Jason.OrderedObject.t() | Keyword.t()
   defp update_witness_json(witness_json, resource, nf_key, merkle_path) do
     witness1 =
       if Utils.json_object_has_empty_key(witness_json, "self_resource") do

--- a/apps/anoma_lib/lib/anoma/transparent_resource/action.ex
+++ b/apps/anoma_lib/lib/anoma/transparent_resource/action.ex
@@ -47,7 +47,7 @@ defmodule Anoma.TransparentResource.Action do
     Delta.sub(committed_delta, nullified_delta)
   end
 
-  @spec verify_correspondence(t()) :: true | {:error, String.t()}
+  @spec verify_correspondence(t()) :: bool() | {:error, String.t()}
   def verify_correspondence(action = %Action{}) do
     # Bail out early, if there are more committed and nullified
     # resources than there are actual resource proofs
@@ -139,7 +139,7 @@ defmodule Anoma.TransparentResource.Action do
     end
   end
 
-  @spec from_noun_proofs(Noun.t()) :: {:ok, MapSet.t(LogicProof.t())}
+  @spec from_noun_proofs(Noun.t()) :: {:ok, MapSet.t(LogicProof.t())} | :error
   defp from_noun_proofs(noun) when is_list(noun) do
     maybe_proofs =
       Enum.map(Noun.list_nock_to_erlang(noun), &proof_from_noun/1)

--- a/apps/anoma_lib/lib/anoma/transparent_resource/logic_proof.ex
+++ b/apps/anoma_lib/lib/anoma/transparent_resource/logic_proof.ex
@@ -164,7 +164,7 @@ defmodule Anoma.TransparentResource.LogicProof do
     :error
   end
 
-  @spec from_noun_plaintext(Noun.t()) :: {:ok, MapSet.t(Resource.t())}
+  @spec from_noun_plaintext(Noun.t()) :: {:ok, MapSet.t(Resource.t())} | :error
   defp from_noun_plaintext(noun) when noun in @empty do
     {:ok, MapSet.new([])}
   end

--- a/apps/anoma_lib/lib/anoma/transparent_resource/transaction.ex
+++ b/apps/anoma_lib/lib/anoma/transparent_resource/transaction.ex
@@ -177,7 +177,7 @@ defmodule Anoma.TransparentResource.Transaction do
     end
   end
 
-  @spec from_noun_actions(Noun.t()) :: {:ok, MapSet.t(Action.t())}
+  @spec from_noun_actions(Noun.t()) :: {:ok, MapSet.t(Action.t())} | :error
   defp from_noun_actions(noun) when is_list(noun) do
     maybe_actions =
       Enum.map(Noun.list_nock_to_erlang(noun), &Action.from_noun/1)

--- a/apps/anoma_lib/lib/examples/e_cairo/e_proof_record.ex
+++ b/apps/anoma_lib/lib/examples/e_cairo/e_proof_record.ex
@@ -32,18 +32,18 @@ defmodule Examples.ECairo.EProofRecord do
         "params/trivial_resource_logic.json"
       )
 
-    assert {:ok, circuit} = File.read(circuit_dir)
-    assert {:ok, witness} = File.read(witness_dir)
+    {:ok, circuit} = File.read(circuit_dir)
+    {:ok, witness} = File.read(witness_dir)
 
     updated_witness =
       if path do
-        assert {:ok, updated_witness} = Tree.set_path(witness, path)
+        {:ok, updated_witness} = Tree.set_path(witness, path)
         updated_witness
       else
         witness
       end
 
-    assert {:ok, input_resource_logic_proof} =
+    {:ok, input_resource_logic_proof} =
              ProofRecord.generate_cairo_proof(
                circuit,
                updated_witness

--- a/apps/anoma_lib/lib/examples/e_cairo/e_resource_logic.ex
+++ b/apps/anoma_lib/lib/examples/e_cairo/e_resource_logic.ex
@@ -106,9 +106,6 @@ defmodule Examples.ECairo.EResourceLogic do
         invalid_input
       )
 
-    assert {:error, "Runtime error: The cairo program execution failed"} ==
-             ret
-
-    ret
+    {:error, "Runtime error: The cairo program execution failed"} = ret
   end
 end

--- a/apps/anoma_lib/lib/examples/enock.ex
+++ b/apps/anoma_lib/lib/examples/enock.ex
@@ -603,7 +603,11 @@ defmodule Examples.ENock do
 
   @spec raw_call(Noun.t(), Noun.t()) :: {:ok, Noun.t()}
   def raw_call(seed, width) do
-    Nock.nock(raw_arm(), [9, 2, 10, [6, 1 | [seed | width]], 0 | 1])
+    {:ok, _} =
+      Nock.nock(
+        raw_arm(),
+        [9, 2, 10, [6, 1 | [seed | width]], 0 | 1]
+      )
   end
 
   @spec raw_27_4() :: {:ok, Noun.t()}
@@ -642,7 +646,11 @@ defmodule Examples.ENock do
 
   @spec raws_call(Noun.t(), Noun.t()) :: {:ok, Noun.t()}
   def raws_call(seed, width) do
-    Nock.nock(raws_arm(), [9, 2, 10, [6, 1 | [seed | width]], 0 | 1])
+    {:ok, _} =
+      Nock.nock(
+        raws_arm(),
+        [9, 2, 10, [6, 1 | [seed | width]], 0 | 1]
+      )
   end
 
   @spec raws_test() :: :ok
@@ -682,7 +690,11 @@ defmodule Examples.ENock do
 
   @spec rad_call(any(), non_neg_integer()) :: {:ok, Noun.t()}
   def rad_call(seed, range) do
-    Nock.nock(rad_arm(), [9, 2, 10, [6, 1 | [seed | range]], 0 | 1])
+    {:ok, _} =
+      Nock.nock(
+        rad_arm(),
+        [9, 2, 10, [6, 1 | [seed | range]], 0 | 1]
+      )
   end
 
   @spec rad_tests() :: {:ok, Noun.t()}

--- a/apps/anoma_lib/lib/nock/jets.ex
+++ b/apps/anoma_lib/lib/nock/jets.ex
@@ -72,6 +72,8 @@ defmodule Nock.Jets do
 
     with {:ok, context} <- Noun.axis(context_axis, Nock.Lib.rm_core()) do
       mug(context)
+    else
+      _ -> raise "unexpected core structure"
     end
   end
 
@@ -95,6 +97,8 @@ defmodule Nock.Jets do
     with {:ok, val} <-
            calculate_core_param(core_index, index_in_core, parent_layer) do
       Noun.mug(hd(val))
+    else
+      _ -> raise "unexpected core structure"
     end
   end
 
@@ -114,6 +118,8 @@ defmodule Nock.Jets do
     with {:ok, core} <- calculate_core_param(core_index, 4, parent_layer),
          {:ok, parent} <- Noun.axis(14, core) do
       Noun.mug(parent)
+    else
+      _ -> raise "unexpected core structure"
     end
   end
 
@@ -322,7 +328,7 @@ defmodule Nock.Jets do
     end
   end
 
-  @spec verify(Noun.t()) :: :error | {:ok, binary()}
+  @spec verify(Noun.t()) :: :error | {:ok, Noun.t()}
   def verify(core) do
     maybe_sample = sample(core)
 
@@ -469,14 +475,11 @@ defmodule Nock.Jets do
 
   @spec cue(Noun.t()) :: :error | {:ok, Noun.t()}
   def cue(core) do
-    maybe_sample = sample(core)
-
-    case maybe_sample do
-      {:ok, sample} when is_noun_atom(sample) ->
-        Noun.Jam.cue(sample)
-
-      _ ->
-        :error
+    with {:ok, sample} <- sample(core),
+         {:ok, noun} when is_noun_atom(noun) <- Noun.Jam.cue(sample) do
+      {:ok, noun}
+    else
+      _ -> :error
     end
   end
 

--- a/apps/anoma_lib/lib/noun.ex
+++ b/apps/anoma_lib/lib/noun.ex
@@ -183,7 +183,7 @@ defmodule Noun do
       fal
     else
       haz = Murmur.hash_x86_32(key, seed)
-      ham = haz >>> 31 |> bxor(haz &&& (1 <<< 31) - 1)
+      ham = (haz >>> 31) |> bxor(haz &&& (1 <<< 31) - 1)
 
       unless ham == 0 do
         ham
@@ -306,11 +306,11 @@ defmodule Noun do
   I convert the signed integer to a noun using the [ZigZag](https://protobuf.dev/programming-guides/encoding/#signed-ints) encoding.
   """
   @spec encode_signed(integer()) :: non_neg_integer()
-  def encode_signed(x) when x >= 0 do
+  def encode_signed(x) when is_integer(x) and x >= 0 do
     x * 2
   end
 
-  def encode_signed(x) when x < 0 do
+  def encode_signed(x) when is_integer(x) and x < 0 do
     -x * 2 - 1
   end
 

--- a/apps/anoma_node/lib/examples/e_transport/e_grpc.ex
+++ b/apps/anoma_node/lib/examples/e_transport/e_grpc.ex
@@ -68,7 +68,7 @@ defmodule Anoma.Node.Examples.EGRPC do
 
     assert Kernel.match?(%EGRPC{}, result)
 
-    result
+    %EGRPC{} = result
   end
 
   @doc """

--- a/apps/anoma_node/lib/node/intents/solver.ex
+++ b/apps/anoma_node/lib/node/intents/solver.ex
@@ -265,7 +265,7 @@ defmodule Anoma.Node.Intents.Solver do
   - `submit(any, node_id)` - I do nothing
   """
 
-  @spec submit(Intent.t(), String.t()) :: :ok
+  @spec submit(Intent.t(), String.t()) :: :ok | nil
   def submit(tx = %Anoma.TransparentResource.Transaction{}, node_id) do
     tx_noun = tx |> Noun.Nounable.to_noun()
     tx_candidate = [[1, 0, [1 | tx_noun], 0 | 909], 0 | 707]

--- a/apps/anoma_node/lib/node/logging.ex
+++ b/apps/anoma_node/lib/node/logging.ex
@@ -489,7 +489,7 @@ defmodule Anoma.Node.Logging do
   #                           Helpers                        #
   ############################################################
 
-  @spec init_table(atom(), bool()) :: {:atomic, :ok}
+  @spec init_table(atom(), bool()) :: {:atomic, :ok} | {:aborted, term()}
   defp init_table(table, rocks) do
     :mnesia.delete_table(table)
     rocks_opt = Anoma.Utility.rock_opts(rocks)

--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -183,7 +183,7 @@ defmodule Anoma.Node.Transaction.Backends do
     end
   end
 
-  @spec cue_when_atom(Noun.t()) :: :error | {:ok, Noun.t()}
+  @spec cue_when_atom(Noun.t()) :: {:ok, Noun.t()} | {:error, Exception.t()}
   defp cue_when_atom(tx_code) when Noun.is_noun_atom(tx_code) do
     Noun.Jam.cue(tx_code)
   end
@@ -456,7 +456,7 @@ defmodule Anoma.Node.Transaction.Backends do
   end
 
   @spec cairo_resource_tx(String.t(), binary(), Noun.t()) ::
-          :ok | :error
+          {:ok, CTransaction.t()} | :error
   defp cairo_resource_tx(node_id, id, result) do
     with {:ok, tx} <- CTransaction.from_noun(result),
          true <- Anoma.RM.Transaction.verify(tx),

--- a/apps/anoma_node/lib/node/transport/tcp/tcp_connection.ex
+++ b/apps/anoma_node/lib/node/transport/tcp/tcp_connection.ex
@@ -176,7 +176,7 @@ defmodule Anoma.Node.Transport.TCP.Connection do
 
   # I encode the message into byts and push them onto the socket.
   # """
-  @spec handle_tcp_out(Envelope.t(), port()) :: :ok
+  @spec handle_tcp_out(Envelope.t(), port()) :: :ok | {:error, term()}
   defp handle_tcp_out(message, socket) do
     Logger.debug("tcp out :: #{inspect(self())} :: #{inspect(message)}")
     bytes = encode(message)

--- a/apps/anoma_node/lib/node/transport/tcp/tcp_listener.ex
+++ b/apps/anoma_node/lib/node/transport/tcp/tcp_listener.ex
@@ -291,7 +291,7 @@ defmodule Anoma.Node.Transport.TCP.Listener do
   # If anything goes wrong, I return an error.
   # """
   @spec create_new_connection(:inet.socket(), String.t()) ::
-          {:ok, pid()} | {:error, any()}
+          DynamicSupervisor.on_start_child()
   defp create_new_connection(socket, node_id) do
     supervisor = Registry.whereis(node_id, :tcp_supervisor)
 

--- a/apps/anoma_node/lib/node/transport/transport.ex
+++ b/apps/anoma_node/lib/node/transport/transport.ex
@@ -78,7 +78,7 @@ defmodule Anoma.Node.Transport do
   Given a remote node id, I start a proxy engine that represents that remote node.
   """
   @spec start_engine_proxy(String.t(), String.t(), atom()) ::
-          {:ok, pid} | {:error, term}
+          DynamicSupervisor.on_start_child()
   def start_engine_proxy(node_id, remote_node_id, type) do
     supervisor = Anoma.Node.Registry.whereis(node_id, :proxy_supervisor)
     args = [node_id: node_id, remote_node_id: remote_node_id, type: type]

--- a/apps/compile_protoc/lib/mix/tasks/compile/protoc.ex
+++ b/apps/compile_protoc/lib/mix/tasks/compile/protoc.ex
@@ -92,7 +92,7 @@ defmodule Mix.Tasks.Compile.Protoc do
   # @doc """
   # I find the protoc executable in the current system, or raise if its not found.
   # """
-  @spec protoc_executable() :: String.t()
+  @spec protoc_executable() :: String.t() | nil
   defp protoc_executable() do
     System.find_executable("protoc") ||
       raise "`protoc` not found in system path"

--- a/apps/compile_protoc/lib/mix/tasks/format.ex
+++ b/apps/compile_protoc/lib/mix/tasks/format.ex
@@ -34,8 +34,9 @@ defmodule Mix.Tasks.FormatProtoc do
   # @doc """
   # I find the clang-format executable in the current system, or raise if its not found.
   # """
-  @spec clang_format_executable() :: String.t()
+  @spec clang_format_executable() :: String.t() | nil
   defp clang_format_executable() do
-    System.find_executable("clang-format")
+    System.find_executable("clang-format") ||
+      raise "`protoc` not found in system path"
   end
 end

--- a/apps/event_broker/lib/examples/e_event_broker.ex
+++ b/apps/event_broker/lib/examples/e_event_broker.ex
@@ -15,7 +15,7 @@ defmodule Examples.EEventBroker do
   """
 
   @spec start_broker() ::
-          :already_started | :error | {:ok, %{broker: pid(), registry: pid()}}
+          :already_started | :error | {:ok, pid()}
   def start_broker do
     on_start =
       with {:ok, sup_pid} <- Supervisor.start_link() do

--- a/mix.exs
+++ b/mix.exs
@@ -17,6 +17,9 @@ defmodule Anoma.MixProject do
         plt_local_path: "plts/anoma.plt",
         plt_core_path: "plts/core.plt",
         flags: [
+          # Check for functions which return values not included in
+          # their spec.
+          "-Wmissing_return",
           # Turn off the warning for improper lists, because we use
           # bare cons frequently and deliberately.
           "-Wno_improper_lists"


### PR DESCRIPTION
This warning checks for functions which return values which are not
included in their specified return type.
