### PR TITLE
Fix double encoding error in the indexer

### DIFF
--- a/apps/anoma_client/lib/api/indexer.ex
+++ b/apps/anoma_client/lib/api/indexer.ex
@@ -1,4 +1,5 @@
 defmodule Anoma.Client.Api.Servers.Indexer do
+  alias Anoma.Client.Connection.GRPCProxy
   alias Anoma.Protobuf.Indexer.Nullifiers
   alias Anoma.Protobuf.Indexer.UnrevealedCommits
   alias Anoma.Protobuf.Indexer.UnspentResources
@@ -9,20 +10,21 @@ defmodule Anoma.Client.Api.Servers.Indexer do
   @spec list_nullifiers(Nullifiers.Request.t(), Stream.t()) ::
           Nullifiers.Response.t()
   def list_nullifiers(_request, _stream) do
-    %Nullifiers.Response{nullifiers: ["null", "ifier"]}
+    {:ok, nullifiers} = GRPCProxy.list_nullifiers()
+    nullifiers
   end
 
   @spec list_unrevealed_commits(UnrevealedCommits.Request.t(), Stream.t()) ::
           UnrevealedCommits.Response.t()
   def list_unrevealed_commits(_request, _stream) do
-    %UnrevealedCommits.Response{commits: ["commit1", "commit2"]}
+    {:ok, commits} = GRPCProxy.list_unrevealed_commits()
+    commits
   end
 
   @spec list_unspent_resources(UnspentResources.Request.t(), Stream.t()) ::
           UnspentResources.Response.t()
   def list_unspent_resources(_request, _stream) do
-    %UnspentResources.Response{
-      unspent_resources: ["unspent resource 1", "unspent resource 2"]
-    }
+    {:ok, resources} = GRPCProxy.list_unspent_resources()
+    resources
   end
 end

--- a/apps/anoma_client/lib/examples/e_client.ex
+++ b/apps/anoma_client/lib/examples/e_client.ex
@@ -163,9 +163,19 @@ defmodule Anoma.Client.Examples.EClient do
   """
   @spec list_nullifiers(EConnection.t()) :: EConnection.t()
   def list_nullifiers(conn \\ setup()) do
+    # Create some nullifiers using another example
+    Anoma.Node.Examples.EIndexer.indexer_reads_nullifier(
+      conn.client.node.node_id
+    )
+
+    # request the nullifiers from the client
     node_id = %NodeInfo{node_id: conn.client.node.node_id}
     request = %Nullifiers.Request{node_info: node_id}
-    {:ok, _reply} = IndexerService.Stub.list_nullifiers(conn.channel, request)
+
+    {:ok, response} =
+      IndexerService.Stub.list_nullifiers(conn.channel, request)
+
+    assert response.nullifiers == ["TkZfWbFpHGfmGAQ="]
 
     conn
   end
@@ -175,12 +185,18 @@ defmodule Anoma.Client.Examples.EClient do
   """
   @spec list_unrevealed_commits(EConnection.t()) :: EConnection.t()
   def list_unrevealed_commits(conn \\ setup()) do
+    # Create an unrevealed commit using another example
+    Anoma.Node.Examples.EIndexer.indexer_reads_unrevealed(
+      conn.client.node.node_id
+    )
+
     node_id = %NodeInfo{node_id: conn.client.node.node_id}
     request = %UnrevealedCommits.Request{node_info: node_id}
 
-    {:ok, _reply} =
+    {:ok, response} =
       IndexerService.Stub.list_unrevealed_commits(conn.channel, request)
 
+    assert response.commits == ["Q01fWbFpHGdmgFYuzI3srU0W"]
     conn
   end
 
