### PR TITLE
remove duplicate tests from commitment tree

### DIFF
--- a/apps/anoma_lib/test/commitment_tree_test.exs
+++ b/apps/anoma_lib/test/commitment_tree_test.exs
@@ -7,14 +7,4 @@ defmodule CommitmentTreeTest do
     for: ECommitmentTree
 
   doctest CommitmentTree
-
-  test "cairo poseidon examples" do
-    cairo_spec = ECommitmentTree.cairo_poseidon_spec()
-    ECommitmentTree.memory_backed_ct(cairo_spec)
-    ECommitmentTree.empty_mnesia_backed_ct(cairo_spec)
-    ECommitmentTree.current_tree_mnesia_ct(cairo_spec)
-    ECommitmentTree.babylon_mnesia_ct(cairo_spec)
-    ECommitmentTree.current_tree_mnesia_ct(cairo_spec)
-    ECommitmentTree.lots_of_inserts_ct(cairo_spec)
-  end
 end


### PR DESCRIPTION
There were duplicate tests introduced. Basically they should have been removed when adding the examples macro.