### PR TITLE
Client Storage Reads with ID

### DIFF
--- a/apps/anoma_client/lib/client/application.ex
+++ b/apps/anoma_client/lib/client/application.ex
@@ -20,6 +20,14 @@ defmodule Anoma.Client.Application do
       {DynamicSupervisor, name: Anoma.Client.ConnectionSupervisor}
     ]
 
+    :mnesia.create_table(Anoma.Client.Storage.Updates,
+      attributes: [:key, :updates]
+    )
+
+    :mnesia.create_table(Anoma.Client.Storage.Values,
+      attributes: [:qualified_key, :value]
+    )
+
     opts = [strategy: :one_for_one, name: Anoma.Client.Supervisor]
     Supervisor.start_link(children, opts)
   end

--- a/apps/anoma_client/lib/client/application.ex
+++ b/apps/anoma_client/lib/client/application.ex
@@ -28,6 +28,10 @@ defmodule Anoma.Client.Application do
       attributes: [:qualified_key, :value]
     )
 
+    :mnesia.create_table(Anoma.Client.Storage.Ids,
+      attributes: [:id, :timestamp]
+    )
+
     opts = [strategy: :one_for_one, name: Anoma.Client.Supervisor]
     Supervisor.start_link(children, opts)
   end

--- a/apps/anoma_client/lib/client/storage.ex
+++ b/apps/anoma_client/lib/client/storage.ex
@@ -1,0 +1,93 @@
+defmodule Anoma.Client.Storage do
+  @moduledoc """
+  I am the Client Storage module.
+
+  I represent the local timestamped cache of a client akin to the Node
+  Storage.
+
+  In contrast to the Node Storage I
+  - never block and return an error on evident semantics failures
+  - use os time for timestamps
+  - don't have in-progress storage and commit directly to default
+    tables
+
+  ### Public API
+
+  I have the following public functionality:
+
+  - read/1
+  - write/2
+  """
+
+  alias __MODULE__
+  use TypedStruct
+
+  @doc """
+  I am the Client Storage write function.
+
+  I allow to write only at the current OS time.
+  """
+  @spec write({any(), any()}) :: :ok | :error
+  def write({key, value}) do
+    time = System.os_time()
+
+    case :mnesia.transaction(fn ->
+           case :mnesia.read({Storage.Updates, key}) do
+             [{Storage.Updates, ^key, list}] ->
+               write_to_tables(time, key, value, list)
+
+             _ ->
+               write_to_tables(time, key, value)
+           end
+         end) do
+      {:atomic, :ok} -> :ok
+      {:aborted, _} -> :error
+    end
+  end
+
+  @doc """
+  I am the Client Storage read function.
+
+  If the time is in the future in comparisson to OS time, I error.
+  If we read before any value was writte, I error.
+
+  Otherwise I read the closest value in the past.
+  """
+  @spec read({non_neg_integer(), any()}) :: {:ok, any()} | :absent | :error
+  def read({time, key}) do
+    current_time = System.os_time()
+
+    if time > current_time do
+      :error
+    else
+      case :mnesia.transaction(fn ->
+             case :mnesia.read({Storage.Updates, key}) do
+               [{Storage.Updates, ^key, list}] ->
+                 case list |> Enum.find(fn a -> a <= time end) do
+                   nil ->
+                     :absent
+
+                   closest_time ->
+                     [{_, _, value}] =
+                       :mnesia.read({Storage.Values, {closest_time, key}})
+
+                     value
+                 end
+
+               [] ->
+                 :absent
+             end
+           end) do
+        {:atomic, :absent} -> :absent
+        {:atomic, val} -> {:ok, val}
+        {:aborted, _} -> :error
+      end
+    end
+  end
+
+  @spec write_to_tables(non_neg_integer(), any(), any(), list()) :: :ok
+  defp write_to_tables(time, key, value, list \\ []) do
+    :mnesia.write({Storage.Updates, key, [time | list]})
+    :mnesia.write({Storage.Values, {time, key}, value})
+  end
+end

