### PR TITLE
Validation of GRPC requests in the node

### DIFF
--- a/apps/anoma_lib/mix.exs
+++ b/apps/anoma_lib/mix.exs
@@ -29,7 +29,6 @@ defmodule AnomaLib.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:anoma_protobuf, in_umbrella: true}
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
       # {:sibling_app_in_umbrella, in_umbrella: true}

--- a/apps/anoma_node/lib/node/transport/grpc/intents.ex
+++ b/apps/anoma_node/lib/node/transport/grpc/intents.ex
@@ -1,12 +1,18 @@
 defmodule Anoma.Node.Transport.GRPC.Servers.Intents do
   alias Anoma.Node.Intents.IntentPool
+  alias Anoma.Node.Registry
   alias Anoma.Protobuf.Intents.Add
   alias Anoma.Protobuf.Intents.List
+  alias Anoma.TransparentResource.Transaction
   alias GRPC.Server.Stream
+  alias Noun.Jam
+  alias Noun.Nounable
 
   use GRPC.Server, service: Anoma.Protobuf.IntentsService.Service
 
   require Logger
+
+  import Anoma.Protobuf.ErrorHandler
 
   @spec list_intents(List.Request.t(), Stream.t()) :: List.Response.t()
   def list_intents(request, _stream) do
@@ -14,13 +20,18 @@ defmodule Anoma.Node.Transport.GRPC.Servers.Intents do
       "GRPC #{inspect(__ENV__.function)} request: #{inspect(request)}"
     )
 
+    # validate the request. will raise if not valid.
+    validate_request!(request)
+
+    # ensure the node id exists
+    if Registry.whereis(request.node_info.node_id, IntentPool) == nil do
+      raise_grpc_error!(:invalid_node_id)
+    end
+
     intents =
       IntentPool.intents(request.node_info.node_id)
-      |> Enum.map(fn i ->
-        i
-        |> Noun.Nounable.to_noun()
-        |> Noun.Jam.jam()
-      end)
+      |> Enum.map(&Nounable.to_noun/1)
+      |> Enum.map(&Jam.jam/1)
 
     %List.Response{intents: intents}
   end
@@ -32,15 +43,25 @@ defmodule Anoma.Node.Transport.GRPC.Servers.Intents do
       "GRPC #{inspect(__ENV__.function)} request: #{inspect(request)}"
     )
 
-    # the input is a jammed intent.
-    #  cue it and create a transaction
+    # validate the request. will raise if not valid.
+    validate_request!(request)
+
+    # ensure the node id exists
+    if Registry.whereis(request.node_info.node_id, IntentPool) == nil do
+      raise_grpc_error!(:invalid_node_id)
+    end
+
+    # the input is a jammed intent. cue it and create a transaction
     {:ok, intent} =
       request.intent.intent
-      |> Noun.Jam.cue!()
-      |> Anoma.TransparentResource.Transaction.from_noun()
+      |> Jam.cue!()
+      |> Transaction.from_noun()
 
     IntentPool.new_intent(request.node_info.node_id, intent)
 
     %Add.Response{result: "intent added"}
+  rescue
+    e ->
+      raise_grpc_error!(e)
   end
 end

--- a/apps/anoma_node/lib/node/transport/grpc/mempool.ex
+++ b/apps/anoma_node/lib/node/transport/grpc/mempool.ex
@@ -1,21 +1,40 @@
 defmodule Anoma.Node.Transport.GRPC.Servers.Mempool do
+  alias Anoma.Node.Registry
+  alias Anoma.Node.Transaction.Mempool
   alias Anoma.Protobuf.Mempool.AddTransaction
   alias GRPC.Server.Stream
-  alias Anoma.Node.Transaction.Mempool
+  alias Noun.Jam
 
   use GRPC.Server, service: Anoma.Protobuf.MempoolService.Service
 
   require Logger
+
+  import Anoma.Protobuf.ErrorHandler
 
   @spec add(AddTransaction.Request.t(), Stream.t()) ::
           AddTransaction.Response.t()
   def add(request, _stream) do
     Logger.debug("GRPC #{inspect(__ENV__.function)}: #{inspect(request)}")
 
-    tx_noun = request.transaction |> Noun.Jam.cue!()
+    # validate the request. will raise if not valid.
+    validate_request!(request)
 
-    Mempool.tx(request.node_info.node_id, {:transparent_resource, tx_noun})
+    # ensure the node id exists
+    if Registry.whereis(request.node_info.node_id, Mempool) == nil do
+      raise_grpc_error!(:invalid_node_id)
+    end
 
+    # create the transaction from the noun
+    noun = Jam.cue!(request.transaction)
+    transaction = {:transparent_resource, noun}
+
+    # submit the transaction to the mempool
+    node_id = request.node_info.node_id
+    :ok = Mempool.tx(node_id, transaction)
+
+    # return an empty response
     %AddTransaction.Response{}
+  rescue
+    e -> raise_grpc_error!(e)
   end
 end

