### PR TITLE
Check that Key Matches Expected Format during TRM Execution

### DIFF
--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -245,7 +245,8 @@ defmodule Anoma.Node.Transaction.Backends do
               blobs:
                 for {key, {value, bool}} <- action.app_data, reduce: blobs do
                   acc ->
-                    if Noun.equal?(bool, 0) do
+                    if Noun.equal?(bool, 0) and
+                         :crypto.hash(:sha256, Noun.Jam.jam(value)) == key do
                       [{key, value} | acc]
                     else
                       acc


### PR DESCRIPTION
Prior we stored any key-value pair which appeared in app data, now we check that the format is as necessary, i.e. as a sha256 hash of a jammed value