### PR TITLE
Use a Map for logic_proofs in the cairo action struct

### DIFF
--- a/apps/anoma_lib/lib/anoma/cairo_resource/action.ex
+++ b/apps/anoma_lib/lib/anoma/cairo_resource/action.ex
@@ -20,8 +20,21 @@ defmodule Anoma.CairoResource.Action do
   alias Anoma.Constants
 
   typedstruct enforce: true do
-    field(:logic_proofs, list(ProofRecord.t()), default: [])
+    field(:logic_proofs, %{binary() => ProofRecord.t()}, default: {})
     field(:compliance_proofs, list(ProofRecord.t()), default: [])
+  end
+
+  @spec new(list(ProofRecord.t()), list(ProofRecord.t())) :: t()
+  def new(logic_proofs, compliance_proofs) do
+    logic_proof_map =
+      Enum.into(logic_proofs, %{}, fn proof ->
+        {proof.public_inputs |> LogicInstance.get_tag(), proof}
+      end)
+
+    %Action{
+      logic_proofs: logic_proof_map,
+      compliance_proofs: compliance_proofs
+    }
   end
 
   @spec from_noun(Noun.t()) :: {:ok, t()} | :error
@@ -36,14 +49,21 @@ defmodule Anoma.CairoResource.Action do
     end
 
     logic = to_noun_list.(logic_proofs)
-    compilance = to_noun_list.(compliance_proofs)
-    checked = Enum.all?(logic ++ compilance, &(elem(&1, 0) == :ok))
+    compliance = to_noun_list.(compliance_proofs)
+    checked = Enum.all?(logic ++ compliance, &(elem(&1, 0) == :ok))
+
+    compliance_list = Enum.map(compliance, &elem(&1, 1))
+
+    logic_map =
+      Enum.into(logic, %{}, fn {:ok, proof} ->
+        {proof.public_inputs |> LogicInstance.get_tag(), proof}
+      end)
 
     with true <- checked do
       {:ok,
        %Action{
-         logic_proofs: Enum.map(logic, &elem(&1, 1)),
-         compliance_proofs: Enum.map(compilance, &elem(&1, 1))
+         logic_proofs: logic_map,
+         compliance_proofs: compliance_list
        }}
     else
       false -> :error
@@ -52,7 +72,8 @@ defmodule Anoma.CairoResource.Action do
 
   @spec verify(t()) :: boolean()
   def verify(action) do
-    with true <- verify_proofs(action.logic_proofs),
+    with true <-
+           verify_proofs(action.logic_proofs |> Map.values(), "logic result"),
          true <-
            verify_proofs(
              action.compliance_proofs,
@@ -62,7 +83,7 @@ defmodule Anoma.CairoResource.Action do
       # Decode logic_instances from resource logics
       logic_instances =
         action.logic_proofs
-        |> Enum.map(fn proof_record ->
+        |> Enum.map(fn {_tag, proof_record} ->
           proof_record.public_inputs
           |> LogicInstance.from_public_input()
         end)
@@ -76,7 +97,7 @@ defmodule Anoma.CairoResource.Action do
         end)
 
       # Get self ids from logic_instances
-      self_ids = Enum.map(logic_instances, & &1.tag)
+      self_ids = MapSet.new(logic_instances, & &1.tag)
 
       # Get cms and nfs from compliance_proofs
       resource_tree_leaves =
@@ -86,7 +107,7 @@ defmodule Anoma.CairoResource.Action do
         end)
 
       # check self resource are all involved
-      all_resource_valid = self_ids == resource_tree_leaves
+      all_resource_valid = self_ids == resource_tree_leaves |> MapSet.new()
 
       # Compute the expected resource tree
       rt =
@@ -110,13 +131,11 @@ defmodule Anoma.CairoResource.Action do
   end
 
   @spec verify_proofs(list(ProofRecord.t()), binary() | nil) :: boolean()
-  defp verify_proofs(proofs, debug_msg \\ nil) do
+  defp verify_proofs(proofs, debug_msg) do
     Enum.reduce_while(proofs, true, fn proof_record, _acc ->
       res = ProofRecord.verify(proof_record)
 
-      if debug_msg do
-        Logger.debug("#{debug_msg}: #{inspect(res)}")
-      end
+      Logger.debug("#{debug_msg}: #{inspect(res)}")
 
       case res do
         true -> {:cont, true}
@@ -138,7 +157,10 @@ defmodule Anoma.CairoResource.Action do
   defimpl Noun.Nounable, for: __MODULE__ do
     @impl true
     def to_noun(action = %Action{}) do
-      {action.logic_proofs, action.compliance_proofs}
+      {
+        action.logic_proofs |> Map.values(),
+        action.compliance_proofs
+      }
       |> Noun.Nounable.to_noun()
     end
   end

--- a/apps/anoma_lib/lib/anoma/cairo_resource/logic_instance.ex
+++ b/apps/anoma_lib/lib/anoma/cairo_resource/logic_instance.ex
@@ -62,6 +62,15 @@ defmodule Anoma.CairoResource.LogicInstance do
     }
   end
 
+  @spec get_tag(binary()) :: binary()
+  def get_tag(public_input) do
+    public_input
+    |> :binary.bin_to_list()
+    |> Cairo.get_output()
+    |> hd()
+    |> :binary.list_to_bin()
+  end
+
   @spec decrypt(list(binary()), binary()) ::
           {:ok, list(binary())} | {:error, term()}
   def decrypt(cipher, sk) do

--- a/apps/anoma_lib/lib/anoma/cairo_resource/logic_instance.ex
+++ b/apps/anoma_lib/lib/anoma/cairo_resource/logic_instance.ex
@@ -71,6 +71,16 @@ defmodule Anoma.CairoResource.LogicInstance do
     |> :binary.list_to_bin()
   end
 
