### PR TITLE
Store client configurations

### DIFF
--- a/apps/anoma_client/lib/examples/e_client.ex
+++ b/apps/anoma_client/lib/examples/e_client.ex
@@ -115,6 +115,19 @@ defmodule Anoma.Client.Examples.EClient do
   end
 
   @doc """
+  I check that the last client config is readable.
+  """
+  @spec get_last_client_config() :: {:ok, map()} | {:error, :no_client_config}
+  def get_last_client_config() do
+    kill_existing_client()
+
+    create_example_client()
+
+    assert {:ok, %{"grpc_port" => _, "node_id" => _}} =
+             Client.get_last_client_config()
+  end
+
+  @doc """
   I create the setup necessary to run each example below without arguments.
   """
   @spec setup() :: EConnection.t()


### PR DESCRIPTION
I've been thinking about how to simplify the testing process described in [this issue](https://github.com/anoma/anoma/issues/1621). The idea is that when a client connects, it stores the port information in a temporary file, making it easily accessible to another application instance.

I'm not entirely sure if these functions fit within this module, but if you like the approach, I can relocate them to a more suitable module if needed.

Let me know if this is helpful, or if I might have misunderstood the issue.

We can also consider disabling it in prod env via config. 

---

Here is how it works:

```elixir
iex(1)> eclient = Anoma.Client.Examples.EClient.create_example_client()
%Anoma.Client.Examples.EClient{
  channel: nil,
  client: %Anoma.Client{
    grpc_port: 59755,
    supervisor: #PID<0.381.0>,
    type: :grpc
  },
  node: %Anoma.Node.Examples.ENode{
    grpc_port: 59753,
    tcp_ports: [],
    pid: #PID<0.332.0>,
    node_id: "94766831"
  },
  supervisor: nil
}
```

In another IEx:

```elixir
iex(1)> Anoma.Client.get_last_client_config()
{:ok, %{"grpc_port" => 59755, "node_id" => "94766831"}}
```
