### PR TITLE
Remove an inspect from `apps/anoma_client/lib/api/mempool.ex`

### DIFF
--- a/apps/anoma_client/lib/api/mempool.ex
+++ b/apps/anoma_client/lib/api/mempool.ex
@@ -12,7 +12,6 @@ defmodule Anoma.Client.Api.Servers.Mempool do
   def add(request, _stream) do
     Logger.debug("GRPC #{inspect(__ENV__.function)}: #{inspect(request)}")
 
-    IO.inspect(request, label: "client")
     :ok = GRPCProxy.add_transaction(request.transaction)
 
     %AddTransaction.Response{}


### PR DESCRIPTION
There was an inspect, and now there is not.
