### PR TITLE
store cairo cipher texts

### DIFF
--- a/apps/anoma_lib/lib/anoma/cairo_resource/logic_instance.ex
+++ b/apps/anoma_lib/lib/anoma/cairo_resource/logic_instance.ex
@@ -62,11 +62,19 @@ defmodule Anoma.CairoResource.LogicInstance do
     }
   end
 
-  @spec decrypt(list(binary()), binary()) :: list(binary())
-  def decrypt(cihper, sk) do
-    cihper
-    |> Enum.map(&:binary.bin_to_list/1)
-    |> Cairo.decrypt(:binary.bin_to_list(sk))
-    |> Enum.map(&:binary.list_to_bin/1)
+  @spec decrypt(list(binary()), binary()) ::
+          {:ok, list(binary())} | {:error, term()}
+  def decrypt(cipher, sk) do
+    sk_bin_list = :binary.bin_to_list(sk)
+
+    case cipher
+         |> Enum.map(&:binary.bin_to_list/1)
+         |> Cairo.decrypt(sk_bin_list) do
+      {:error, reason} ->
+        {:error, reason}
+
+      plain_text ->
+        {:ok, plain_text |> Enum.map(&:binary.list_to_bin/1)}
+    end
   end
 end

--- a/apps/anoma_lib/lib/anoma/cairo_resource/shielded_transaction.ex
+++ b/apps/anoma_lib/lib/anoma/cairo_resource/shielded_transaction.ex
@@ -15,7 +15,6 @@ defmodule Anoma.CairoResource.Transaction do
   alias Anoma.CairoResource.Resource
   alias Anoma.CairoResource.Utils
   alias Anoma.CairoResource.Workflow
-  alias Anoma.Node.DummyStorage, as: Storage
 
   typedstruct enforce: true do
     # TODO: The roots, commitments, and nullifiers can be eliminated. We can
@@ -174,23 +173,6 @@ defmodule Anoma.CairoResource.Transaction do
     @spec verify_duplicate_nfs(Anoma.RM.Transaction.t()) :: boolean()
     defp verify_duplicate_nfs(tx) do
       Enum.uniq(tx.nullifiers) == tx.nullifiers
-    end
-
-    @impl true
-    def cm_tree(_tx, _storage) do
-      CommitmentTree.new(
-        CommitmentTree.Spec.cairo_poseidon_cm_tree_spec(),
-        nil
-      )
-    end
-
-    @impl true
-    def resource_existence_check(transaction, storage) do
-      for root <- transaction.roots, reduce: true do
-        acc ->
-          root_key = ["rm", "commitment_root", root]
-          acc && Storage.get(storage, root_key) == {:ok, true}
-      end
     end
 
     @spec get_binding_pub_keys(list(binary())) :: list(byte())
@@ -360,5 +342,13 @@ defmodule Anoma.CairoResource.Transaction do
     else
       {:error, x} -> {:error, x}
     end
+  end
+
+  @spec cm_tree() :: CommitmentTree.t()
+  def cm_tree() do
+    CommitmentTree.new(
+      CommitmentTree.Spec.cairo_poseidon_cm_tree_spec(),
+      nil
+    )
   end
 end

--- a/apps/anoma_lib/lib/anoma/cairo_resource/shielded_transaction.ex
+++ b/apps/anoma_lib/lib/anoma/cairo_resource/shielded_transaction.ex
@@ -9,12 +9,16 @@ defmodule Anoma.CairoResource.Transaction do
 
   alias __MODULE__
   use TypedStruct
-  alias Anoma.CairoResource.Action
-  alias Anoma.CairoResource.ComplianceInstance
-  alias Anoma.CairoResource.ProofRecord
-  alias Anoma.CairoResource.Resource
-  alias Anoma.CairoResource.Utils
-  alias Anoma.CairoResource.Workflow
+
+  alias Anoma.CairoResource.{
+    Action,
+    ComplianceInstance,
+    ProofRecord,
+    Resource,
+    LogicInstance,
+    Utils,
+    Workflow
+  }
 
   typedstruct enforce: true do
     # TODO: The roots, commitments, and nullifiers can be eliminated. We can
