### PR TITLE
Fix Root Fix Check Merge

### DIFF
--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -362,7 +362,8 @@ defmodule Anoma.Node.Transaction.Backends do
           with {:atomic, [{_, {height, _}, ^root}]} <-
                  :mnesia.transaction(fn ->
                    :mnesia.match_object(
-                     {Storage.values_table(node_id), {:_, :anchor}, root}
+                     {Storage.values_table(node_id),
+                      {:_, anoma_keyspace("anchor")}, root}
                    )
                  end) do
             if height > time do


### PR DESCRIPTION
Original merge of the branch artem/bug-root-check-table was incorrect as it did not respect the reading at keyspaces instead of atoms introduced in parallel branches merged beforehand.

This fixes this, by reading the anchor at the anoma keyspace.