### PR TITLE
Fix version comparison and improve compatibility

### DIFF
--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -1,8 +1,9 @@
 mix docs
 
 echo "var versionNodes = [" > ./doc/.doc-versions.js
-app=`mix run -e 'IO.puts(Mix.Project.config()[:app])'`; \
-for v in $(git tag | tac); do echo "{version: \"$v\", url: \"https://anoma.github.io/anoma/$v/\"}," >> ./doc/.doc-versions.js; done
+for v in $(git tag | sort -Vr); do
+    echo "{version: \"$v\", url: \"https://anoma.github.io/anoma/$v/\"}," >> ./doc/.doc-versions.js
+done
 echo "]" >> ./doc/.doc-versions.js
 
 cat << EOF >> ./doc/.doc-versions.js
@@ -17,15 +18,12 @@ function comparePartials(versionA, versionB) {
     let splitB = b.split('.');
     const length = Math.max(splitA.length, splitB.length);
     for (let i = 0; i < length; i++) {
-        if (parseInt(splitA[i]) > parseInt(splitB[i]) ||
-            ((splitA[i] === splitB[i]) && isNaN(splitB[i + 1]))) {
-            return 1;
-        }
-        if (parseInt(splitA[i]) < parseInt(splitB[i]) ||
-            ((splitA[i] === splitB[i]) && isNaN(splitA[i + 1]))) {
-            return -1;
-        }
+        let partA = parseInt(splitA[i] || 0);
+        let partB = parseInt(splitB[i] || 0);
+        if (partA > partB) return 1;
+        if (partA < partB) return -1;
     }
+    return 0;
 }
 
 versionNodes = versionNodes.sort(comparePartials).reverse()


### PR DESCRIPTION
I've fixed the version comparison logic to ensure it works correctly across different platforms. Replaced `tac` with `sort -Vr` for better compatibility. Also removed an unused `app` variable and confirmed that `EOF` properly closes the `cat` block. These changes should make the script more reliable and portable.