### PR TITLE
BugFix: Assume all 12 Calls Receive Keyspaces

### DIFF
--- a/apps/anoma_lib/lib/examples/enock.ex
+++ b/apps/anoma_lib/lib/examples/enock.ex
@@ -52,7 +52,7 @@ defmodule Examples.ENock do
 
   @spec zero(Noun.t()) :: Noun.t()
   def zero(key \\ "key") do
-    zero_counter_arm = [1, key | 0]
+    zero_counter_arm = [1, [key] | 0]
     arm = [10, [2 | zero_counter_arm], 1, 0 | 0]
     sample = 0
     keyspace = 0
@@ -61,7 +61,7 @@ defmodule Examples.ENock do
 
   @spec inc(Noun.t()) :: Noun.t()
   def inc(key \\ "key") do
-    increment_value_arm = [[1 | key], 4, 12, [1 | 0], [0 | 6], 1, key | 0]
+    increment_value_arm = [[1 | [key]], 4, 12, [1 | 0], [0 | 6], 1, [key] | 0]
     # Place the result in a list
     arm = [10, [2 | increment_value_arm], 1, 0 | 0]
     sample = 0

--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -417,8 +417,8 @@ defmodule Anoma.Node.Examples.ETransaction do
          %Mempool.Tx{
            code: ^zero,
            backend: ^back,
-           vm_result: {:ok, [[^key | 0] | 0]},
-           tx_result: {:ok, [[^key | 0]]}
+           vm_result: {:ok, [[[^key] | 0] | 0]},
+           tx_result: {:ok, [[[^key] | 0]]}
          }
        ]}
     ] = block
@@ -456,14 +456,14 @@ defmodule Anoma.Node.Examples.ETransaction do
          %Mempool.Tx{
            code: ^zero,
            backend: ^back1,
-           vm_result: {:ok, [[^key | 0] | 0]},
-           tx_result: {:ok, [[^key | 0]]}
+           vm_result: {:ok, [[[^key] | 0] | 0]},
+           tx_result: {:ok, [[[^key] | 0]]}
          },
          %Mempool.Tx{
            code: ^inc,
            backend: ^back2,
-           vm_result: {:ok, [[^key | 1] | 0]},
-           tx_result: {:ok, [[^key | 1]]}
+           vm_result: {:ok, [[[^key] | 1] | 0]},
+           tx_result: {:ok, [[[^key] | 1]]}
          }
        ]}
     ] = block
@@ -497,8 +497,8 @@ defmodule Anoma.Node.Examples.ETransaction do
          %Mempool.Tx{
            code: ^inc,
            backend: ^back,
-           vm_result: {:ok, [[^key | 1] | 0]},
-           tx_result: {:ok, [[^key | 1]]}
+           vm_result: {:ok, [[[^key] | 1] | 0]},
+           tx_result: {:ok, [[[^key] | 1]]}
          }
        ]}
     ] = block
@@ -535,14 +535,14 @@ defmodule Anoma.Node.Examples.ETransaction do
          %Mempool.Tx{
            code: ^zero,
            backend: {:debug_read_term, _},
-           vm_result: {:ok, [[^key | 0] | 0]},
-           tx_result: {:ok, {:read_value, [[^key | 0] | 0]}}
+           vm_result: {:ok, [[[^key] | 0] | 0]},
+           tx_result: {:ok, {:read_value, [[[^key] | 0] | 0]}}
          },
          %Mempool.Tx{
            code: ^inc,
            backend: ^back,
-           vm_result: {:ok, [[^key | 1] | 0]},
-           tx_result: {:ok, [[^key | 1]]}
+           vm_result: {:ok, [[[^key] | 1] | 0]},
+           tx_result: {:ok, [[[^key] | 1]]}
          }
        ]}
     ] = block

--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -121,7 +121,11 @@ defmodule Anoma.Node.Transaction.Backends do
       scry_function: fn list ->
         if list do
           with [id, key] <- list |> Noun.list_nock_to_erlang(),
-               {:ok, value} <- Ordering.read(node_id, {id, key}) do
+               {:ok, value} <-
+                 Ordering.read(
+                   node_id,
+                   {id, key |> Noun.list_nock_to_erlang()}
+                 ) do
             {:ok, value}
           else
             _ -> :error


### PR DESCRIPTION
As all 12 calls should query storage, we should assume we are querying the keyspaces.