@@ -362,5 +366,23 @@ defmodule Anoma.CairoResource.Transaction do
       CommitmentTree.Spec.cairo_poseidon_cm_tree_spec(),
       nil
     )
+  end
+
+  @doc """
+  Retrieves the cipher texts from the given transaction.
+
+  ## Parameters
+    - tx: A `Transaction` struct containing the transaction data.
+
+  ## Returns
+    - A list of tuples where each tuple contains a binary tag(commitment) and a cipher text(a list of binary).
+  """
+  @spec get_cipher_texts(Transaction.t()) ::
+          list(%{tag: binary(), cipher: list(binary())})
+  def get_cipher_texts(tx) do
+    tx.actions
+    |> Enum.flat_map(& &1.logic_proofs)
+    |> Enum.map(&LogicInstance.from_public_input(&1.public_inputs))
+    |> Enum.map(&%{tag: &1.tag, cipher: &1.cipher})
   end
 end

--- a/apps/anoma_lib/lib/anoma/constants.ex
+++ b/apps/anoma_lib/lib/anoma/constants.ex
@@ -25,4 +25,15 @@ defmodule Anoma.Constants do
       <<0, 243, 140, 176, 138, 18, 187, 241, 244, 57, 14, 171, 83, 197, 244,
         132, 155, 123, 124, 59, 152, 25, 9, 88, 193, 242, 178, 20, 246, 56,
         191, 55>>
+
+  @doc """
+  The default merkle root in cairo RM is used when the root set is empty and can
+  also serve as the root of ephemeral resources.
+  """
+  @spec default_cairo_rm_root() :: binary()
+  def default_cairo_rm_root,
+    do:
+      <<6, 124, 174, 248, 163, 2, 209, 70, 232, 31, 51, 44, 37, 217, 113, 131,
+        226, 238, 232, 60, 152, 133, 78, 133, 107, 15, 250, 211, 118, 207, 54,
+        121>>
 end

--- a/apps/anoma_lib/lib/anoma/rm/transaction.ex
+++ b/apps/anoma_lib/lib/anoma/rm/transaction.ex
@@ -28,12 +28,6 @@ defprotocol Anoma.RM.Transaction do
 
   @spec nullifiers(t()) :: list(binary())
   def nullifiers(transaction)
-
-  @spec cm_tree(t(), term()) :: CommitmentTree.t()
-  def cm_tree(transaction, storage)
-
-  @spec resource_existence_check(t(), pid()) :: boolean()
-  def resource_existence_check(transaction, storage)
 end
 
 defmodule Anoma.RM.Trans do

--- a/apps/anoma_lib/lib/anoma/rm/transaction.ex
+++ b/apps/anoma_lib/lib/anoma/rm/transaction.ex
@@ -14,7 +14,7 @@ defprotocol Anoma.RM.Transaction do
   @spec compose(t(), t()) :: t()
   def compose(tx1, tx2)
 
-  @spec verify(t()) :: boolean()
+  @spec verify(t()) :: true | {:error, String.t()}
   def verify(transaction)
 
   @spec storage_commitments(t()) :: list(binary())

--- a/apps/anoma_lib/lib/examples/e_cairo/e_compliance_witness.ex
+++ b/apps/anoma_lib/lib/examples/e_cairo/e_compliance_witness.ex
@@ -49,7 +49,7 @@ defmodule Examples.ECairo.EComplianceWitness do
   def a_compliance_private_input_for_intents() do
     input_nf_key = <<1::256>>
     rcv = <<3::256>>
-    eph_root = Cairo.random_felt() |> :binary.list_to_bin()
+    eph_root = Anoma.Constants.default_cairo_rm_root()
     {_ct, merkle_proof, _anchor} = ECommitmentTree.a_merkle_proof()
 
     compliance_private_input =

--- a/apps/anoma_lib/lib/examples/e_cairo/e_resource_logic.ex
+++ b/apps/anoma_lib/lib/examples/e_cairo/e_resource_logic.ex
@@ -17,7 +17,8 @@ defmodule Examples.ECairo.EResourceLogic do
 
     instance = res.public_inputs |> LogicInstance.from_public_input()
 