@@ -189,12 +205,18 @@ defmodule Anoma.Client.Examples.EClient do
   """
   @spec list_unspent_resources(EConnection.t()) :: EConnection.t()
   def list_unspent_resources(conn \\ setup()) do
+    # Create an unrevealed commit using another example
+    Anoma.Node.Examples.EIndexer.indexer_reads_unrevealed(
+      conn.client.node.node_id
+    )
+
     node_id = %NodeInfo{node_id: conn.client.node.node_id}
     request = %UnspentResources.Request{node_info: node_id}
 
-    {:ok, _reply} =
+    {:ok, reply} =
       IndexerService.Stub.list_unspent_resources(conn.channel, request)
 
+    assert reply.unspent_resources == ["WbFpHGdmgFYuzI3srU0W"]
     conn
   end
 

--- a/apps/anoma_client/lib/examples/e_client.ex
+++ b/apps/anoma_client/lib/examples/e_client.ex
@@ -175,7 +175,7 @@ defmodule Anoma.Client.Examples.EClient do
     {:ok, response} =
       IndexerService.Stub.list_nullifiers(conn.channel, request)
 
-    assert response.nullifiers == ["TkZfWbFpHGfmGAQ="]
+    assert response.nullifiers == [Base.decode64!("TkZfWbFpHGfmGAQ=")]
 
     conn
   end
@@ -196,7 +196,7 @@ defmodule Anoma.Client.Examples.EClient do
     {:ok, response} =
       IndexerService.Stub.list_unrevealed_commits(conn.channel, request)
 
-    assert response.commits == ["Q01fWbFpHGdmgFYuzI3srU0W"]
+    assert response.commits == [Base.decode64!("Q01fWbFpHGdmgFYuzI3srU0W")]
     conn
   end
 

--- a/apps/anoma_client/lib/examples/e_client.ex
+++ b/apps/anoma_client/lib/examples/e_client.ex
@@ -216,7 +216,11 @@ defmodule Anoma.Client.Examples.EClient do
     {:ok, reply} =
       IndexerService.Stub.list_unspent_resources(conn.channel, request)
 
-    assert reply.unspent_resources == ["WbFpHGdmgFYuzI3srU0W"]
+    assert reply.unspent_resources == [
+             <<89, 177, 105, 28, 103, 102, 128, 86, 46, 204, 141, 236, 173,
+               77, 22>>
+           ]
+
     conn
   end
 

--- a/apps/anoma_client/lib/examples/e_proxy.ex
+++ b/apps/anoma_client/lib/examples/e_proxy.ex
@@ -72,7 +72,7 @@ defmodule Anoma.Client.Examples.EProxy do
   """
   @spec list_nullifiers(EClient.t()) :: {EClient.t(), [any()]}
   def list_nullifiers(client \\ setup()) do
-    expected_nullifiers = ["null", "ifier"]
+    expected_nullifiers = []
 
     # call the proxy
     {:ok, response} = GRPCProxy.list_nullifiers()
@@ -88,7 +88,7 @@ defmodule Anoma.Client.Examples.EProxy do
   """
   @spec list_unrevealed_commits(EClient.t()) :: {EClient.t(), [any()]}
   def list_unrevealed_commits(client \\ setup()) do
-    expected_commits = ["commit1", "commit2"]
+    expected_commits = []
 
     # call the proxy and assert the result is what was expected
     {:ok, response} = GRPCProxy.list_unrevealed_commits()
@@ -104,7 +104,7 @@ defmodule Anoma.Client.Examples.EProxy do
   """
   @spec list_unspent_resources(EClient.t()) :: {EClient.t(), [any()]}
   def list_unspent_resources(client \\ setup()) do
-    expected_resources = ["unspent resource 1", "unspent resource 2"]
+    expected_resources = []
 
     # call the proxy
     {:ok, result} = GRPCProxy.list_unspent_resources()

--- a/apps/anoma_node/lib/node/transport/grpc/indexer.ex
+++ b/apps/anoma_node/lib/node/transport/grpc/indexer.ex
@@ -1,4 +1,5 @@
 defmodule Anoma.Node.Transport.GRPC.Servers.Indexer do
+  alias Anoma.Node.Utility.Indexer
   alias Anoma.Protobuf.Indexer.Nullifiers
   alias Anoma.Protobuf.Indexer.UnrevealedCommits
   alias Anoma.Protobuf.Indexer.UnspentResources
@@ -10,21 +11,41 @@ defmodule Anoma.Node.Transport.GRPC.Servers.Indexer do
 
   @spec list_nullifiers(Nullifiers.Request.t(), Stream.t()) ::
           Nullifiers.Response.t()
-  def list_nullifiers(_request, _stream) do
-    %Nullifiers.Response{nullifiers: ["null", "ifier"]}
+  def list_nullifiers(request, _stream) do
+    Logger.debug("GRPC #{inspect(__ENV__.function)}: #{inspect(request)}")
+
+    nullifiers =
+      Indexer.get(request.node_info.node_id, :nlfs)
+      |> Enum.map(&Base.encode64/1)
+
+    %Nullifiers.Response{nullifiers: nullifiers}
   end
 
   @spec list_unrevealed_commits(UnrevealedCommits.Request.t(), Stream.t()) ::
           UnrevealedCommits.Response.t()