--- a/apps/anoma_client/lib/examples/e_storage.ex
+++ b/apps/anoma_client/lib/examples/e_storage.ex
@@ -1,0 +1,66 @@
+defmodule Anoma.Client.Examples.EStorage do
+  alias Anoma.Client.Storage
+
+  @type storage_result :: list({:key, any()} | {:value, any()})
+
+  ############################################################
+  #                    Helpers                               #
+  ############################################################
+
+  def setup() do
+    :mnesia.clear_table(Storage.Updates)
+    :mnesia.clear_table(Storage.Values)
+  end
+
+  ############################################################
+  #                    Examples                              #
+  ############################################################
+
+  @spec write_value(any(), any()) :: storage_result
+  def write_value(key \\ "key", value \\ "value") do
+    setup()
+    Storage.write({key, value})
+
+    [key: key, value: value]
+  end
+
+  @spec read_value(any(), any()) :: storage_result
+  def read_value(key \\ "key", value \\ "value") do
+    write_value(key, value)
+
+    {:ok, value} = Storage.read({System.os_time(), key})
+    [key: key, value: value]
+  end
+
+  @spec overwrite_value(any(), any()) :: storage_result
+  def overwrite_value(key \\ "key", value \\ "value") do
+    write_value({key, value})
+    another_value = "another_" <> value
+    Storage.write({key, another_value})
+    [key: key, value: another_value]
+  end
+
+  @spec read_overwritten_value(any(), any()) :: storage_result
+  def read_overwritten_value(key \\ "key", value \\ "value") do
+    args = overwrite_value(key, value)
+    new_value = args[:value]
+    {:ok, ^new_value} = Storage.read({System.os_time(), key})
+    [key: key, value: new_value]
+  end
+
+  @spec read_absent(any()) :: storage_result
+  def read_absent(key \\ "key") do
+    setup()
+
+    :absent = Storage.read({System.os_time(), key})
+    [key: key, value: :absent]
+  end
+
+  @spec read_in_future_and_fail(any()) :: storage_result
+  def read_in_future_and_fail(key \\ "key") do
+    setup()
+
+    :error = Storage.read({System.os_time() * 2, key})
+    [key: key, value: :error]
+  end
+end

--- a/apps/anoma_client/lib/examples/e_storage.ex
+++ b/apps/anoma_client/lib/examples/e_storage.ex
@@ -10,6 +10,7 @@ defmodule Anoma.Client.Examples.EStorage do
   def setup() do
     :mnesia.clear_table(Storage.Updates)
     :mnesia.clear_table(Storage.Values)
+    :mnesia.clear_table(Storage.Ids)
   end
 
   ############################################################
@@ -62,5 +63,40 @@ defmodule Anoma.Client.Examples.EStorage do
 
     :error = Storage.read({System.os_time() * 2, key})
     [key: key, value: :error]
+  end
+
+  @spec read_value_with_new_id(any(), any(), any()) :: storage_result
+  def read_value_with_new_id(id \\ "id", key \\ "key", value \\ "value") do
+    write_value(key, value)
+
+    {:ok, ^value} = Storage.read_with_id({id, key})
+
+    [key: key, value: value]
+  end
+
+  @spec read_absent_with_new_id(any(), any()) :: storage_result
+  def read_absent_with_new_id(id \\ "id", key \\ "key") do
+    setup()
+
+    :absent = Storage.read_with_id({id, key})
+
+    [key: key, value: :absent]
+  end
+
+  @spec read_value_with_old_id(String.t(), any(), String.t()) ::
+          storage_result
+  def read_value_with_old_id(id \\ "id", key \\ "key", value \\ "value") do
+    write_value(key, value)
+
+    {:ok, ^value} = Storage.read_with_id({id, key})
+
+    new_value = "new_" <> value
+
+    Storage.write({key, new_value})
+
+    {:ok, ^value} = Storage.read_with_id({id, key})
+    {:ok, ^new_value} = Storage.read_with_id({"new_" <> id, key})
+
+    [key: key, value: new_value]
   end
 end

--- a/apps/anoma_client/test/storage_test.exs
+++ b/apps/anoma_client/test/storage_test.exs
@@ -1,0 +1,8 @@
+defmodule StorageTest do
+  # these tests cannot run async
+  # they require the grpc proxy and there can only be one instance of this at a time.
+  use ExUnit.Case, async: true
+
+  use TestHelper.GenerateExampleTests,
+    for: Anoma.Client.Examples.EStorage
+end


### PR DESCRIPTION
Currently the storage allows only for direct reads at a time. However,
that will allow for impure behavior during scry evaluation. We
mitigate this similarly to the Node NockmaVM, namely accompanying the
keys to read with IDs which are stored in local tables.