-    plaintext = LogicInstance.decrypt(instance.cipher, <<1::256>>)
+    assert {:ok, plaintext} =
+             LogicInstance.decrypt(instance.cipher, <<1::256>>)
 
     a_resource = EResource.a_fixed_resource()
 

--- a/apps/anoma_lib/lib/examples/e_cairo/e_transaction.ex
+++ b/apps/anoma_lib/lib/examples/e_cairo/e_transaction.ex
@@ -174,7 +174,8 @@ defmodule Examples.ECairo.ETransaction do
       Anoma.RM.Transaction.compose(shielded_tx_1, shielded_tx_2)
       |> Transaction.finalize()
 
-    assert false == Anoma.RM.Transaction.verify(composed_shielded_tx)
+    assert {:error, "Duplicate nullifiers error"} ==
+             Anoma.RM.Transaction.verify(composed_shielded_tx)
 
     composed_shielded_tx
   end
@@ -192,7 +193,8 @@ defmodule Examples.ECairo.ETransaction do
       }
       |> Transaction.finalize()
 
-    assert false == Anoma.RM.Transaction.verify(invalid_shielded_tx)
+    assert {:error, "Delta proof verification failure"} ==
+             Anoma.RM.Transaction.verify(invalid_shielded_tx)
 
     invalid_shielded_tx
   end

--- a/apps/anoma_lib/lib/examples/e_cairo/e_transaction.ex
+++ b/apps/anoma_lib/lib/examples/e_cairo/e_transaction.ex
@@ -1,5 +1,5 @@
 defmodule Examples.ECairo.ETransaction do
-  alias Anoma.CairoResource.Transaction
+  alias Anoma.CairoResource.{LogicInstance, Transaction}
   alias Examples.ECairo.EAction
 
   use TestHelper.TestMacro
@@ -197,5 +197,20 @@ defmodule Examples.ECairo.ETransaction do
              Anoma.RM.Transaction.verify(invalid_shielded_tx)
 
     invalid_shielded_tx
+  end
+
+  @spec shielded_transaction_cipher_texts() :: [
+          %{cipher: list(), tag: binary()}
+        ]
+  def shielded_transaction_cipher_texts(decryption_key \\ <<1::256>>) do
+    cipher_texts =
+      a_shielded_transaction_with_multiple_actions()
+      |> Transaction.get_cipher_texts()
+
+    for %{tag: _, cipher: c} <- cipher_texts do
+      assert {:ok, _} = LogicInstance.decrypt(c, decryption_key)
+    end
+
+    cipher_texts
   end
 end

--- a/apps/anoma_lib/lib/examples/ecommitment_tree.ex
+++ b/apps/anoma_lib/lib/examples/ecommitment_tree.ex
@@ -167,4 +167,21 @@ defmodule Examples.ECommitmentTree do
 
     {ct, merkle_proof, anchor}
   end
+
+  @doc """
+  A commitment tree with commits from Examples.ERM.EShielded.ETransaction.a_shielded_transaction/0
+  """
+  @spec memory_backed_ct_with_trivial_cairo_tx(term()) ::
+          {CommitmentTree.t(), binary()}
+  def memory_backed_ct_with_trivial_cairo_tx(spec \\ cairo_poseidon_spec()) do
+    tree = memory_backed_ct(spec)
+
+    output_resource_cm =
+      ECairo.EResource.a_fixed_output_resource()
+      |> Anoma.CairoResource.Resource.commitment()
+
+    {tree, anchor} = CommitmentTree.add(tree, [output_resource_cm])
+
+    {tree, anchor}
+  end
 end