--- a/apps/anoma_node/mix.exs
+++ b/apps/anoma_node/mix.exs
@@ -40,6 +40,7 @@ defmodule AnomaNode.MixProject do
   defp deps do
     [
       {:anoma_lib, in_umbrella: true},
+      {:anoma_protobuf, in_umbrella: true},
       {:event_broker, in_umbrella: true}
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},

--- a/apps/anoma_protobuf/lib/error_handler.ex
+++ b/apps/anoma_protobuf/lib/error_handler.ex
@@ -1,0 +1,117 @@
+defmodule Anoma.Protobuf.ErrorHandler do
+  @moduledoc """
+  I define functions that deal with errors during the handling of GRPC requests.
+
+  I have functionality to validate an incoming request, and to raise errors that
+  return useful error messages to the sender of the request.
+  """
+  require Logger
+
+  @doc """
+  Given a GRPC request, I check if this request is valid.
+
+  If it is not, I raise a GRPC error. If it is, I do nothing.
+  """
+  @spec validate_request!(any()) :: :noop
+  def validate_request!(req) do
+    case Validate.valid?(req) do
+      {:ok, :valid} ->
+        :noop
+
+      {:error, :invalid, errors} ->
+        raise_grpc_error!({:invalid_request, errors})
+    end
+  end
+
+  # @doc """
+  # Function to handle any error values coming from the domain.
+  #
+  # If no clause matches, a generic undefined error is raised.
+  # """
+  @spec raise_grpc_error!(any()) :: any()
+  # node id was not found on this machine
+  def raise_grpc_error!(:invalid_node_id) do
+    Logger.error("node id does not exist")
+
+    raise GRPC.RPCError,
+      status: GRPC.Status.invalid_argument(),
+      message: "node id does not exist"
+  end
+
+  # error cueing a jammed noun
+  def raise_grpc_error!(%Noun.Jam.CueError{}) do
+    raise GRPC.RPCError,
+      status: GRPC.Status.invalid_argument(),
+      message: "invalid nock code"
+  end
+
+  # generic invalid request
+  def raise_grpc_error!(:invalid_request) do
+    raise GRPC.RPCError,
+      status: GRPC.Status.unknown(),
+      message: "invalid request"
+  end
+
+  # invalid request with list of values that are invalid
+  # E.g., [node_id: "can not be nil"]
+  def raise_grpc_error!({:invalid_request, errors}) when is_map(errors) do
+    raise GRPC.RPCError,
+      status: GRPC.Status.invalid_argument(),
+      message: error_message(errors)
+  end
+
+  # an exception was caught that has a message
+  # e.g., KeyError
+  def raise_grpc_error!(%{message: m}) do
+    raise GRPC.RPCError,
+      status: GRPC.Status.unknown(),
+      message: m
+  end
+
+  # generic catch all
+  def raise_grpc_error!(e) do
+    Logger.error("unknown error in GRPC: #{inspect(e)}")
+
+    raise GRPC.RPCError,
+      status: GRPC.Status.unknown(),
+      message: "undefined error"
+  end
+
+  ############################################################
+  #                       Helpers                            #
+  ############################################################
+
+  # @doc """
+  # I take in an error map and return a string that explains the errors to the
+  # user.
+  # """
+  @spec error_message(Validate.error_map()) :: String.t()
+  defp error_message(%{nil: nils, invalid: invalids}) do
+    nil_errors(nils) <> invalid_errors(invalids)
+  end
+
+  # @doc """
+  # I return a string telling all the fields that were nil, and were not supposed to be.
+  # """
+  @spec nil_errors([Validate.nil_error()]) :: String.t()
+  defp nil_errors(nils) do
+    nils
+    |> Enum.map(&"#{&1} can not be nil")
+    |> Enum.intersperse(", ")
+    |> Enum.join("")
+  end
+
+  # @doc """
+  # I return an error message telling why specific fields were invalid, and the
+  # reason they are invalid.
+  # """
+  @spec invalid_errors([{atom(), Validate.error_map()}]) :: String.t()
+  defp invalid_errors([]), do: ""
+
+  defp invalid_errors(invalids) do
+    invalids
+    |> Enum.map(fn {field, errors} ->
+      "#{inspect(field)} #{error_message(errors)}"
+    end)
+  end
+end

