### PR TITLE
Intent Pool Handles Commitments

### DIFF
--- a/apps/anoma_lib/lib/anoma/rm/intent.ex
+++ b/apps/anoma_lib/lib/anoma/rm/intent.ex
@@ -8,6 +8,9 @@ defprotocol Anoma.RM.Intent do
 
   @spec verify(t()) :: true | {:error, any()}
   def verify(intent)
+
+  @spec nullifiers(t()) :: MapSet.t()
+  def nullifiers(intent)
 end
 
 defimpl Anoma.RM.Intent, for: Anoma.RM.DumbIntent do
@@ -21,5 +24,10 @@ defimpl Anoma.RM.Intent, for: Anoma.RM.DumbIntent do
   @impl true
   def verify(intent = %DumbIntent{}) do
     intent.value == 0
+  end
+
+  @impl true
+  def nullifiers(%DumbIntent{}) do
+    MapSet.new([])
   end
 end

--- a/apps/anoma_lib/lib/anoma/rm/intent.ex
+++ b/apps/anoma_lib/lib/anoma/rm/intent.ex
@@ -11,6 +11,9 @@ defprotocol Anoma.RM.Intent do
 
   @spec nullifiers(t()) :: MapSet.t()
   def nullifiers(intent)
+
+  @spec commitments(t()) :: MapSet.t()
+  def commitments(intent)
 end
 
 defimpl Anoma.RM.Intent, for: Anoma.RM.DumbIntent do
@@ -28,6 +31,11 @@ defimpl Anoma.RM.Intent, for: Anoma.RM.DumbIntent do
 
   @impl true
   def nullifiers(%DumbIntent{}) do
+    MapSet.new([])
+  end
+
+  @impl true
+  def commitments(%DumbIntent{}) do
     MapSet.new([])
   end
 end

--- a/apps/anoma_lib/lib/anoma/transparent_resource/transaction.ex
+++ b/apps/anoma_lib/lib/anoma/transparent_resource/transaction.ex
@@ -238,4 +238,9 @@ defimpl Anoma.RM.Intent, for: Anoma.TransparentResource.Transaction do
   def verify(tx = %Transaction{}) do
     Transaction.verify(tx)
   end
+
+  @impl true
+  def nullifiers(tx = %Transaction{}) do
+    Transaction.nullifiers(tx)
+  end
 end

--- a/apps/anoma_lib/lib/anoma/transparent_resource/transaction.ex
+++ b/apps/anoma_lib/lib/anoma/transparent_resource/transaction.ex
@@ -243,4 +243,9 @@ defimpl Anoma.RM.Intent, for: Anoma.TransparentResource.Transaction do
   def nullifiers(tx = %Transaction{}) do
     Transaction.nullifiers(tx)
   end
+
+  @impl true
+  def commitments(tx = %Transaction{}) do
+    Transaction.commitments(tx)
+  end
 end

--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -343,11 +343,12 @@ defmodule Anoma.Node.Examples.ETransaction do
     assert {:ok, base_swap |> Transaction.commitments()} ==
              Storage.read(node_id, {1, ["anoma", "commitments"]})
 
-    {tree, anchor} =
-      Examples.ECommitmentTree.memory_backed_ct_with_trivial_swap()
+    cms = base_swap |> Transaction.commitments()
 
-    assert {:ok, tree} == Storage.read(node_id, {1, ["anoma", "ct"]})
-    assert {:ok, anchor} == Storage.read(node_id, {1, ["anoma", "anchor"]})
+    assert {:ok, cms} == Storage.read(node_id, {1, ["anoma", "commitments"]})
+
+    assert {:ok, Backends.value(cms)} ==
+             Storage.read(node_id, {1, ["anoma", "anchor"]})
 
     EventBroker.unsubscribe_me([])
 

--- a/apps/anoma_node/lib/examples/eintent_pool.ex
+++ b/apps/anoma_node/lib/examples/eintent_pool.ex
@@ -8,7 +8,11 @@ defmodule Anoma.Node.Examples.EIntentPool do
 
   alias Anoma.Node.Intents.IntentPool
   alias Anoma.RM.DumbIntent
+  alias Anoma.RM.Intent
   alias Anoma.Node.Examples.ENode
+  alias Anoma.Node
+
+  require Node.Event
 
   ############################################################
   #                           Scenarios                      #
@@ -89,6 +93,49 @@ defmodule Anoma.Node.Examples.EIntentPool do
     )
 
     assert enode.node_id |> IntentPool.intents() |> Enum.empty?()
