### PR TITLE
Fix Reading From Incorrect Table At Root Check

### DIFF
--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -242,14 +242,12 @@ defmodule Anoma.Node.Transaction.Backends do
     latest_root_time =
       for root <- trans.roots, reduce: 0 do
         time ->
-          with {:atomic, [{_, height_list, ^root}]} <-
+          with {:atomic, [{_, {height, _}, ^root}]} <-
                  :mnesia.transaction(fn ->
                    :mnesia.match_object(
-                     {Storage.updates_table(node_id), root, :_}
+                     {Storage.values_table(node_id), {:_, :anchor}, root}
                    )
                  end) do
-            height = hd(height_list)
-
             if height > time do
               height
             else


### PR DESCRIPTION
Previously, we were not reading the proper table to get the times at which roots in a transaction were written.

Recall that the (bare) key we update is the anchor and not the root itself. Root is one of the value.