### PR TITLE
Launch the transaction before sending the transaction event

### DIFF
--- a/apps/anoma_node/lib/node/transaction/mempool.ex
+++ b/apps/anoma_node/lib/node/transaction/mempool.ex
@@ -400,9 +400,9 @@ defmodule Anoma.Node.Transaction.Mempool do
     value = %Tx{backend: backend, code: code}
     node_id = state.node_id
 
-    tx_event(tx_id, value, node_id)
-
     Executor.launch(node_id, tx, tx_id)
+
+    tx_event(tx_id, value, node_id)
 
     %Mempool{
       state


### PR DESCRIPTION
This PR sends the transaction event *after* the transaction has been launched.
This ensures the supervisor has the child ready when a process handles the tx event.