### PR TITLE
Fix/err

### DIFF
--- a/apps/anoma_client/lib/client/client_connection/connection.ex
+++ b/apps/anoma_client/lib/client/client_connection/connection.ex
@@ -94,7 +94,7 @@ defmodule Anoma.Client.Connection.TCP do
   end
 
   # @doc """
-  # I reply to a message that was sent previoulsy.
+  # I reply to a message that was sent previously.
   # """
   def handle_cast({:reply_to, ref, message}, state) do
     case Map.pop(state.callers, ref) do

--- a/apps/compile_protoc/lib/mix/tasks/compile/protoc.ex
+++ b/apps/compile_protoc/lib/mix/tasks/compile/protoc.ex
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.Compile.Protoc do
     target_path = compiler_opts[:elixir_out]
 
     if forced? or source_updated?(source_path, target_path) do
-      Mix.shell().info("Compling protobuf files")
+      Mix.shell().info("Compiling protobuf files")
 
       cleanup_targets(target_path)
 


### PR DESCRIPTION
# Fix: Corrected typos in source files

## Changes
- `apps/compile_protoc/lib/mix/tasks/compile/protoc.ex:23`: "Compling" corrected to "Compiling".
- `apps/anoma_client/lib/client/client_connection/connection.ex:97`: "previoulsy" corrected to "previously".

## Purpose
- Ensured accuracy and professionalism in code comments and identifiers.
