### PR TITLE
Fix Testnet Random Seed Usage

### DIFF
--- a/apps/anoma_node/lib/examples/e_indexer.ex
+++ b/apps/anoma_node/lib/examples/e_indexer.ex
@@ -34,8 +34,14 @@ defmodule Anoma.Node.Examples.EIndexer do
     updates = Storage.updates_table(node_id)
     values = Storage.values_table(node_id)
 
-    nlf1 = %Resource{rseed: "random1"} |> Resource.nullifier()
-    nlf2 = %Resource{rseed: "random2"} |> Resource.nullifier()
+    nlf1 =
+      %Resource{nonce: :crypto.hash(:sha256, "random1")}
+      |> Resource.nullifier()
+
+    nlf2 =
+      %Resource{nonce: :crypto.hash(:sha256, "random2")}
+      |> Resource.nullifier()
+
     set = MapSet.new([nlf1, nlf2])
 
     write_new(updates, values, [1], set, nil)
@@ -51,8 +57,14 @@ defmodule Anoma.Node.Examples.EIndexer do
     updates = Storage.updates_table(node_id)
     values = Storage.values_table(node_id)
 
-    resource1 = %Resource{rseed: "random1"} |> Resource.nullifier()
-    resource2 = %Resource{rseed: "random2"} |> Resource.nullifier()
+    resource1 =
+      %Resource{nonce: :crypto.hash(:sha256, "random1")}
+      |> Resource.nullifier()
+
+    resource2 =
+      %Resource{nonce: :crypto.hash(:sha256, "random2")}
+      |> Resource.nullifier()
+
     set = MapSet.new([resource1, resource2])
 
     write_new(updates, values, [1], nil, set)
@@ -68,7 +80,7 @@ defmodule Anoma.Node.Examples.EIndexer do
     updates = Storage.updates_table(node_id)
     values = Storage.values_table(node_id)
 
-    resource = %Resource{rseed: "random1"}
+    resource = %Resource{nonce: :crypto.hash(:sha256, "random1")}
     nul1 = resource |> Resource.nullifier()
     com1 = resource |> Resource.commitment()
     nulfs = MapSet.new([nul1])
@@ -88,10 +100,14 @@ defmodule Anoma.Node.Examples.EIndexer do
     updates = Storage.updates_table(node_id)
     values = Storage.values_table(node_id)
 
-    resource = %Resource{rseed: "random1"}
+    resource = %Resource{nonce: :crypto.hash(:sha256, "random1")}
     nul1 = resource |> Resource.nullifier()
     com1 = resource |> Resource.commitment()
-    com2 = %Resource{rseed: "random2"} |> Resource.commitment()
+
+    com2 =
+      %Resource{nonce: :crypto.hash(:sha256, "random2")}
+      |> Resource.commitment()
+
     nulfs = MapSet.new([nul1])
     coms = MapSet.new([com1, com2])
 


### PR DESCRIPTION
Used random seed field in the examples. Should be kept a fake field for TRM