### PR TITLE
Implement Proper FIFO Execution for Devnet

### DIFF
--- a/apps/anoma_node/lib/examples/e_consensus.ex
+++ b/apps/anoma_node/lib/examples/e_consensus.ex
@@ -41,8 +41,6 @@ defmodule Anoma.Node.Examples.EConsensus do
 
     {:ok, _} = Consensus.start_link(node_id: node_id, interval: 500)
 
-    Mempool.tx(node_id, ETransaction.zero(), "id 1")
-
     assert_receive(
       %EventBroker.Event{
         body: %Node.Event{
@@ -66,6 +64,8 @@ defmodule Anoma.Node.Examples.EConsensus do
       },
       5000
     )
+
+    Mempool.tx(node_id, ETransaction.zero(), "id 1")
 
     assert_receive(
       %EventBroker.Event{

--- a/apps/anoma_node/lib/node/transaction/mempool.ex
+++ b/apps/anoma_node/lib/node/transaction/mempool.ex
@@ -266,7 +266,7 @@ defmodule Anoma.Node.Transaction.Mempool do
   I am a function to dump transactions.
 
   Given a node ID, I give all the transactions as currently stored in the
-  corresponding Mempool state.
+  corresponding Mempool state in the order in which they were submitted.
   """
 
   @spec tx_dump(String.t()) :: [Mempool.Tx.t()]
@@ -356,7 +356,7 @@ defmodule Anoma.Node.Transaction.Mempool do
 
   @impl true
   def handle_call(:dump, _from, state) do
-    {:reply, state.transactions |> Map.keys(), state}
+    {:reply, state.id_order |> Enum.reverse(), state}
   end
 
   def handle_call(_, _, state) do

--- a/apps/anoma_node/lib/node/utility/consensus.ex
+++ b/apps/anoma_node/lib/node/utility/consensus.ex
@@ -79,7 +79,7 @@ defmodule Anoma.Node.Utility.Consensus do
 
   def execute(node_id, interval) do
     {consensus, _} =
-      Mempool.tx_dump(node_id) |> Enum.reverse() |> Enum.split(10)
+      Mempool.tx_dump(node_id) |> Enum.split(10)
 
     Mempool.execute(node_id, consensus)
 


### PR DESCRIPTION
Add a mempool field to keep track of the proper order in which transactions have been received.

Make Consensus use the properly ordered information for automatic execution.