### PR TITLE
EventBroker fix `with_subscription` 

### DIFF
--- a/apps/event_broker/lib/event_broker.ex
+++ b/apps/event_broker/lib/event_broker.ex
@@ -87,6 +87,24 @@ defmodule EventBroker do
   ############################################################
 
   @doc """
+  I return the filter specs for the current process.
+  I return a list of filterspeclists.
+  """
+  @spec my_subscriptions() :: [filter_spec_list]
+  def my_subscriptions() do
+    subscriptions(self())
+  end
+
+  @doc """
+  I return the filter specs for the given process id.
+  I return a list of filterspeclists.
+  """
+  @spec subscriptions(pid()) :: [filter_spec_list]
+  def subscriptions(pid) do
+    GenServer.call(EventBroker.Registry, {:subscriptions, pid})
+  end
+
+  @doc """
   I am the Event Broker event function.
 
   I process any incoming events by sending them to all of Broker subscribers

--- a/apps/event_broker/lib/event_broker.ex
+++ b/apps/event_broker/lib/event_broker.ex
@@ -15,6 +15,56 @@ defmodule EventBroker do
   - `unsubscribe_me/1`
   - `subscribe/2`
   - `unsubscribe/2`
+
+  ## Overview
+
+  The EventBroker manages subscriptions for processes that are interested in a
+  particular type of message.
+
+  ### Filters
+
+  Messages are defined as "filter specs" that define patterns an event must
+  match in order for them to be sent. The filter below will subscribe to all
+  events that are are maps with a key `:type` that has value `:error`.
+
+  ```
+  deffilter MyFilter do
+    %{type: :error} -> true
+    _ -> false
+  end
+  ```
+
+  Filters can be composed by creating a "filter spec list". If a process is
+  interested in all `MyFilter` events, but only those whose `message` field is
+  `nil`, a second filter can be used to refine the filter.
+
+  ```
+  deffilter MyFilterNil do
+    %{message: nil} -> true
+    _ -> false
+  end
+
+  ```
+
+  ### Subscribing to events
+
+  To subscribe to all messages that match the `MyFilter` the subscribing process
+  must call `&EventBroker.subscribe/1` with the filter spec list as argument.
+  E.g., `EventBroker.subscribe([MyFilter])`. To only subscribe to events that
+  also have `nil` for the `:message` value, the filter spec list should include
+  the `MyFilterNil` filter. E.g., `EventBroker.subscribe([MyFilter,
+  MyFilterNil])`.
+
+  If a particular filter is no longer of intrest, `EventBroker.unsubscribe/1`
+  can be used to unsubscribe from a filter.
+
+  ### Sending events
+
+  Any process can generate an event using the `&EventBroker.event/1` function.
+
+  ```
+  EventBroker.event(%{type: :error, message: "something happened"})
+  ```
   """
 
   use Application

--- a/apps/event_broker/lib/examples/e_event_broker.ex
+++ b/apps/event_broker/lib/examples/e_event_broker.ex
@@ -177,21 +177,11 @@ defmodule Examples.EEventBroker do
   def unsub_all() do
     start_broker()
 
-    registered = :sys.get_state(Registry).registered_filters
-
-    for {spec, pid} <- registered, reduce: [] do
-      acc ->
-        if :sys.get_state(pid).subscribers |> MapSet.member?(self()) do
-          acc ++ [spec]
-        else
-          acc
-        end
-    end
+    # unsubscribe from all my current subscriptions
+    EventBroker.my_subscriptions()
     |> Enum.each(&EventBroker.unsubscribe_me(&1))
 
-    assert [[]] ==
-             :sys.get_state(Registry).registered_filters
-             |> Map.keys()
+    assert EventBroker.my_subscriptions() == []
 
     :sys.get_state(Registry)
   end
@@ -219,7 +209,7 @@ defmodule Examples.EEventBroker do
 
     assert Process.alive?(agent)
 
-    assert MapSet.new([self()]) == :sys.get_state(agent).subscribers
+    assert self() in :sys.get_state(agent).subscribers
 
     {:sys.get_state(Registry), agent}
   end

--- a/apps/event_broker/lib/examples/e_filter.ex
+++ b/apps/event_broker/lib/examples/e_filter.ex
@@ -1,0 +1,32 @@
+defmodule Examples.EEVentBroker.EFilter do
+  @moduledoc """
+  I define examples on how to use the deffilter macro to create filters for the event broker.
+  """
+  alias EventBroker.Event
+
+  use EventBroker.DefFilter
+
+  # @doc """
+  # I am a filter that subscribes to all messages.
+  # I don't filter on any patterns, so all messages are valid.
+  # """
+  deffilter AcceptAll do
+    _ -> true
+  end
+
+  # @doc """
+  # I am a filter that rejects all messages.
+  # """
+  deffilter RejectAll do
+    _ -> false
+  end
+
+  # @doc """
+  # I am a filter that accept evnets that have a body which is a map and has a key
+  # `:level` with value `:error`.
+  # """
+  deffilter Error do
+    %Event{body: %{level: :error}} -> true
+    _ -> false
+  end
+end