--- a/apps/anoma_protobuf/lib/validate.ex
+++ b/apps/anoma_protobuf/lib/validate.ex
@@ -1,0 +1,177 @@
+defprotocol Validate do
+  @moduledoc """
+  I am a protocol that can be used to validate a struct.
+  I am used to validate GRPC requests.
+
+  GRPC requests can contain nil instead of a value, where the codebase expects a struct.
+
+  For example, the request below is valid GRPC.
+
+  ```
+  %Anoma.Protobuf.Intents.Add.Request{
+    node_info: nil,
+    intent: nil,
+    __unknown_fields__: []
+  }
+  ```
+
+  However, if the node_info field is not expected to be nil, this will cause crashes.
+
+  These types of errors can be caught early by using this protocol.
+  """
+
+  @typedoc """
+  An error_map map is a map that contains error data about a request.
+
+  E.g.,
+
+  ```
+  %{
+    nil: [:intent],
+    invalid: [node_info: %{nil: [:node_id], invalid: []}]}
+  }
+  """
+  @type error_map :: %{nil: [atom()], invalid: [{atom(), invalid_error}]}
+
+  @typedoc "An atom that was nil in a map."
+  @type nil_error :: atom()
+
+  @typedoc "A key in a map that was invalid."
+  @type invalid_error :: {atom(), error_map}
+
+  @fallback_to_any true
+  @spec valid?(t) :: {:ok, :valid} | {:error, :invalid, error_map}
+  def valid?(request)
+end
+
+defmodule Validate.Helpers do
+  @moduledoc """
+  I contain helper functions for the `Validate` protocol.
+  I implement genertic data traversal and constraint checking.
+  """
+
+  @doc """
+  I traverse a given data structure and return the values that are nil or
+  invalid according to their protocol.
+
+  For any value that is not enumerable, I return no errors.
+
+  Note: we assume that there are no missing keys, otherwise the GRPC request
+  would fail anyway. So it's only necessary to check for existing keys that are
+  nil.
+  """
+  @spec constraints(any(), Keyword.t()) :: Validate.error_map()
+  def constraints(v, opts \\ [])
+
+  def constraints(s, opts) when is_struct(s) do
+    constraints(Map.from_struct(s), opts)
+  end
+
+  def constraints(m, opts) when is_map(m) do
+    opts = Keyword.validate!(opts, non_nil: [])
+    acc = %{invalid: [], nil: []}
+
+    m
+    |> Enum.reduce(acc, fn {k, v}, acc ->
+      case {k, v, Validate.valid?(v)} do
+        {k, nil, _} ->
+          if k in opts[:non_nil] do
+            Map.update!(acc, nil, &[k | &1])
+          else
+            acc
+          end
+
+        {k, _v, {:error, :invalid, err}} ->
+          Map.update!(acc, :invalid, &[{k, err} | &1])
+
+        {_k, _v, _} ->
+          acc
+      end
+    end)
+  end
+
+  def constraints(_, _), do: %{invalid: [], nil: []}
+
+  @doc """
+  Validates a value with the given options.
+
+  This function will call the constraints function on the value and translate
+  that result into a result.
+  """
+  @spec validate(any(), Keyword.t()) ::
+          {:ok, :valid} | {:error, :invalid, Validate.error_map()}
+  def validate(value, opts) do
+    value
+    |> constraints(opts)
+    |> case do
+      %{nil: [], invalid: []} ->
+        {:ok, :valid}
+
+      %{nil: _, invalid: _} = errs ->
+        {:error, :invalid, errs}
+    end
+  end
+end
+
+############################################################
+#                       Intentpool                         #
+############################################################
+
+defimpl Validate, for: Anoma.Protobuf.Intents.List.Request do
+  @not_nil [:node_info, :intent]
+
+  def valid?(request) do
+    Validate.Helpers.validate(request, non_nil: @not_nil)
+  end
+end
+
+defimpl Validate, for: Anoma.Protobuf.Intents.Add.Request do
+  @not_nil [:node_info, :intent]
+
+  def valid?(request) do
+    Validate.Helpers.validate(request, non_nil: @not_nil)
+  end
+end
+
+############################################################
+#                       Mempool                            #
+############################################################
+
+defimpl Validate, for: Anoma.Protobuf.Mempool.Add.Request do
+  @not_nil [:node_info, :transaction]
+
+  def valid?(request) do
+    Validate.Helpers.validate(request, non_nil: @not_nil)
+  end
+end
+
+############################################################
+#                       Node Info                          #
+############################################################
+
+defimpl Validate, for: Anoma.Protobuf.NodeInfo do
+  @not_nil [:node_id]
+
+  def valid?(request) do
+    Validate.Helpers.validate(request, non_nil: @not_nil)
+  end
+end
+
+############################################################
+#                       Intent                             #
+############################################################
+
+defimpl Validate, for: Anoma.Protobuf.Intents.Intent do
+  @not_nil [:node_id]
+
+  def valid?(request) do
+    Validate.Helpers.validate(request, non_nil: @not_nil)
+  end
+end
+
+# catch all for other types
+defimpl Validate, for: Any do
+  def valid?(_value) do
+    {:ok, :valid}
+  end
+end

--- a/apps/anoma_protobuf/mix.exs
+++ b/apps/anoma_protobuf/mix.exs
@@ -39,6 +39,7 @@ defmodule Anoma.Protobuf.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      {:anoma_lib, in_umbrella: true},
       {:compile_protoc, in_umbrella: true},
       {:grpc, "~> 0.9"},
       {:protobuf, "~> 0.11.0"}


### PR DESCRIPTION
This PR adds validation to the GRPC requests in the node. 

The summary as to why this is a thing: 
 - In protobuf everything is optional (see: https://protobuf.dev/programming-guides/proto3/#field-labels)
 - GRPC crashes agressively, and no interception of that is possible (afaict)
 - Validating requests allows us to return reasonable error messages to the user.