### PR TITLE
Fix from_noun_actions Assuming Input is Elixir List

### DIFF
--- a/apps/anoma_lib/lib/anoma/transparent_resource/transaction.ex
+++ b/apps/anoma_lib/lib/anoma/transparent_resource/transaction.ex
@@ -110,4 +110,8 @@ defmodule Anoma.TransparentResource.Transaction do
       {:ok, MapSet.new(Enum.map(maybe_actions, fn {:ok, x} -> x end))}
     end
   end
+
+  defp from_noun_actions(noun) when noun in [0, <<>>, []] do
+    {:ok, MapSet.new([])}
+  end
 end


### PR DESCRIPTION
Recall that 0 is an empty list in Nock.