### PR TITLE
client reconnects and restarts completely if disconnected

### DIFF
--- a/apps/anoma_client/lib/client/client_connection/grpc_proxy.ex
+++ b/apps/anoma_client/lib/client/client_connection/grpc_proxy.ex
@@ -51,11 +51,11 @@ defmodule Anoma.Client.Connection.GRPCProxy do
   def init(args) do
     state = struct(__MODULE__, Enum.into(args, %{}))
 
-    case GRPC.Stub.connect("#{state.host}:#{state.port}") do
+    case connect(state.host, state.port) do
       {:ok, channel} ->
         {:ok, %{state | channel: channel}}
 
-      _err ->
+      {:error, :failed_to_connect} ->
         {:stop, :node_unreachable}
     end
   end
@@ -101,15 +101,18 @@ defmodule Anoma.Client.Connection.GRPCProxy do
   def handle_call({:list_intents}, _from, state) do
     node_info = %NodeInfo{node_id: state.node_id}
     request = %List.Request{node_info: node_info}
-    intents = IntentsService.Stub.list_intents(state.channel, request)
-    {:reply, intents, state}
+
+    {:ok, response} =
+      IntentsService.Stub.list_intents(state.channel, request, timeout: 1000)
+
+    {:reply, {:ok, response}, state}
   end
 
   def handle_call({:add_intent, intent}, _from, state) do
     node_info = %NodeInfo{node_id: state.node_id}
     request = %Add.Request{node_info: node_info, intent: intent}
-    result = IntentsService.Stub.add_intent(state.channel, request)
-    {:reply, result, state}
+    {:ok, response} = IntentsService.Stub.add_intent(state.channel, request)
+    {:reply, {:ok, response}, state}
   end
 
   def handle_call({:list_nullifiers}, _from, state) do
@@ -160,5 +163,34 @@ defmodule Anoma.Client.Connection.GRPCProxy do
   @impl true
   def handle_info(_message, state) do
     {:noreply, state}
+  end
+
+  ############################################################
+  #                       Helpers                            #
+  ############################################################
+
+  # @doc """
+  # I try to establish a connection to the remote node.
+  # If I dont succeed after 10 attempts, I stop trying.
+  # """
+  @spec connect(String.t(), String.t(), non_neg_integer()) ::
+          {:ok, any()} | {:error, :failed_to_connect}
+  defp connect(host, port, attempts \\ 5)
+
+  defp connect(host, port, 0) do
+    Logger.error("failed to connect to node at #{host}, port #{port}")
+    {:error, :failed_to_connect}
+  end
+
+  defp connect(host, port, attempts) do
+    Logger.debug("connecting to node at #{host}, port #{port}")
+
+    case GRPC.Stub.connect("#{host}:#{port}") do
+      {:ok, channel} ->
+        {:ok, channel}
+
+      _err ->
+        connect(host, port, attempts - 1)
+    end
   end
 end

--- a/apps/anoma_client/lib/client/client_connection/supervisor.ex
+++ b/apps/anoma_client/lib/client/client_connection/supervisor.ex
@@ -65,6 +65,6 @@ defmodule Anoma.Client.Connection.Supervisor do
        start_server: true}
     ]
 
-    Supervisor.init(children, strategy: :one_for_one)
+    Supervisor.init(children, strategy: :one_for_all)
   end
 end


### PR DESCRIPTION
This PR makes the client completely disconnect when a request fails. 

The behavior is now as follows.

Client connects to node
Node goes offline
Client makes request
Client request times out
Client GRPCProxy crashes
Supervisor terminates entire client supervision tree
Client restarts, and attempts to connect to the node 10 times 
If success, client starts
If failure, client terminates, and supervisor tries again

I'm unsure if this is "good enough", or if we want something different. 

I think I might tackle this a bit cleaner when I add support for multiple nodes from within the client. 
