### PR TITLE
intent pool: use Event.t() in spec

### DIFF
--- a/apps/anoma_node/lib/node/intents/intent_pool.ex
+++ b/apps/anoma_node/lib/node/intents/intent_pool.ex
@@ -270,7 +270,7 @@ defmodule Anoma.Node.Intents.IntentPool do
     end
   end
 
-  @spec handle_new_state(t(), %EventBroker.Event{}) :: t()
+  @spec handle_new_state(t(), EventBroker.Event.t()) :: t()
   defp handle_new_state(state, %EventBroker.Event{
          body: %Node.Event{
            body: %Backends.TRMEvent{


### PR DESCRIPTION
Address a credo warning about using the struct rather than t().