+  @spec get_root(binary()) :: binary()
+  def get_root(public_input) do
+    public_input
+    |> :binary.bin_to_list()
+    |> Cairo.get_output()
+    |> tl()
+    |> hd()
+    |> :binary.list_to_bin()
+  end
+
   @spec decrypt(list(binary()), binary()) ::
           {:ok, list(binary())} | {:error, term()}
   def decrypt(cipher, sk) do

--- a/apps/anoma_lib/lib/anoma/cairo_resource/shielded_transaction.ex
+++ b/apps/anoma_lib/lib/anoma/cairo_resource/shielded_transaction.ex
@@ -171,6 +171,7 @@ defmodule Anoma.CairoResource.Transaction do
         tx.actions
         |> Enum.flat_map(fn action ->
           action.logic_proofs
+          |> Map.values()
           |> Enum.map(&ProofRecord.get_cairo_program_hash/1)
         end)
 
@@ -382,7 +383,10 @@ defmodule Anoma.CairoResource.Transaction do
   def get_cipher_texts(tx) do
     tx.actions
     |> Enum.flat_map(& &1.logic_proofs)
-    |> Enum.map(&LogicInstance.from_public_input(&1.public_inputs))
+    |> Enum.map(fn {_tag, proof_record} ->
+      proof_record.public_inputs
+      |> LogicInstance.from_public_input()
+    end)
     |> Enum.map(&%{tag: &1.tag, cipher: &1.cipher})
   end
 end

--- a/apps/anoma_lib/lib/anoma/cairo_resource/workflow.ex
+++ b/apps/anoma_lib/lib/anoma/cairo_resource/workflow.ex
@@ -330,12 +330,10 @@ defmodule Anoma.CairoResource.Workflow do
         compliance_proofs
       ) do
     Action.new(
-      Enum.zip_with(
+      Enum.concat(
         input_logic_proofs,
-        output_logic_proofs,
-        &[&1, &2]
-      )
-      |> Enum.concat(),
+        output_logic_proofs
+      ),
       compliance_proofs
     )
   end

--- a/apps/anoma_lib/lib/anoma/cairo_resource/workflow.ex
+++ b/apps/anoma_lib/lib/anoma/cairo_resource/workflow.ex
@@ -329,16 +329,15 @@ defmodule Anoma.CairoResource.Workflow do
         output_logic_proofs,
         compliance_proofs
       ) do
-    %Action{
-      logic_proofs:
-        Enum.zip_with(
-          input_logic_proofs,
-          output_logic_proofs,
-          &[&1, &2]
-        )
-        |> Enum.concat(),
-      compliance_proofs: compliance_proofs
-    }
+    Action.new(
+      Enum.zip_with(
+        input_logic_proofs,
+        output_logic_proofs,
+        &[&1, &2]
+      )
+      |> Enum.concat(),
+      compliance_proofs
+    )
   end
 
   @spec create_private_keys(list(Jason.OrderedObject.t())) ::

--- a/apps/anoma_lib/lib/examples/e_cairo/e_action.ex
+++ b/apps/anoma_lib/lib/examples/e_cairo/e_action.ex
@@ -107,8 +107,8 @@ defmodule Examples.ECairo.EAction do
       Action.new(
         [
           input_resource_logic_proof_1,
-          output_resource_logic_proof_1,
           input_resource_logic_proof_2,
+          output_resource_logic_proof_1,
           output_resource_logic_proof_2
         ],
         [compliance_unit_1, compliance_unit_2]

--- a/apps/anoma_lib/lib/examples/e_cairo/e_action.ex
+++ b/apps/anoma_lib/lib/examples/e_cairo/e_action.ex
@@ -16,10 +16,8 @@ defmodule Examples.ECairo.EAction do
     input_resource_logic = EResourceLogic.a_input_resource_logic()
     output_resource_logic = EResourceLogic.a_output_resource_logic()
 
-    action = %Action{
-      logic_proofs: [input_resource_logic, output_resource_logic],
-      compliance_proofs: [proof]
-    }
+    action =
+      Action.new([input_resource_logic, output_resource_logic], [proof])
 
     assert Action.verify(action)
 
@@ -32,10 +30,8 @@ defmodule Examples.ECairo.EAction do
     input_resource_logic = EResourceLogic.an_input_intent_resource_logic()
     output_resource_logic = EResourceLogic.an_output_intent_resource_logic()
 
-    action = %Action{
-      logic_proofs: [input_resource_logic, output_resource_logic],
-      compliance_proofs: [proof]
-    }
+    action =
+      Action.new([input_resource_logic, output_resource_logic], [proof])
 
     assert Action.verify(action)
 
@@ -107,15 +103,16 @@ defmodule Examples.ECairo.EAction do
         output_resource_path_2
       )
 
-    action = %Action{
-      logic_proofs: [
-        input_resource_logic_proof_1,
-        output_resource_logic_proof_1,
-        input_resource_logic_proof_2,
-        output_resource_logic_proof_2
-      ],
-      compliance_proofs: [compliance_unit_1, compliance_unit_2]
-    }
+    action =
+      Action.new(
+        [
+          input_resource_logic_proof_1,
+          output_resource_logic_proof_1,
+          input_resource_logic_proof_2,
+          output_resource_logic_proof_2
+        ],
+        [compliance_unit_1, compliance_unit_2]
+      )
 
     assert Action.verify(action)
 


### PR DESCRIPTION
We no longer need to worry about the specific order of logic proofs in the Cairo action by using a Map, as it simplifies checks in actions and transactions. This change is already included in the latest Spec.

close #1646 
based on #1654 