### PR TITLE
Change Jet Checks

### DIFF
--- a/apps/anoma_lib/lib/nock.ex
+++ b/apps/anoma_lib/lib/nock.ex
@@ -83,15 +83,12 @@ defmodule Nock do
 
           # a jet exists. mug the parent too
           {:ok,
-           {label, parent_axis, parent_mug, jet_function, jet_mode, cost}} ->
+           {label, parent_axis, parent_registry, jet_function, jet_mode, cost}} ->
             maybe_parent = Noun.axis(parent_axis, core)
 
             case maybe_parent do
               {:ok, parent} ->
-                try do
-                  # IO.inspect(Noun.mug(parent), label: "mugged parent")
-                  # elixir syntax for normal erlang =
-                  ^parent_mug = Noun.mug(parent)
+                if Noun.equal?(parent, parent_registry) do
                   # it's all there. use the jet.
                   # note: this is vastly simplified from a full jetting
                   # implementation. in particular, we are only jetting
@@ -138,10 +135,8 @@ defmodule Nock do
                         :error
                       end
                   end
-                rescue
-                  # parent mug didn't match. can't use the jet
-                  _ in MatchError ->
-                    nock(core, [2 | [[0 | 1] | [0 | axis]]], env)
+                else
+                  nock(core, [2 | [[0 | 1] | [0 | axis]]], env)
                 end
 
               # the parent didn't even exist, the jet is bogus

--- a/apps/anoma_lib/lib/nock/jets.ex
+++ b/apps/anoma_lib/lib/nock/jets.ex
@@ -68,10 +68,18 @@ defmodule Nock.Jets do
   """
   @spec calculate_mug_of_layer(non_neg_integer()) :: non_neg_integer()
   def calculate_mug_of_layer(layer) do
+    layer |> calculate_layer() |> Noun.mug()
+  end
+
+  @doc """
+  I get the layer based on its number.
+  """
+  @spec calculate_layer(non_neg_integer()) :: Noun.t()
+  def calculate_layer(layer) do
     context_axis = layer_offset(layer)
 
     with {:ok, context} <- Noun.axis(context_axis, Nock.Lib.rm_core()) do
-      mug(context)
+      context
     end
   end
 
@@ -107,13 +115,19 @@ defmodule Nock.Jets do
 
       > Nock.Jets.calculate_mug_of_param_layer(10, 4)
       11284470320276584209
-
-  For our standard library, so far only layer 4 is parameterized
   """
   def calculate_mug_of_param_layer(core_index, parent_layer) do
+    core_index |> calculate_param_layer(parent_layer) |> Noun.mug()
+  end
+
+  @doc """
+  I find the door cores, i.e. parametrized layers.
+  """
+  @spec calculate_param_layer(non_neg_integer(), non_neg_integer) :: Noun.t()
+  def calculate_param_layer(core_index, parent_layer) do
     with {:ok, core} <- calculate_core_param(core_index, 4, parent_layer),
          {:ok, parent} <- Noun.axis(14, core) do
-      Noun.mug(parent)
+      parent
     end
   end
 

--- a/apps/anoma_lib/lib/nock/jets/mugs.ex
+++ b/apps/anoma_lib/lib/nock/jets/mugs.ex
@@ -8,20 +8,20 @@ defmodule Nock.Jets.Mugs do
 
   alias Nock.Jets
 