--- a/apps/event_broker/lib/examples/e_subscribe.ex
+++ b/apps/event_broker/lib/examples/e_subscribe.ex
@@ -1,0 +1,139 @@
+defmodule Examples.EEventBroker.Subscribe do
+  @moduledoc """
+  I define examples on how to susbcribe to topics in the event broker.
+  """
+
+  alias Examples.EEVentBroker.EFilter
+  alias EventBroker.Event
+
+  use ExUnit.Case
+
+  # A list of default filters to use in the examples below.
+  @filters [%EFilter.AcceptAll{}, %EFilter.Error{}]
+
+  @doc """
+  I subscribe using the `Trivial` filter and assert that I receive any events
+  sent on the message broker.
+  """
+  @spec subscribe_to_filter(struct()) :: {:received, any()}
+  def subscribe_to_filter(filter \\ %EFilter.AcceptAll{}) do
+    # subscribe to the trivial filter (i.e., all messages)
+    EventBroker.subscribe_me([filter])
+
+    # create an event that matches the filter
+    event = %Event{source_module: nil, body: %{message: "everything matches"}}
+
+    # send the event
+    EventBroker.event(event)
+
+    # assert that this process receives the event
+    assert_receive ^event
+
+    EventBroker.unsubscribe_me([filter])
+
+    {:received, event}
+  end
+
+  @doc """
+  I subscribe to multiple filters and assert that I receive the events that are
+  allowed by those filters.
+  """
+
+  @spec subscribe_to_multiple_filters([struct()]) :: {:received, any()}
+  def subscribe_to_multiple_filters(filters \\ @filters) do
+    # subscribe to the trivial filter (i.e., all messages)
+    EventBroker.subscribe_me(filters)
+
+    # confirm this process is subscribed
+    assert_subscription(filters)
+
+    # create an event that matches the filter
+    event = %Event{source_module: nil, body: %{level: :error}}
+
+    # send the event
+    :ok = EventBroker.event(event)
+
+    # assert that this process receives the event
+    assert_receive ^event
+
+    EventBroker.unsubscribe_me(filters)
+
+    # confirm this process is unsubscribed
+    refute_subscription(filters)
+
+    {:received, event}
+  end
+
+  @doc """
+  I unsubscribe a process from a filter and verify that it is unsubscribed.
+  """
+  def unsubscribe_from_filter(filter \\ %EFilter.AcceptAll{}) do
+    # subscribe to the trivial filter (i.e., all messages)
+    EventBroker.subscribe_me([filter])
+
+    # create an event that matches the filter
+    event = %Event{source_module: nil, body: %{message: "everything matches"}}
+
+    # send the event
+    EventBroker.event(event)
+
+    # assert that this process receives the event
+    assert_receive ^event
+
+    EventBroker.unsubscribe_me([filter])
+
+    {:received, event}
+  end
+
+  ############################################################
+  #                       Helpers                            #
+  ############################################################
+  @doc """
+  I assert that the current process is subscribed to the given filter.
+  """
+  @spec assert_subscription([struct()] | struct()) :: [struct()] | struct()
+  def assert_subscription(filter) when is_struct(filter) do
+    # fetch the current subscriptions
+    current_subscriptions = EventBroker.my_subscriptions()
+
+    # check that we're currently not subscribed to this filter
+    assert [filter] in current_subscriptions
+
+    filter
+  end
+
+  def assert_subscription(filters) when is_list(filters) do
+    # fetch the current subscriptions
+    current_subscriptions = EventBroker.my_subscriptions()
+
+    # check that we're currently not subscribed to this filter
+    assert filters in current_subscriptions
+
+    filters
+  end
+
+  @doc """
+  Given a list of filters, I make sure that the current process is not subscribed to them.
+  """
+  @spec refute_subscription([struct()] | struct()) :: [struct()] | struct()
+  def refute_subscription(filters) when is_list(filters) do
+    # fetch the current subscriptions
+    current_subscriptions = EventBroker.my_subscriptions()
+
+    # check that we're currently not subscribed to this filter
+    assert filters not in current_subscriptions
+
+    filters
+  end
+
+  @spec refute_subscription(struct()) :: struct()
+  def refute_subscription(filter) when is_struct(filter) do
+    # fetch the current subscriptions
+    current_subscriptions = EventBroker.my_subscriptions()
+
+    # check that we're currently not subscribed to this filter
+    assert [filter] not in current_subscriptions
+
+    filter
+  end
+end

