### PR TITLE
Tag Tests Using Juvix-Compiled Code

### DIFF
--- a/apps/anoma_client/test/prove_test.exs
+++ b/apps/anoma_client/test/prove_test.exs
@@ -1,6 +1,8 @@
 defmodule ProveTEst do
   use ExUnit.Case
 
+  @moduletag :juvix
+
   use TestHelper.GenerateExampleTests,
     for: Anoma.Client.Examples.EProve
 end

--- a/apps/anoma_client/test/test_helper.exs
+++ b/apps/anoma_client/test/test_helper.exs
@@ -1,4 +1,4 @@
-ExUnit.start()
+ExUnit.start(exclude: [:juvix])
 
 # the ets table for created nodes is used by all test modules that use
 # an example node.


### PR DESCRIPTION
Some of the tests use actual Juvix-compiled code. This can break for several reasons and hence should be usually skipped.

They need to remain, however, so that we can update the files once Juvix compilation comes in-sync with Node.