### PR TITLE
Make Blocks Scryable

### DIFF
--- a/apps/anoma_node/lib/node/replay/start_state.ex
+++ b/apps/anoma_node/lib/node/replay/start_state.ex
@@ -210,7 +210,9 @@ defmodule Anoma.Node.Replay.State do
 
         blocks ->
           blocks
-          |> Enum.reduce(default_summary, fn {_, round, txs}, summary ->
+          |> Enum.reduce(default_summary, fn {_, ["anoma", "block", round],
+                                              txs},
+                                             summary ->
             summary
             |> Map.update!(:last_round, &max(round, &1))
             |> Map.update!(:transaction_count, &(&1 + Enum.count(txs)))

--- a/apps/anoma_node/lib/node/transaction/mempool/mempool.ex
+++ b/apps/anoma_node/lib/node/transaction/mempool/mempool.ex
@@ -125,6 +125,31 @@ defmodule Anoma.Node.Transaction.Mempool do
     end
   end
 
+  defimpl Noun.Nounable, for: Tx do
+    @impl true
+    def to_noun(t) do
+      tx_result =
+        case t.tx_result do
+          {:ok, noun} -> ["ok" | noun]
+          res -> Noun.Nounable.to_noun(res)
+        end
+
+      vm_result =
+        case t.vm_result do
+          {:ok, noun} -> ["ok" | noun]
+          res -> Noun.Nounable.to_noun(res)
+        end
+
+      backend =
+        case t.backend do
+          {:debug_read_term, _} -> "read"
+          res -> Noun.Nounable.to_noun(res)
+        end
+
+      [tx_result, vm_result, backend | t.code]
+    end
+  end
+
   typedstruct do
     @typedoc """
     I am the type of the Mempool Engine.

--- a/apps/anoma_node/lib/node/transaction/storage/storage.ex
+++ b/apps/anoma_node/lib/node/transaction/storage/storage.ex
@@ -452,7 +452,11 @@ defmodule Anoma.Node.Transaction.Storage do
         :mnesia.write({updates_table(state.node_id), key, new_updates})
       end
 
-      :mnesia.write({blocks_table(state.node_id), round, writes})
+      noun_writes = Enum.map(writes, &Noun.Nounable.to_noun/1)
+
+      :mnesia.write(
+        {blocks_table(state.node_id), ["anoma", "block", round], noun_writes}
+      )
     end
 
     :mnesia.transaction(mnesia_tx)


### PR DESCRIPTION
Makes blocks be stored in the noun format with appropriate keyspace for further scry intergrations.