### PR TITLE
docs: Fix typo in terminology section Update git.livemd

### DIFF
--- a/documentation/contributing/git.livemd
+++ b/documentation/contributing/git.livemd
@@ -52,7 +52,7 @@ This document is best viewed from within liveview, as the charts do not render o
 * `next` - a branch that has a superset of features that will be
   included in the next release
 
-* `maint` - a maintnance branch that will be updated if bugs are found
+* `maint` - a maintenance branch that will be updated if bugs are found
 
 * `integreation branch` - a topic that merges a bunch of other topics
 


### PR DESCRIPTION
Hi team,  

While reading through the Git documentation, I noticed a small typo in the **Terminology** section.
The word "maintnance" was used instead of "**maintenance**" to describe the `maint` branch.  

I've corrected this to ensure clarity and consistency.

Best regards,  
**famouswizard**