--- a/apps/event_broker/lib/examples/e_with_subscription.ex
+++ b/apps/event_broker/lib/examples/e_with_subscription.ex
@@ -1,0 +1,137 @@
+defmodule Examples.EEVentBroker.WithSub do
+  @moduledoc """
+  I contain examples of how the `with_subscription` block works.
+  """
+
+  alias Examples.EEVentBroker.EFilter
+  alias EventBroker.Event
+
+  import Examples.EEventBroker.Subscribe
+
+  use ExUnit.Case
+  use EventBroker.WithSubscription
+
+  # A list of default filters to use in the examples below.
+  @filters [%EFilter.AcceptAll{}, %EFilter.Error{}]
+
+  @doc """
+  I run a piece of code with a subscription. I assert that the messages sent
+  within this block are sent to me.
+  """
+  @spec with_subscription(struct()) :: struct()
+  def with_subscription(filter \\ %EFilter.AcceptAll{}) do
+    # make sure this process is not already subscribed
+    refute_subscription(filter)
+
+    with_subscription([[filter]]) do
+      # create an event that matches the filter
+      event = %Event{
+        source_module: nil,
+        body: %{message: "everything matches"}
+      }
+
+      # send the event
+      EventBroker.event(event)
+
+      # assert that this process receives the event
+      assert_receive ^event
+    end
+
+    # make sure this process is not still subscribed
+    refute_subscription(filter)
+
+    filter
+  end
+
+  @doc """
+  I run a piece of code with a subscription to multiple filters. I assert that
+  the messages sent within this block are sent to me.
+  """
+  @spec with_subscriptions([struct()]) :: [struct()]
+  def with_subscriptions(filters \\ @filters) do
+    # make sure this process is not already subscribed
+    refute_subscription(filters)
+
+    with_subscription([filters]) do
+      # create an event that matches the filter
+      event = %Event{
+        source_module: nil,
+        body: %{level: :error}
+      }
+
+      # send the event
+      EventBroker.event(event)
+
+      # assert that this process receives the event
+      assert_receive ^event
+    end
+
+    # make sure this process is not still subscribed
+    refute_subscription(filters)
+
+    filters
+  end
+
+  @doc """
+  I check that, when a process is subscribed to a given filter, that filter
+  still exists after a `with_subscription` block that uses the same filter.
+  """
+  @spec with_existing_subscription(struct()) :: struct()
+  def with_existing_subscription(filter \\ %EFilter.AcceptAll{}) do
+    # subscribe to the given filter
+    EventBroker.subscribe_me([filter])
+
+    # make sure this process is not already subscribed
+    assert_subscription(filter)
+
+    with_subscription([[filter]]) do
+      assert_subscription(filter)
+    end
+
+    # make sure this process is still subscribed
+    assert_subscription(filter)
+
+    filter
+  end
+
+  @doc """
+  I nest two with_subscription blocks and assert that the middle one is subscribed to the outer topics as well.
+  """
+  @spec with_nested_subscription([struct()]) :: [struct()]
+  def with_nested_subscription([filter1, filter2] \\ @filters) do
+    # no filter1
+    refute_subscription(filter1)
+
+    # no filter2
+    refute_subscription(filter2)
+
+    with_subscription([[filter1]]) do
+      # confirm filter1
+      assert_subscription(filter1)
+
+      # no filter2
+      refute_subscription(filter2)
+
+      with_subscription([[filter2]]) do
+        # confirm filter1
+        assert_subscription(filter1)
+        # confirm filter2
+        assert_subscription(filter2)
+      end
+
+      # confirm filter1
+      assert_subscription(filter1)
+
+      # no filter2
+      refute_subscription(filter2)
+    end
+
+    # no filter1
+    refute_subscription(filter1)
+
+    # no filter2
+    refute_subscription(filter2)
+
+    [filter1, filter2]
+  end
+end

--- a/apps/event_broker/test/subscribe_test.exs
+++ b/apps/event_broker/test/subscribe_test.exs
@@ -1,0 +1,6 @@
+defmodule EventbrokerTest.SubscribeTest do
+  use ExUnit.Case, async: true
+
+  use TestHelper.GenerateExampleTests,
+    for: Examples.EEventBroker.Subscribe
+end

--- a/apps/event_broker/test/with_subscription_test.exs
+++ b/apps/event_broker/test/with_subscription_test.exs
@@ -1,0 +1,6 @@
+defmodule EventbrokerTest.WithSub do
+  use ExUnit.Case, async: true
+
+  use TestHelper.GenerateExampleTests,
+    for: Examples.EEVentBroker.WithSub
+end


### PR DESCRIPTION
This PR mainly addressed the `with_subscription` semantics. In short, I removed the wrapping of it in a task, added a `my_subscriptions` function to the eventbroker.

I also fixed two minor bugs and added some examples.