### PR TITLE
Fix Wrong From Noun for Lists

### DIFF
--- a/apps/anoma_lib/lib/noun/nounable.ex
+++ b/apps/anoma_lib/lib/noun/nounable.ex
@@ -17,6 +17,8 @@ alias Noun.Nounable
 alias Noun.Nounable.Kind
 
 defimpl Nounable, for: List do
+  import Noun
+
   @moduledoc """
   I offer an implementation of Nounable and from_noun for lists
   """
@@ -31,8 +33,7 @@ defimpl Nounable, for: List do
   I do not recursively convert the structures in the list.
   """
   @spec from_noun(Noun.t()) :: {:ok, list(Noun.t())} | :error
-  def from_noun(0), do: {:ok, []}
-  def from_noun([]), do: {:ok, []}
+  def from_noun(zero) when is_noun_zero(zero), do: {:ok, []}
 
   def from_noun([h | t]) do
     with {:ok, ts} <- from_noun(t) do


### PR DESCRIPTION
Previously the from_noun for lists did not include the empty bitstring