+
+    enode
+  end
+
+  @doc """
+  I check that adding an intent with nullifiers already known in the nlfs_set
+  does not add the intent to the pool.
+  """
+  @spec add_intent_with_known_nullifiers(ENode.t()) :: ENode.t()
+  def add_intent_with_known_nullifiers(enode \\ ENode.start_node()) do
+    intent = Examples.ETransparent.ETransaction.nullify_intent_eph()
+    nlfs_set = Intent.nullifiers(intent)
+
+    new_nullifiers_event(enode, nlfs_set)
+
+    node_id = enode.node_id
+    IntentPool.new_intent(node_id, intent)
+
+    # the intent will not be present in the mapset
+    assert IntentPool.intents(node_id) == MapSet.new([])
+
+    enode
+  end
+
+  @doc """
+  I submit a nullifier event to the node.
+  """
+  @spec new_nullifiers_event(ENode.t(), MapSet.t()) :: ENode.t()
+  def new_nullifiers_event(
+        enode \\ ENode.start_node(),
+        nlfs_set \\ MapSet.new()
+      ) do
+    node_id = enode.node_id
+
+    event =
+      Node.Event.new_with_body(
+        node_id,
+        %Anoma.Node.Transaction.Backends.NullifierEvent{
+          nullifiers: nlfs_set
+        }
+      )
+
+    EventBroker.event(event)
 
     enode
   end

--- a/apps/anoma_node/lib/examples/eintent_pool.ex
+++ b/apps/anoma_node/lib/examples/eintent_pool.ex
@@ -130,8 +130,9 @@ defmodule Anoma.Node.Examples.EIntentPool do
     event =
       Node.Event.new_with_body(
         node_id,
-        %Anoma.Node.Transaction.Backends.NullifierEvent{
-          nullifiers: nlfs_set
+        %Anoma.Node.Transaction.Backends.TRMEvent{
+          nullifiers: nlfs_set,
+          commitments: MapSet.new([])
         }
       )
 

--- a/apps/anoma_node/lib/node/intents/intent_pool.ex
+++ b/apps/anoma_node/lib/node/intents/intent_pool.ex
@@ -55,7 +55,7 @@ defmodule Anoma.Node.Intents.IntentPool do
 
     EventBroker.subscribe_me([
       Node.Event.node_filter(node_id),
-      nullifier_filter()
+      trm_filter()
     ])
 
     {:ok, %IntentPool{node_id: args[:node_id]}}
@@ -118,7 +118,7 @@ defmodule Anoma.Node.Intents.IntentPool do
   @impl true
   def handle_info(
         %EventBroker.Event{
-          body: %Node.Event{body: %Backends.NullifierEvent{nullifiers: set}}
+          body: %Node.Event{body: %Backends.TRMEvent{nullifiers: set}}
         },
         state
       ) do
@@ -240,9 +240,9 @@ defmodule Anoma.Node.Intents.IntentPool do
     |> MapSet.new()
   end
 
-  deffilter NullifierFilter do
+  deffilter TRMFilter do
     %EventBroker.Event{
-      body: %Anoma.Node.Event{body: %Backends.NullifierEvent{}}
+      body: %Anoma.Node.Event{body: %Backends.TRMEvent{}}
     } ->
       true
 
@@ -250,7 +250,7 @@ defmodule Anoma.Node.Intents.IntentPool do
       false
   end
 
-  defp nullifier_filter() do
-    %__MODULE__.NullifierFilter{}
+  defp trm_filter() do
+    %__MODULE__.TRMFilter{}
   end
 end

--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -18,7 +18,6 @@ defmodule Anoma.Node.Transaction.Backends do
   alias Anoma.TransparentResource
   alias Anoma.TransparentResource.Transaction, as: TTransaction
   alias Anoma.TransparentResource.Resource, as: TResource
-  alias CommitmentTree.Spec
 
   import Nock
   require Noun
@@ -63,15 +62,18 @@ defmodule Anoma.Node.Transaction.Backends do
     field(:tx_result, {:ok, any()} | :error)
   end
 
-  typedstruct enforce: true, module: NullifierEvent do
+  typedstruct enforce: true, module: TRMEvent do
     @typedoc """
     I hold the content of the Nullifier Event, which communicates a set of
     nullifiers defined by the actions of the transaction candidate to the
     Intent Pool.
 
     ### Fields
+
+    - `:commitments`        - The set of commitments.
     - `:nullifiers`         - The set of nullifiers.
     """
+    field(:commitments, MapSet.t(binary()))
     field(:nullifiers, MapSet.t(binary()))
   end
 
@@ -203,15 +205,6 @@ defmodule Anoma.Node.Transaction.Backends do
             }
         end
 
