### PR TITLE
Don't crash when invalid intent is passed to Intents.verify

### DIFF
--- a/apps/anoma_client/lib/api/intents.ex
+++ b/apps/anoma_client/lib/api/intents.ex
@@ -78,5 +78,12 @@ defmodule Anoma.Client.Api.Servers.Intents do
       end
 
     %Verify.Response{valid: bool}
+  rescue
+    _ in Noun.Jam.CueError ->
+      Logger.debug(
+        "GRPC #{inspect(__ENV__.function)}: #{inspect(request)} - CueError"
+      )
+
+      %Verify.Response{valid: false}
   end
 end

--- a/apps/anoma_client/lib/examples/e_client.ex
+++ b/apps/anoma_client/lib/examples/e_client.ex
@@ -237,6 +237,19 @@ defmodule Anoma.Client.Examples.EClient do
     reply.valid
   end
 
+  @spec verify_intent_with_invalid_intent(EConnection.t()) :: EConnection.t()
+  def verify_intent_with_invalid_intent(conn \\ setup()) do
+    intent = %Intent{intent: "invalid"}
+
+    node_id = %NodeInfo{node_id: conn.client.node.node_id}
+    request = %Verify.Request{node_info: node_id, intent: intent}
+    {:ok, reply} = IntentsService.Stub.verify(conn.channel, request)
+
+    refute reply.valid
+
+    conn
+  end
+
   @doc """
   I list all nullifiers.
   """


### PR DESCRIPTION
Reproduced and fixed the issue described in https://github.com/anoma/anoma/issues/1676.

With the fix, `Anoma.Protobuf.IntentsService.Verify` with invalid intent does not crash.