### PR TITLE
Ensure ex_unit starts up properly with the Node

### DIFF
--- a/apps/anoma_node/mix.exs
+++ b/apps/anoma_node/mix.exs
@@ -31,7 +31,8 @@ defmodule AnomaNode.MixProject do
         :logger,
         :mnesia,
         :runtime_tools,
-        :tools
+        :tools,
+        :ex_unit
       ]
     ]
   end


### PR DESCRIPTION
The reason why we'd want this is when running examples that have capture log.

```
iex(anoma@YU-NO)1> Anoma.Node.Examples.ETransaction.resubmit_trivial_swap
"example_A2D042FF16911027DE1D9C09ABBFD2B6"
```

Is what we have after this patch but before this patch we have

```
iex(anoma@YU-NO)5> Anoma.Node.Examples.ETransaction.resubmit_trivial_swap
** (exit) exited in: GenServer.call(ExUnit.CaptureServer, {:log_capture_on, #PID<0.805.0>, #PID<0.1353.0>, []}, :infinity)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
    (elixir 1.17.3) lib/gen_server.ex:1121: GenServer.call/3
    (ex_unit 1.17.3) lib/ex_unit/capture_log.ex:110: ExUnit.CaptureLog.with_log/2
    (ex_unit 1.17.3) lib/ex_unit/capture_log.ex:75: ExUnit.CaptureLog.capture_log/2
    (anoma_node 0.30.0) lib/examples/e_transaction.ex:368: Anoma.Node.Examples.ETransaction.resubmit_trivial_swap/1
    iex:5: (file)

```

There might be better places to put this however