-      ct =
-        case Ordering.read(node_id, {id, anoma_keyspace("ct")}) do
-          :absent -> CommitmentTree.new(Spec.cm_tree_spec(), nil)
-          val -> val
-        end
-
-      {ct_new, anchor} =
-        CommitmentTree.add(ct, map.commitments |> MapSet.to_list())
-
       Ordering.add(
         node_id,
         {id,
@@ -220,14 +213,11 @@ defmodule Anoma.Node.Transaction.Backends do
              {anoma_keyspace("nullifiers"), map.nullifiers},
              {anoma_keyspace("commitments"), map.commitments}
            ],
-           write: [
-             {anoma_keyspace("anchor"), anchor},
-             {anoma_keyspace("ct"), ct_new}
-           ]
+           write: [{anoma_keyspace("anchor"), value(map.commitments)}]
          }}
       )
 
-      nullifier_event(map.nullifiers, node_id)
+      transparent_rm_event(map.commitments, map.nullifiers, node_id)
 
       {:ok, tx}
     else
@@ -441,14 +431,73 @@ defmodule Anoma.Node.Transaction.Backends do
     event(backend, event)
   end
 
-  @spec nullifier_event(MapSet.t(binary()), String.t()) :: :ok
-  defp nullifier_event(set, node_id) do
+  @spec transparent_rm_event(
+          MapSet.t(binary()),
+          MapSet.t(binary()),
+          String.t()
+        ) :: :ok
+  defp transparent_rm_event(cms, nlfs, node_id) do
     event =
-      Node.Event.new_with_body(node_id, %__MODULE__.NullifierEvent{
-        nullifiers: set
+      Node.Event.new_with_body(node_id, %__MODULE__.TRMEvent{
+        commitments: cms,
+        nullifiers: nlfs
       })
 
     EventBroker.event(event)
+  end
+
+  @doc """
+  I am the commitment accumulator add function for the transparent resource
+  machine.
+
+  Given the commitment set, I add a commitment to it.
+  """
+
+  @spec add(MapSet.t(), binary()) :: MapSet.t()
+  def add(acc, cm) do
+    MapSet.put(acc, cm)
+  end
+
+  @doc """
+  I am the commitment accumulator witness function for the transparent
+  resource machine.
+
+  Given the commitment set and a commitment, I return the original set if
+  the commitment is a member of the former. Otherwise, I return nil
+  """
+
+  @spec witness(MapSet.t(), binary()) :: MapSet.t() | nil
+  def witness(acc, cm) do
+    if MapSet.member?(acc, cm) do
+      acc
+    end
+  end
+
+  @doc """
+  I am the commitment accumulator value function for the transparent
+  resource machine.
+
+  Given the commitment set, I turn it to binary and then hash it using
+  sha-256.
+  """
+
+  @spec value(MapSet.t()) :: binary()
+  def value(acc) do
+    :crypto.hash(:sha256, :erlang.term_to_binary(acc))
+  end
+
+  @doc """
+  I am the commitment accumulator verify function for the transparent
+  resource machine.
+
+  Given the commitment, a witness (i.e. a set) and a commitment value, I
+  output true iff the witness's value is the same as the provided value and
+  the commitment is indeed in the set.
+  """
+
+  @spec verify(binary(), MapSet.t(), binary()) :: bool()
+  def verify(cm, w, val) do
+    val == value(w) and MapSet.member?(w, cm)
   end
 
   @spec anoma_keyspace(String.t()) :: list(String.t())

--- a/apps/anoma_node/test/intent_pool_test.exs
+++ b/apps/anoma_node/test/intent_pool_test.exs
@@ -7,5 +7,17 @@ defmodule IntentPoolTest do
     EIntentPool.list_intents(ENode.start_node(node_id: "IP_test1"))
     EIntentPool.add_intent(ENode.start_node(node_id: "IP_test2"))
     EIntentPool.remove_intent(ENode.start_node(node_id: "IP_test3"))
+
+    EIntentPool.add_intent_transaction_nullifier(
+      ENode.start_node(node_id: "IP_test3")
+    )
+
+    EIntentPool.remove_intents_with_nulllified_resources(
+      ENode.start_node(node_id: "IP_test3")
+    )
+
+    EIntentPool.add_intent_with_known_nullifiers(
+      ENode.start_node(node_id: "IP_test3")
+    )
   end
 end


### PR DESCRIPTION
Intent Pool now stores commitments and does not accepts intents whose commitments are already in, also removing those which have commitments which were transmitted through the Event Broker.