-  @layer_1_context_mug Jets.calculate_mug_of_layer(1)
-  @layer_4_context_mug Jets.calculate_mug_of_layer(4)
-  @layer_5_context_mug Jets.calculate_mug_of_layer(5)
-  @layer_6_context_mug Jets.calculate_mug_of_layer(6)
-  @layer_7_context_mug Jets.calculate_mug_of_layer(7)
-  @layer_8_context_mug Jets.calculate_mug_of_layer(8)
-  @layer_9_context_mug Jets.calculate_mug_of_layer(9)
-  @layer_10_context_mug Jets.calculate_mug_of_layer(10)
-  @layer_4_block_context_mug Jets.calculate_mug_of_param_layer(10, 4)
-  @layer_10_in_context_mug Jets.calculate_mug_of_param_layer(21, 10)
-  @layer_11_in_context_mug Jets.calculate_mug_of_param_layer(21, 11)
+  @layer_1 Jets.calculate_layer(1)
+  @layer_4 Jets.calculate_layer(4)
+  @layer_5 Jets.calculate_layer(5)
+  @layer_6 Jets.calculate_layer(6)
+  @layer_7 Jets.calculate_layer(7)
+  @layer_8 Jets.calculate_layer(8)
+  @layer_9 Jets.calculate_layer(9)
+  @layer_10 Jets.calculate_layer(10)
+  @layer_4_block Jets.calculate_param_layer(10, 4)
+  @layer_10_in Jets.calculate_param_layer(21, 10)
+  @layer_11_in Jets.calculate_param_layer(21, 11)
 
   # always the topmost layer
-  @layer_rm_context_mug Jets.calculate_mug_of_layer(Nock.Lib.stdlib_layers())
+  @layer_rm Jets.calculate_layer(Nock.Lib.stdlib_layers())
 
   # hardcoded jet registry
   # valid statuses:
