### PR TITLE
ci: don't run release workflow on special tags

### DIFF
--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -19,7 +19,7 @@ on:
   push:
     tags:
       - v*
-      - !v*-*
+      - '!v*-*'
 
 jobs:
   compile:

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -19,6 +19,7 @@ on:
   push:
     tags:
       - v*
+      - !v*-*
 
 jobs:
   compile:


### PR DESCRIPTION
i.e., those with a - in them somewhere.

we might want a separate workflow for these sometime, though.
