### PR TITLE
Pin `protobuf-gen-elixir` escript version in the CI

### DIFF
--- a/.github/actions/elixir_setup/action.yaml
+++ b/.github/actions/elixir_setup/action.yaml
@@ -27,4 +27,4 @@ runs:
     # install protobuf package
     - name: Install Protobuf Elixir dependencies
       shell: bash
-      run: mix escript.install hex protobuf --force
+      run: mix escript.install hex protobuf 0.11.0 --force

--- a/.github/actions/elixir_setup/action.yaml
+++ b/.github/actions/elixir_setup/action.yaml
@@ -27,4 +27,7 @@ runs:
     # install protobuf package
     - name: Install Protobuf Elixir dependencies
       shell: bash
-      run: mix escript.install hex protobuf 0.11.0 --force
+      run: |
+        version=$(echo -n $(elixir -e "$(<mix.lock) |> Map.get(:protobuf) |> elem(2) |> IO.puts"))
+        echo "version: ${version}"
+        mix escript.install hex protobuf "$version" --force


### PR DESCRIPTION
`mix escript.install hex protobuf` installs the latest version. At this time that's 0.14. We are still on protobuf 0.11 however, and then this breaks the generated boilerplate.

Updated the CI to use the version from the mix.lock file.