--- a/apps/anoma_lib/lib/examples/ecommitment_tree.ex
+++ b/apps/anoma_lib/lib/examples/ecommitment_tree.ex
@@ -173,14 +173,13 @@ defmodule Examples.ECommitmentTree do
   """
   @spec memory_backed_ct_with_trivial_cairo_tx(term()) ::
           {CommitmentTree.t(), binary()}
-  def memory_backed_ct_with_trivial_cairo_tx(spec \\ cairo_poseidon_spec()) do
+  def memory_backed_ct_with_trivial_cairo_tx(
+        cms,
+        spec \\ cairo_poseidon_spec()
+      ) do
     tree = memory_backed_ct(spec)
 
-    output_resource_cm =
-      ECairo.EResource.a_fixed_output_resource()
-      |> Anoma.CairoResource.Resource.commitment()
-
-    {tree, anchor} = CommitmentTree.add(tree, [output_resource_cm])
+    {tree, anchor} = CommitmentTree.add(tree, cms)
 
     {tree, anchor}
   end

--- a/apps/anoma_node/lib/examples/e_shielded_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_shielded_transaction.ex
@@ -35,11 +35,20 @@ defmodule Anoma.Node.Examples.EShieldedTransaction do
         output_resource_cm
       ])
 
+    set_of_ciphertexts =
+      Examples.ECairo.ETransaction.a_shielded_transaction()
+      |> Anoma.CairoResource.Transaction.get_cipher_texts()
+      |> MapSet.new()
+
     assert {:ok,
             MapSet.new([Anoma.Constants.default_cairo_rm_root(), anchor])} ==
              Storage.read(node_id, {1, ["anoma", "cairo_roots"]})
 
     assert {:ok, tree} == Storage.read(node_id, {1, ["anoma", "cairo_ct"]})
+
+    assert {:ok, set_of_ciphertexts} ==
+             Storage.read(node_id, {1, ["anoma", "cairo_ciphertexts"]})
+
     EventBroker.unsubscribe_me([])
 
     node_id
@@ -50,6 +59,11 @@ defmodule Anoma.Node.Examples.EShieldedTransaction do
     ETransaction.start_tx_module(node_id)
 
     tx_w_backend = complex_cairo_transaction()
+
+    set_of_ciphertexts =
+      Examples.ECairo.ETransaction.a_shielded_transaction_with_multiple_actions()
+      |> Anoma.CairoResource.Transaction.get_cipher_texts()
+      |> MapSet.new()
 
     EventBroker.subscribe_me([])
 
@@ -67,6 +81,9 @@ defmodule Anoma.Node.Examples.EShieldedTransaction do
 
     assert {:ok, MapSet.new([input_nullifier_1, input_nullifier_2])} ==
              Storage.read(node_id, {1, ["anoma", "cairo_nullifiers"]})
+
+    assert {:ok, set_of_ciphertexts} ==
+             Storage.read(node_id, {1, ["anoma", "cairo_ciphertexts"]})
 
     output_cm_1 =
       ESResource.a_fixed_output_resource()
@@ -100,11 +117,21 @@ defmodule Anoma.Node.Examples.EShieldedTransaction do
 
     tx_w_backend_1 = trivial_cairo_transaction()
 
+    set_of_ciphertexts1 =
+      Examples.ECairo.ETransaction.a_shielded_transaction()
+      |> Anoma.CairoResource.Transaction.get_cipher_texts()
+      |> MapSet.new()
+
     EventBroker.subscribe_me([])
 
     Mempool.tx(node_id, tx_w_backend_1, "id 1")
 
     tx_w_backend_2 = trivial_cairo_intent_transaction()
+
+    set_of_ciphertexts2 =
+      Examples.ECairo.ETransaction.a_shielded_transaction_with_intents()
+      |> Anoma.CairoResource.Transaction.get_cipher_texts()
+      |> MapSet.new()
 
     Mempool.tx(node_id, tx_w_backend_2, "id 2")
     Mempool.execute(node_id, Mempool.tx_dump(node_id))
@@ -149,6 +176,13 @@ defmodule Anoma.Node.Examples.EShieldedTransaction do
              Storage.read(node_id, {2, ["anoma", "cairo_roots"]})
 
     assert {:ok, tree} == Storage.read(node_id, {2, ["anoma", "cairo_ct"]})
+
+    set_of_ciphertexts =
+      MapSet.union(set_of_ciphertexts1, set_of_ciphertexts2)
+
+    assert {:ok, set_of_ciphertexts} ==
+             Storage.read(node_id, {2, ["anoma", "cairo_ciphertexts"]})
+
     EventBroker.unsubscribe_me([])
 
     node_id

--- a/apps/anoma_node/lib/examples/e_shielded_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_shielded_transaction.ex
@@ -26,12 +26,17 @@ defmodule Anoma.Node.Examples.EShieldedTransaction do
     assert {:ok, MapSet.new([input_nullifier])} ==
              Storage.read(node_id, {1, ["anoma", "cairo_nullifiers"]})
 
+    output_resource_cm =
+      ESResource.a_fixed_output_resource()
+      |> Anoma.CairoResource.Resource.commitment()
+
     {tree, anchor} =
-      Examples.ECommitmentTree.memory_backed_ct_with_trivial_cairo_tx()
+      Examples.ECommitmentTree.memory_backed_ct_with_trivial_cairo_tx([
+        output_resource_cm
+      ])
 
-    {_ct, _merkle_proof, old_root} = Examples.ECommitmentTree.a_merkle_proof()
-
-    assert {:ok, MapSet.new([old_root, anchor])} ==
+    assert {:ok,
+            MapSet.new([Anoma.Constants.default_cairo_rm_root(), anchor])} ==
              Storage.read(node_id, {1, ["anoma", "cairo_roots"]})
 
     assert {:ok, tree} == Storage.read(node_id, {1, ["anoma", "cairo_ct"]})
@@ -40,9 +45,142 @@ defmodule Anoma.Node.Examples.EShieldedTransaction do
     node_id
   end
 
+  @spec submit_successful_complex_cairo_tx(String.t()) :: String.t()
+  def submit_successful_complex_cairo_tx(node_id \\ Node.example_random_id()) do
+    ETransaction.start_tx_module(node_id)
+
+    tx_w_backend = complex_cairo_transaction()
+
+    EventBroker.subscribe_me([])
+
+    Mempool.tx(node_id, tx_w_backend, "id 1")
+    Mempool.execute(node_id, Mempool.tx_dump(node_id))
+
+    ETransaction.recieve_round_event(node_id, 0)
+
+    # Generate the nf and cm from fixed resources
+    input_nullifier_1 = ESResource.a_resource_nullifier()
+
+    input_nullifier_2 =
+      ESResource.a_trivial_input_intent_resource()
+      |> Anoma.CairoResource.Resource.nullifier(<<1::256>>)
+
+    assert {:ok, MapSet.new([input_nullifier_1, input_nullifier_2])} ==
+             Storage.read(node_id, {1, ["anoma", "cairo_nullifiers"]})
+
+    output_cm_1 =
+      ESResource.a_fixed_output_resource()
+      |> Anoma.CairoResource.Resource.commitment()
+
+    output_cm_2 =
+      ESResource.a_trivial_output_intent_resource()
+      |> Anoma.CairoResource.Resource.commitment()
+
+    {tree, anchor} =
+      Examples.ECommitmentTree.memory_backed_ct_with_trivial_cairo_tx([
+        output_cm_1,
+        output_cm_2
+      ])
+
+    assert {:ok,
+            MapSet.new([Anoma.Constants.default_cairo_rm_root(), anchor])} ==
+             Storage.read(node_id, {1, ["anoma", "cairo_roots"]})
+
+    assert {:ok, tree} == Storage.read(node_id, {1, ["anoma", "cairo_ct"]})
+    EventBroker.unsubscribe_me([])
+
+    node_id
+  end
+
+  @spec submit_successful_multiple_cairo_txs(String.t()) :: String.t()
+  def submit_successful_multiple_cairo_txs(
+        node_id \\ Node.example_random_id()
+      ) do
+    ETransaction.start_tx_module(node_id)
+
+    tx_w_backend_1 = trivial_cairo_transaction()
+
+    EventBroker.subscribe_me([])
+
+    Mempool.tx(node_id, tx_w_backend_1, "id 1")
+
+    tx_w_backend_2 = trivial_cairo_intent_transaction()
+
+    Mempool.tx(node_id, tx_w_backend_2, "id 2")
+    Mempool.execute(node_id, Mempool.tx_dump(node_id))
+
+    ETransaction.recieve_round_event(node_id, 0)
+
+    # Generate the nf and cm from fixed resources
+    input_nullifier_1 = ESResource.a_resource_nullifier()
+
+    input_nullifier_2 =
+      ESResource.a_trivial_input_intent_resource()
+      |> Anoma.CairoResource.Resource.nullifier(<<1::256>>)
+
+    assert {:ok, MapSet.new([input_nullifier_1, input_nullifier_2])} ==
+             Storage.read(node_id, {2, ["anoma", "cairo_nullifiers"]})
+
+    output_cm_1 =
+      ESResource.a_fixed_output_resource()
+      |> Anoma.CairoResource.Resource.commitment()
+
+    output_cm_2 =
+      ESResource.a_trivial_output_intent_resource()
+      |> Anoma.CairoResource.Resource.commitment()
+
+    {_, anchor_1} =
+      Examples.ECommitmentTree.memory_backed_ct_with_trivial_cairo_tx([
+        output_cm_1
+      ])
+
+    {tree, anchor_2} =
+      Examples.ECommitmentTree.memory_backed_ct_with_trivial_cairo_tx([
+        output_cm_1,
+        output_cm_2
+      ])
+
+    assert {:ok,
+            MapSet.new([
+              Anoma.Constants.default_cairo_rm_root(),
+              anchor_1,
+              anchor_2
+            ])} ==
+             Storage.read(node_id, {2, ["anoma", "cairo_roots"]})
+
+    assert {:ok, tree} == Storage.read(node_id, {2, ["anoma", "cairo_ct"]})
+    EventBroker.unsubscribe_me([])
+
+    node_id
+  end
+
   @spec trivial_cairo_transaction() :: {Backends.backend(), Noun.t()}
   def trivial_cairo_transaction() do
     s_tx = Examples.ECairo.ETransaction.a_shielded_transaction()
+    noun = s_tx |> Noun.Nounable.to_noun()
+
+    assert Anoma.CairoResource.Transaction.from_noun(noun) == {:ok, s_tx}
+
+    {:cairo_resource, ENock.transparent_core(noun)}
+  end
+
+  @spec trivial_cairo_intent_transaction() :: {Backends.backend(), Noun.t()}
+  def trivial_cairo_intent_transaction() do
+    s_tx =
+      Examples.ECairo.ETransaction.a_shielded_transaction_with_intents()
+
+    noun = s_tx |> Noun.Nounable.to_noun()
+
+    assert Anoma.CairoResource.Transaction.from_noun(noun) == {:ok, s_tx}
+
+    {:cairo_resource, ENock.transparent_core(noun)}
+  end
+
+  @spec complex_cairo_transaction() :: {Backends.backend(), Noun.t()}
+  def complex_cairo_transaction() do
+    s_tx =
+      Examples.ECairo.ETransaction.a_shielded_transaction_with_multiple_actions()
+
     noun = s_tx |> Noun.Nounable.to_noun()
 
     assert Anoma.CairoResource.Transaction.from_noun(noun) == {:ok, s_tx}

--- a/apps/anoma_node/lib/examples/e_shielded_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_shielded_transaction.ex
@@ -1,0 +1,52 @@
+defmodule Anoma.Node.Examples.EShieldedTransaction do
+  alias Anoma.Node
+  alias Node.Transaction.{Storage, Mempool, Backends}
+  alias Examples.{ENock, ETransparent.ETransaction}
+  alias Examples.ECairo.EResource, as: ESResource
+  alias Anoma.Node.Examples.ETransaction
+  require ExUnit.Assertions
+  import ExUnit.Assertions
+
+  @spec submit_successful_trivial_cairo_tx(String.t()) :: String.t()
+  def submit_successful_trivial_cairo_tx(node_id \\ Node.example_random_id()) do
+    ETransaction.start_tx_module(node_id)
+
+    tx_w_backend = trivial_cairo_transaction()
+
+    EventBroker.subscribe_me([])
+
+    Mempool.tx(node_id, tx_w_backend, "id 1")
+    Mempool.execute(node_id, Mempool.tx_dump(node_id))
+
+    ETransaction.recieve_round_event(node_id, 0)
+
+    # Generate the nf and cm from fixed resources
+    input_nullifier = ESResource.a_resource_nullifier()
+
+    assert {:ok, MapSet.new([input_nullifier])} ==
+             Storage.read(node_id, {1, ["anoma", "cairo_nullifiers"]})
+
+    {tree, anchor} =
+      Examples.ECommitmentTree.memory_backed_ct_with_trivial_cairo_tx()
+
+    {_ct, _merkle_proof, old_root} = Examples.ECommitmentTree.a_merkle_proof()
+
+    assert {:ok, MapSet.new([old_root, anchor])} ==
+             Storage.read(node_id, {1, ["anoma", "cairo_roots"]})
+
+    assert {:ok, tree} == Storage.read(node_id, {1, ["anoma", "cairo_ct"]})
+    EventBroker.unsubscribe_me([])
+
+    node_id
+  end
+
+  @spec trivial_cairo_transaction() :: {Backends.backend(), Noun.t()}
+  def trivial_cairo_transaction() do
+    s_tx = Examples.ECairo.ETransaction.a_shielded_transaction()
+    noun = s_tx |> Noun.Nounable.to_noun()
+
+    assert Anoma.CairoResource.Transaction.from_noun(noun) == {:ok, s_tx}
+
+    {:cairo_resource, ENock.transparent_core(noun)}
+  end
+end

--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -623,7 +623,7 @@ defmodule Anoma.Node.Examples.ETransaction do
   end
 
   @spec recieve_round_event(String.t(), non_neg_integer()) :: :ok | :error_tx
-  defp recieve_round_event(node_id, round) do
+  def recieve_round_event(node_id, round) do
     receive do
       %EventBroker.Event{
         body: %Node.Event{

--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -414,8 +414,8 @@ defmodule Anoma.Node.Transaction.Backends do
   defp cairo_resource_tx(node_id, id, result) do
     with {:ok, tx} <- CTransaction.from_noun(result),
          true <- Anoma.RM.Transaction.verify(tx),
+         true <- root_existence_check(tx, node_id, id),
          # No need to check the commitment existence
-         # TODO: add the root check
          true <- nullifier_existence_check(tx, node_id, id) do
       ct =
         case Ordering.read(node_id, {id, :ct}) do
@@ -432,7 +432,8 @@ defmodule Anoma.Node.Transaction.Backends do
          %{
            append: [
              {:nullifiers, MapSet.new(tx.nullifiers)},
-             {:commitments, MapSet.new(tx.commitments)}
+             {:commitments, MapSet.new(tx.commitments)},
+             {:roots, MapSet.new([anchor])}
            ],
            write: [{:anchor, anchor}, {:ct, ct_new}]
          }}
@@ -470,6 +471,19 @@ defmodule Anoma.Node.Transaction.Backends do
       end
     else
       _ -> true
+    end
+  end
+
+  @spec root_existence_check(CTransaction.t(), String.t(), binary()) ::
+          true | {:error, String.t()}
+  def root_existence_check(transaction, node_id, id) do
+    with {:ok, stored_roots} <-
+           Ordering.read(node_id, {id, :roots}),
+         true <-
+           Enum.all?(transaction.roots, &MapSet.member?(stored_roots, &1)) do
+      true
+    else
+      _ -> {:error, "A submitted root dose not exist in storage"}
     end
   end
 

--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -442,18 +442,16 @@ defmodule Anoma.Node.Transaction.Backends do
 
       {:ok, tx}
     else
-      # TODO: handle errors, we should redesign Anoma.RM.Transaction interfaces
-      # e ->
-      #   unless e == :error do
-      #     Logging.log_event(
-      #       node_id,
-      #       :error,
-      #       "Transaction verification failed. Reason: #{inspect(e)}"
-      #     )
-      #   end
+      e ->
+        unless e == :error do
+          Logging.log_event(
+            node_id,
+            :error,
+            "Transaction verification failed. Reason: #{inspect(e)}"
+          )
+        end
 
-      #   :error
-      _ -> :error
+        :error
     end
   end
 

--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -457,6 +457,11 @@ defmodule Anoma.Node.Transaction.Backends do
          }}
       )
 
+      # Get ciphertext from tx
+      _ciphertext = CTransaction.get_cipher_texts(tx)
+
+      # TODO: Store ciphertext
+
       cairo_rm_event(
         MapSet.new(tx.commitments),
         MapSet.new(tx.nullifiers),

--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -445,13 +445,17 @@ defmodule Anoma.Node.Transaction.Backends do
       {ct_new, anchor} =
         CommitmentTree.add(ct, tx.commitments)
 
+      ciphertexts = tx |> CTransaction.get_cipher_texts() |> MapSet.new()
+
       Ordering.add(
         node_id,
         {id,
          %{
            append: [
              {anoma_keyspace("cairo_nullifiers"), MapSet.new(tx.nullifiers)},
-             {anoma_keyspace("cairo_roots"), MapSet.put(append_roots, anchor)}
+             {anoma_keyspace("cairo_roots"),
+              MapSet.put(append_roots, anchor)},
+             {anoma_keyspace("cairo_ciphertexts"), ciphertexts}
            ],
            write: [{anoma_keyspace("cairo_ct"), ct_new}]
          }}

--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -438,7 +438,7 @@ defmodule Anoma.Node.Transaction.Backends do
             {CTransaction.cm_tree(),
              MapSet.new([Anoma.Constants.default_cairo_rm_root()])}
 
-          val ->
+          {:ok, val} ->
             {val, MapSet.new()}
         end
 
@@ -503,7 +503,7 @@ defmodule Anoma.Node.Transaction.Backends do
     stored_roots =
       case Ordering.read(node_id, {id, anoma_keyspace("cairo_roots")}) do
         :absent -> MapSet.new([Anoma.Constants.default_cairo_rm_root()])
-        val -> val
+        {:ok, val} -> val
       end
 
     Enum.all?(transaction.roots, &MapSet.member?(stored_roots, &1)) or

--- a/apps/anoma_node/test/shielded_transaction_test.exs
+++ b/apps/anoma_node/test/shielded_transaction_test.exs
@@ -1,0 +1,8 @@
+defmodule ShieldedTransactionTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :zk
+
+  use TestHelper.GenerateExampleTests,
+    for: Anoma.Node.Examples.EShieldedTransaction
+end

--- a/apps/anoma_node/test/test_helper.exs
+++ b/apps/anoma_node/test/test_helper.exs
@@ -1,4 +1,4 @@
-ExUnit.start()
+ExUnit.start(exclude: [:zk])
 
 # the ets table for created nodes is used by all test modules that use
 # an example node.

--- a/apps/anoma_node/test/transaction_test.exs
+++ b/apps/anoma_node/test/transaction_test.exs
@@ -1,7 +1,4 @@
 defmodule TransactionTest do
   use ExUnit.Case, async: true
   use TestHelper.GenerateExampleTests, for: Anoma.Node.Examples.ETransaction
-
-  use TestHelper.GenerateExampleTests,
-    for: Anoma.Node.Examples.EShieldedTransaction
 end

--- a/apps/anoma_node/test/transaction_test.exs
+++ b/apps/anoma_node/test/transaction_test.exs
@@ -1,4 +1,7 @@
 defmodule TransactionTest do
   use ExUnit.Case, async: true
   use TestHelper.GenerateExampleTests, for: Anoma.Node.Examples.ETransaction
+
+  use TestHelper.GenerateExampleTests,
+    for: Anoma.Node.Examples.EShieldedTransaction
 end


### PR DESCRIPTION
based on #1562
to solve #1675 

@agureev 
I've added an API to get ciphertexts from Cairo transactions. As discussed, could you help store the ciphertexts and provide an API for users to fetch them. I left a TODO [here](https://github.com/anoma/anoma/blob/dc3ea16777cab670cc2f766b79ecce42766d9ca6/apps/anoma_node/lib/node/transaction/backends.ex#L455) in the cairo backend. 