### PR TITLE
Remove IO.Inspect for Mempool/Add request

### DIFF
--- a/apps/anoma_client/lib/api/mempool.ex
+++ b/apps/anoma_client/lib/api/mempool.ex
@@ -12,7 +12,6 @@ defmodule Anoma.Client.Api.Servers.Mempool do
   def add(request, _stream) do
     Logger.debug("GRPC #{inspect(__ENV__.function)}: #{inspect(request)}")
 
-    IO.inspect(request, label: "client")
     :ok = GRPCProxy.add_transaction(request.transaction)
 
     %AddTransaction.Response{}


### PR DESCRIPTION
The Mempool/Add request is already being logging in the debug channel of the Logger so this duplicate log can be removed. The fact that it is using IO.inspect means it cannot be switched off by using logger configration.