### PR TITLE
Fix Bug Assuming Type Instantiations are Nock Lists

### DIFF
--- a/apps/anoma_lib/lib/anoma/transparent_resource/action.ex
+++ b/apps/anoma_lib/lib/anoma/transparent_resource/action.ex
@@ -99,8 +99,7 @@ defmodule Anoma.TransparentResource.Action do
   end
 
   @spec from_noun(Noun.t()) :: {:ok, t()} | :error
-  def from_noun([commits, nulls, proofs, app_data | terminator])
-      when terminator in [0, <<>>, <<0>>, []] do
+  def from_noun([commits, nulls, proofs | app_data]) do
     with {:ok, proofs} <- from_noun_proofs(proofs) do
       {:ok,
        %Action{
@@ -130,8 +129,8 @@ defmodule Anoma.TransparentResource.Action do
       [
         MapSet.to_list(trans.commitments),
         MapSet.to_list(trans.nullifiers),
-        Enum.map(trans.proofs, &Noun.Nounable.to_noun/1),
-        trans.app_data
+        Enum.map(trans.proofs, &Noun.Nounable.to_noun/1)
+        | trans.app_data
       ]
     end
   end

--- a/apps/anoma_lib/lib/anoma/transparent_resource/logic_proof.ex
+++ b/apps/anoma_lib/lib/anoma/transparent_resource/logic_proof.ex
@@ -68,18 +68,12 @@ defmodule Anoma.TransparentResource.LogicProof do
 
   @spec from_noun(Noun.t()) :: {:ok, t()} | :error
   def from_noun([
-        resource,
-        [
-          [commits, nulls, self_tag, other_public | terminator],
-          [commits_plain, nullified_plain, other_private | terminator2]
-          | terminator3
-        ]
-        | terminator4
-      ])
-      when terminator in @empty and
-             terminator2 in @empty and
-             terminator3 in @empty and
-             terminator4 in @empty do
+        resource
+        | [
+            [commits, nulls, self_tag | other_public]
+            | [commits_plain, nullified_plain | other_private]
+          ]
+      ]) do
     with {:ok, self_resource} <- Resource.from_noun(resource),
          {:ok, tag} <- determine_self_tag(self_tag),
          {:ok, nullified_plaintexts} <- from_noun_plaintext(nullified_plain),
@@ -118,7 +112,7 @@ defmodule Anoma.TransparentResource.LogicProof do
       {public_inputs, private_inputs} =
         LogicProof.internal_logic_inputs(proof)
 
-      [Resource.to_noun(proof.resource), [public_inputs, private_inputs]]
+      [Resource.to_noun(proof.resource) | [public_inputs | private_inputs]]
     end
   end
 
@@ -136,14 +130,14 @@ defmodule Anoma.TransparentResource.LogicProof do
     public_inputs = [
       MapSet.to_list(proof.commitments),
       MapSet.to_list(proof.nullifiers),
-      self_tag,
-      proof.other_public
+      self_tag
+      | proof.other_public
     ]
 
     private_inputs = [
       Enum.map(proof.committed_plaintexts, &Resource.to_noun/1),
-      Enum.map(proof.nullified_plaintexts, &Resource.to_noun/1),
-      proof.other_private
+      Enum.map(proof.nullified_plaintexts, &Resource.to_noun/1)
+      | proof.other_private
     ]
 
     {public_inputs, private_inputs}

--- a/apps/anoma_lib/lib/anoma/transparent_resource/resource.ex
+++ b/apps/anoma_lib/lib/anoma/transparent_resource/resource.ex
@@ -47,8 +47,8 @@ defmodule Anoma.TransparentResource.Resource do
       resource.quantity,
       resource.data,
       resource.nullifier_key,
-      resource.nonce,
-      resource.rseed
+      resource.nonce
+      | resource.rseed
     ]
   end
 
@@ -60,10 +60,9 @@ defmodule Anoma.TransparentResource.Resource do
         quantity,
         data,
         nullifier_key,
-        nonce,
-        rseed | terminator
-      ])
-      when terminator in [0, <<>>, <<0>>, []] do
+        nonce
+        | rseed
+      ]) do
     # we make sure the types are respected
     {:ok,
      %Resource{

--- a/apps/anoma_lib/lib/anoma/transparent_resource/transaction.ex
+++ b/apps/anoma_lib/lib/anoma/transparent_resource/transaction.ex
@@ -146,8 +146,7 @@ defmodule Anoma.TransparentResource.Transaction do
 
   # We any here, as it's giving a weird error
   @spec from_noun(Noun.t()) :: {:ok, t()} | :error
-  def from_noun([roots, actions, delta, delta_proof | terminator])
-      when terminator in [0, <<>>, <<0>>, []] do
+  def from_noun([roots, actions, delta | delta_proof]) do
     with {:ok, actions} <- from_noun_actions(actions),
          {:ok, delta} <- Delta.from_noun(delta) do
       {:ok,
@@ -171,9 +170,9 @@ defmodule Anoma.TransparentResource.Transaction do
         MapSet.to_list(trans.roots),
         Enum.map(trans.actions, &Noun.Nounable.to_noun/1),
         Map.to_list(trans.delta)
-        |> Enum.map(fn {x, y} -> [x, Noun.encode_signed(y)] end),
+        |> Enum.map(fn {x, y} -> [x, Noun.encode_signed(y)] end)
         # Consider better provinance value
-        trans.delta_proof
+        | trans.delta_proof
       ]
     end
   end


### PR DESCRIPTION
RM Types were for some reason assumed to be lists.