@@ -30,113 +30,109 @@ defmodule Nock.Jets.Mugs do
   # - :check, check that jet and naive produce the same result
   @jet_registry %{
     Jets.calculate_mug_of_core(342, 1) =>
-      {"dec", 7, @layer_1_context_mug, &Nock.Jets.dec/1, :enabled, 10},
+      {"dec", 7, @layer_1, &Nock.Jets.dec/1, :enabled, 10},
     Jets.calculate_mug_of_core(20, 1) =>
-      {"add", 7, @layer_1_context_mug, &Nock.Jets.add/1, :enabled, 10},
+      {"add", 7, @layer_1, &Nock.Jets.add/1, :enabled, 10},
     Jets.calculate_mug_of_core(47, 1) =>
-      {"sub", 7, @layer_1_context_mug, &Nock.Jets.sub/1, :enabled, 10},
+      {"sub", 7, @layer_1, &Nock.Jets.sub/1, :enabled, 10},
     Jets.calculate_mug_of_core(343, 1) =>
-      {"lth", 7, @layer_1_context_mug, &Nock.Jets.lth/1, :enabled, 10},
+      {"lth", 7, @layer_1, &Nock.Jets.lth/1, :enabled, 10},
     Jets.calculate_mug_of_core(84, 1) =>
-      {"lte", 7, @layer_1_context_mug, &Nock.Jets.lte/1, :enabled, 10},
+      {"lte", 7, @layer_1, &Nock.Jets.lte/1, :enabled, 10},
     Jets.calculate_mug_of_core(43, 1) =>
-      {"gth", 7, @layer_1_context_mug, &Nock.Jets.gth/1, :enabled, 10},
+      {"gth", 7, @layer_1, &Nock.Jets.gth/1, :enabled, 10},
     Jets.calculate_mug_of_core(22, 1) =>
-      {"gte", 7, @layer_1_context_mug, &Nock.Jets.gte/1, :enabled, 10},
+      {"gte", 7, @layer_1, &Nock.Jets.gte/1, :enabled, 10},
     Jets.calculate_mug_of_core(4, 1) =>
-      {"mul", 7, @layer_1_context_mug, &Nock.Jets.mul/1, :enabled, 10},
+      {"mul", 7, @layer_1, &Nock.Jets.mul/1, :enabled, 10},
     Jets.calculate_mug_of_core(170, 1) =>
-      {"div", 7, @layer_1_context_mug, &Nock.Jets.div/1, :enabled, 10},
+      {"div", 7, @layer_1, &Nock.Jets.div/1, :enabled, 10},
     Jets.calculate_mug_of_core(46, 1) =>
-      {"mod", 7, @layer_1_context_mug, &Nock.Jets.mod/1, :enabled, 10},
+      {"mod", 7, @layer_1, &Nock.Jets.mod/1, :enabled, 10},
     Jets.calculate_mug_of_core(4, 6) =>
-      {"verify", 7, @layer_6_context_mug, &Nock.Jets.verify/1, :enabled, 100},
+      {"verify", 7, @layer_6, &Nock.Jets.verify/1, :enabled, 100},
     Jets.calculate_mug_of_core(10, 6) =>
-      {"sign", 7, @layer_6_context_mug, &Nock.Jets.sign/1, :enabled, 100},
+      {"sign", 7, @layer_6, &Nock.Jets.sign/1, :enabled, 100},
     Jets.calculate_mug_of_core(22, 6) =>
-      {"verify-detatched", 7, @layer_6_context_mug,
-       &Nock.Jets.verify_detatched/1, :enabled, 100},
-    Jets.calculate_mug_of_core(23, 6) =>
-      {"sign-detatched", 7, @layer_6_context_mug, &Nock.Jets.sign_detatched/1,
+      {"verify-detatched", 7, @layer_6, &Nock.Jets.verify_detatched/1,
        :enabled, 100},
+    Jets.calculate_mug_of_core(23, 6) =>
+      {"sign-detatched", 7, @layer_6, &Nock.Jets.sign_detatched/1, :enabled,
+       100},
     Jets.calculate_mug_of_core(4, 4) =>
-      {"bex", 7, @layer_4_context_mug, &Nock.Jets.bex/1, :enabled, 20},
+      {"bex", 7, @layer_4, &Nock.Jets.bex/1, :enabled, 20},
     Jets.calculate_mug_of_core(4, 5) =>
-      {"mix", 7, @layer_5_context_mug, &Nock.Jets.mix/1, :enabled, 20},
+      {"mix", 7, @layer_5, &Nock.Jets.mix/1, :enabled, 20},
     Jets.calculate_mug_of_core(22, 5) =>
-      {"jam", 7, @layer_5_context_mug, &Nock.Jets.jam/1, :enabled, 50},
+      {"jam", 7, @layer_5, &Nock.Jets.jam/1, :enabled, 50},
     Jets.calculate_mug_of_core(94, 5) =>
-      {"cue", 7, @layer_5_context_mug, &Nock.Jets.cue/1, :enabled, 50},
+      {"cue", 7, @layer_5, &Nock.Jets.cue/1, :enabled, 50},
     Jets.calculate_mug_of_core(22, 7) =>
-      {"shax", 7, @layer_7_context_mug, &Nock.Jets.shax/1, :enabled, 100},
+      {"shax", 7, @layer_7, &Nock.Jets.shax/1, :enabled, 100},
     Jets.calculate_mug_of_param_core(190, 10, 4) =>
-      {"met", 14, @layer_4_block_context_mug, &Nock.Jets.met/1, :enabled, 20},
+      {"met", 14, @layer_4_block, &Nock.Jets.met/1, :enabled, 20},
     Jets.calculate_mug_of_param_core(367, 10, 4) =>
-      {"end", 14, @layer_4_block_context_mug, &Nock.Jets.nend/1, :enabled, 20},
+      {"end", 14, @layer_4_block, &Nock.Jets.nend/1, :enabled, 20},
     Jets.calculate_mug_of_param_core(90, 10, 4) =>
-      {"lsh", 14, @layer_4_block_context_mug, &Nock.Jets.lsh/1, :enabled, 20},
+      {"lsh", 14, @layer_4_block, &Nock.Jets.lsh/1, :enabled, 20},
     Jets.calculate_mug_of_param_core(767, 10, 4) =>
-      {"rsh", 14, @layer_4_block_context_mug, &Nock.Jets.rsh/1, :enabled, 20},
+      {"rsh", 14, @layer_4_block, &Nock.Jets.rsh/1, :enabled, 20},
     Jets.calculate_mug_of_core(1515, 8) =>
-      {"abs", 7, @layer_8_context_mug, &Nock.Jets.abs/1, :enabled, 30},
+      {"abs", 7, @layer_8, &Nock.Jets.abs/1, :enabled, 30},
     Jets.calculate_mug_of_core(759, 8) =>
-      {"dif", 7, @layer_8_context_mug, &Nock.Jets.dif/1, :enabled, 30},
+      {"dif", 7, @layer_8, &Nock.Jets.dif/1, :enabled, 30},
     Jets.calculate_mug_of_core(22, 8) =>
-      {"dul", 7, @layer_8_context_mug, &Nock.Jets.dul/1, :enabled, 30},
+      {"dul", 7, @layer_8, &Nock.Jets.dul/1, :enabled, 30},
     Jets.calculate_mug_of_core(190, 8) =>
-      {"fra", 7, @layer_8_context_mug, &Nock.Jets.fra/1, :enabled, 30},
+      {"fra", 7, @layer_8, &Nock.Jets.fra/1, :enabled, 30},
     Jets.calculate_mug_of_core(46, 8) =>
-      {"pro", 7, @layer_8_context_mug, &Nock.Jets.pro/1, :enabled, 30},
+      {"pro", 7, @layer_8, &Nock.Jets.pro/1, :enabled, 30},
     Jets.calculate_mug_of_core(1514, 8) =>
-      {"rem", 7, @layer_8_context_mug, &Nock.Jets.rem/1, :enabled, 30},
+      {"rem", 7, @layer_8, &Nock.Jets.rem/1, :enabled, 30},
     Jets.calculate_mug_of_core(4, 8) =>
-      {"sum", 7, @layer_8_context_mug, &Nock.Jets.sum/1, :enabled, 30},
+      {"sum", 7, @layer_8, &Nock.Jets.sum/1, :enabled, 30},
     Jets.calculate_mug_of_core(10, 8) =>
-      {"sun", 7, @layer_8_context_mug, &Nock.Jets.sun/1, :enabled, 30},
+      {"sun", 7, @layer_8, &Nock.Jets.sun/1, :enabled, 30},
     Jets.calculate_mug_of_core(188, 8) =>
-      {"syn", 7, @layer_8_context_mug, &Nock.Jets.syn/1, :enabled, 30},
+      {"syn", 7, @layer_8, &Nock.Jets.syn/1, :enabled, 30},
     Jets.calculate_mug_of_core(191, 8) =>
-      {"cmp", 7, @layer_8_context_mug, &Nock.Jets.cmp/1, :enabled, 30},
+      {"cmp", 7, @layer_8, &Nock.Jets.cmp/1, :enabled, 30},
     Jets.calculate_mug_of_core(189, 9) =>
-      {"mug", 7, @layer_9_context_mug, &Nock.Jets.nmug/1, :enabled, 50},
+      {"mug", 7, @layer_9, &Nock.Jets.nmug/1, :enabled, 50},
     Jets.calculate_mug_of_core(765, 9) =>
-      {"dor", 7, @layer_9_context_mug, &Nock.Jets.dor/1, :enabled, 30},
+      {"dor", 7, @layer_9, &Nock.Jets.dor/1, :enabled, 30},
     Jets.calculate_mug_of_core(190, 9) =>
-      {"gor", 7, @layer_9_context_mug, &Nock.Jets.gor/1, :enabled, 30},
+      {"gor", 7, @layer_9, &Nock.Jets.gor/1, :enabled, 30},
     Jets.calculate_mug_of_core(10, 9) =>
-      {"mor", 7, @layer_9_context_mug, &Nock.Jets.mor/1, :enabled, 30},
+      {"mor", 7, @layer_9, &Nock.Jets.mor/1, :enabled, 30},
     Jets.calculate_mug_of_core(22, 10) =>
-      {"silt", 7, @layer_10_context_mug, &Nock.Jets.silt/1, :enabled, 30},
+      {"silt", 7, @layer_10, &Nock.Jets.silt/1, :enabled, 30},
     Jets.calculate_mug_of_param_core(84, 21, 10) =>
-      {"put", 7, @layer_10_in_context_mug, &Nock.Jets.put/1, :enabled, 30},
+      {"put", 7, @layer_10_in, &Nock.Jets.put/1, :enabled, 30},
     Jets.calculate_mug_of_param_core(174, 21, 10) =>
-      {"uni", 7, @layer_10_in_context_mug, &Nock.Jets.uni/1, :enabled, 30},
+      {"uni", 7, @layer_10_in, &Nock.Jets.uni/1, :enabled, 30},
     Jets.calculate_mug_of_param_core(85, 21, 10) =>
-      {"int", 7, @layer_10_in_context_mug, &Nock.Jets.int/1, :enabled, 30},
+      {"int", 7, @layer_10_in, &Nock.Jets.int/1, :enabled, 30},
     Jets.calculate_mug_of_param_core(175, 21, 10) =>
-      {"dif", 7, @layer_10_in_context_mug, &Nock.Jets.sdif/1, :enabled, 30},
+      {"dif", 7, @layer_10_in, &Nock.Jets.sdif/1, :enabled, 30},
     Jets.calculate_mug_of_param_core(763, 21, 10) =>
-      {"duni", 7, @layer_10_in_context_mug, &Nock.Jets.duni/1, :enabled, 30},
+      {"duni", 7, @layer_10_in, &Nock.Jets.duni/1, :enabled, 30},
     Jets.calculate_mug_of_param_core(762, 21, 10) =>
-      {"has", 7, @layer_10_in_context_mug, &Nock.Jets.has/1, :enabled, 30},
+      {"has", 7, @layer_10_in, &Nock.Jets.has/1, :enabled, 30},
     Jets.calculate_mug_of_param_core(340, 21, 11) =>
-      {"put", 7, @layer_11_in_context_mug, &Nock.Jets.mput/1, :enabled, 30},
+      {"put", 7, @layer_11_in, &Nock.Jets.mput/1, :enabled, 30},
     Jets.calculate_mug_of_param_core(701, 21, 11) =>
-      {"got", 7, @layer_11_in_context_mug, &Nock.Jets.got/1, :enabled, 30},
+      {"got", 7, @layer_11_in, &Nock.Jets.got/1, :enabled, 30},
     Jets.calculate_mug_of_core(1492, Nock.Lib.stdlib_layers()) =>
-      {"kind", 7, @layer_rm_context_mug, &Nock.Jets.kind/1, :enabled, 100},
+      {"kind", 7, @layer_rm, &Nock.Jets.kind/1, :enabled, 100},
     Jets.calculate_mug_of_core(92, Nock.Lib.stdlib_layers()) =>
-      {"delta-add", 7, @layer_rm_context_mug, &Nock.Jets.delta_add/1,
-       :enabled, 50},
+      {"delta-add", 7, @layer_rm, &Nock.Jets.delta_add/1, :enabled, 50},
     Jets.calculate_mug_of_core(1527, Nock.Lib.stdlib_layers()) =>
-      {"delta-sub", 7, @layer_rm_context_mug, &Nock.Jets.delta_sub/1,
-       :enabled, 50},
+      {"delta-sub", 7, @layer_rm, &Nock.Jets.delta_sub/1, :enabled, 50},
     Jets.calculate_mug_of_core(4, Nock.Lib.stdlib_layers()) =>
-      {"action-delta", 7, @layer_rm_context_mug, &Nock.Jets.action_delta/1,
-       :enabled, 50},
+      {"action-delta", 7, @layer_rm, &Nock.Jets.action_delta/1, :enabled, 50},
     Jets.calculate_mug_of_core(1494, Nock.Lib.stdlib_layers()) =>
-      {"make-delta", 7, @layer_rm_context_mug, &Nock.Jets.make_delta/1,
-       :enabled, 50}
+      {"make-delta", 7, @layer_rm, &Nock.Jets.make_delta/1, :enabled, 50}
   }
 
   @doc """


### PR DESCRIPTION
Prior, the jet registry carried the mug of the parent to compare
against. However, mug computations for such large core can be
expensive in Elixir due to murmur3 limitations.

In order to speed up the process, we now store instead of mugs the
actual parents and can compare against them during the jet checks.