### PR TITLE
Pad binary data for verify_detached jet to required size

### DIFF
--- a/apps/anoma_lib/lib/nock/jets.ex
+++ b/apps/anoma_lib/lib/nock/jets.ex
@@ -305,9 +305,9 @@ defmodule Nock.Jets do
       when is_noun_atom(a) and is_noun_atom(b) and is_noun_atom(c) ->
         try do
           if Sign.verify_detached(
-               Noun.atom_integer_to_binary(a),
+               Noun.atom_integer_to_binary(a, 64),
                Noun.atom_integer_to_binary(b),
-               Noun.atom_integer_to_binary(c)
+               Noun.atom_integer_to_binary(c, 32)
              ) do
             {:ok, 0}
           else

--- a/apps/anoma_lib/lib/nock/jets.ex
+++ b/apps/anoma_lib/lib/nock/jets.ex
@@ -331,7 +331,7 @@ defmodule Nock.Jets do
         try do
           case Sign.verify(
                  Noun.atom_integer_to_binary(a),
-                 Noun.atom_integer_to_binary(b)
+                 Noun.atom_integer_to_binary(b, 32)
                ) do
             {:ok, val} -> {:ok, [0 | val]}
             {:error, _} -> {:ok, 0}
@@ -369,7 +369,7 @@ defmodule Nock.Jets do
           {:ok,
            sign_fn.(
              Noun.atom_integer_to_binary(a),
-             Noun.atom_integer_to_binary(b)
+             Noun.atom_integer_to_binary(b, 64)
            )}
         rescue
           _ in ArgumentError -> :error


### PR DESCRIPTION
A ed25519 signature is 64 bytes and a verifying key is 32 bytes. These
are passed to the verify_detached jet as atoms. These atoms must be
padded to the expected size otherwise the verification can fail.

For example, as part of the Kudos application test the following
signature was generated:

1e66a254ff3897aa6657e418258b9a8ebc59f165deb17858f18e56e48f1f4bc63519c4d3d0e776835bbcc1a955e6310c11df59de27d907612667063b09a6d0

The last byte of this signature is 0 so when its atom representation is
converted back to bytes by Noun.atom_integer_to_binary, the resulting
binary is only 63 bytes.

The final byte is missing and so the signature verification check fails.

The only relevant commit in this PR is https://github.com/anoma/anoma/pull/1861/commits/bd485d54ea350c692055e4e0bb619734f39e415c

The `message` argument to this jet has unknown size and so cannot be padded. This might cause hard to debug verification failures in the future. Perhaps we should consider the proposal to encode these arguments as a cell `[byte_size atom_payload]`, see: https://github.com/anoma/anoma/issues/1285.

Other jets, where the input is assumed to be a binary of an expected size, could also be affected by this issue. 