-  def list_unrevealed_commits(_request, _stream) do
-    %UnrevealedCommits.Response{commits: ["commit1", "commit2"]}
+  def list_unrevealed_commits(request, _stream) do
+    Logger.debug("GRPC #{inspect(__ENV__.function)}: #{inspect(request)}")
+
+    unrevealed =
+      Indexer.get(request.node_info.node_id, :unrevealed)
+      |> Enum.map(&Base.encode64/1)
+
+    %UnrevealedCommits.Response{commits: unrevealed}
   end
 
   @spec list_unspent_resources(UnspentResources.Request.t(), Stream.t()) ::
           UnspentResources.Response.t()
-  def list_unspent_resources(_request, _stream) do
-    %UnspentResources.Response{
-      unspent_resources: ["unspent resource 1", "unspent resource 2"]
-    }
+  def list_unspent_resources(request, _stream) do
+    Logger.debug("GRPC #{inspect(__ENV__.function)}: #{inspect(request)}")
+
+    resources =
+      Indexer.get(request.node_info.node_id, :resources)
+      |> Enum.map(fn r ->
+        Noun.Nounable.to_noun(r)
+        |> Nock.Jam.jam()
+      end)
+      |> Enum.map(&Base.encode64/1)
+
+    %UnspentResources.Response{unspent_resources: resources}
   end
 end

--- a/apps/anoma_node/lib/node/transport/grpc/indexer.ex
+++ b/apps/anoma_node/lib/node/transport/grpc/indexer.ex
@@ -44,7 +44,6 @@ defmodule Anoma.Node.Transport.GRPC.Servers.Indexer do
         Noun.Nounable.to_noun(r)
         |> Nock.Jam.jam()
       end)
-      |> Enum.map(&Base.encode64/1)
 
     %UnspentResources.Response{unspent_resources: resources}
   end

--- a/apps/anoma_node/lib/node/transport/grpc/indexer.ex
+++ b/apps/anoma_node/lib/node/transport/grpc/indexer.ex
@@ -14,9 +14,7 @@ defmodule Anoma.Node.Transport.GRPC.Servers.Indexer do
   def list_nullifiers(request, _stream) do
     Logger.debug("GRPC #{inspect(__ENV__.function)}: #{inspect(request)}")
 
-    nullifiers =
-      Indexer.get(request.node_info.node_id, :nlfs)
-      |> Enum.map(&Base.encode64/1)
+    nullifiers = Indexer.get(request.node_info.node_id, :nlfs)
 
     %Nullifiers.Response{nullifiers: nullifiers}
   end
@@ -26,9 +24,7 @@ defmodule Anoma.Node.Transport.GRPC.Servers.Indexer do
   def list_unrevealed_commits(request, _stream) do
     Logger.debug("GRPC #{inspect(__ENV__.function)}: #{inspect(request)}")
 
-    unrevealed =
-      Indexer.get(request.node_info.node_id, :unrevealed)
-      |> Enum.map(&Base.encode64/1)
+    unrevealed = Indexer.get(request.node_info.node_id, :unrevealed)
 
     %UnrevealedCommits.Response{commits: unrevealed}
   end

--- a/apps/anoma_protobuf/priv/protobuf/indexer/nullifiers.proto
+++ b/apps/anoma_protobuf/priv/protobuf/indexer/nullifiers.proto
@@ -7,5 +7,5 @@ import "node_info.proto";
 message Request { NodeInfo node_info = 1; }
 
 message Response {
-  repeated string nullifiers = 1; // a list of intents.
+  repeated bytes nullifiers = 1; // a list of intents.
 }

--- a/apps/anoma_protobuf/priv/protobuf/indexer/unrevealed_commits.proto
+++ b/apps/anoma_protobuf/priv/protobuf/indexer/unrevealed_commits.proto
@@ -7,5 +7,5 @@ import "node_info.proto";
 message Request { NodeInfo node_info = 1; }
 
 message Response {
-  repeated string commits = 1; // a list of intents.
+  repeated bytes commits = 1; // a list of intents.
 }

--- a/apps/anoma_protobuf/priv/protobuf/indexer/unspent_resources.proto
+++ b/apps/anoma_protobuf/priv/protobuf/indexer/unspent_resources.proto
@@ -7,5 +7,5 @@ import "node_info.proto";
 message Request { NodeInfo node_info = 1; }
 
 message Response {
-  repeated string unspent_resources = 1; // a list of intents.
+  repeated bytes unspent_resources = 1; // a list of intents.
 }


### PR DESCRIPTION
The indexer GRPC endpoint double base64 encoded its outputs. This fixes that.