### PR TITLE
fix formatting of lib/noun.ex

### DIFF
--- a/apps/anoma_lib/lib/noun.ex
+++ b/apps/anoma_lib/lib/noun.ex
@@ -183,7 +183,7 @@ defmodule Noun do
       fal
     else
       haz = Murmur.hash_x86_32(key, seed)
-      ham = haz >>> 31 |> bxor(haz &&& (1 <<< 31) - 1)
+      ham = (haz >>> 31) |> bxor(haz &&& (1 <<< 31) - 1)
 
       unless ham == 0 do
         ham


### PR DESCRIPTION
I use `mix format` since the LSPs are failing on the project, and noticed this file isnt formatted. So I'm formatting it here, so I can go on with my life and hate LSPs.