### PR TITLE
TRM RLPS Inputs Change

### DIFF
--- a/apps/anoma_client/lib/api/intents.ex
+++ b/apps/anoma_client/lib/api/intents.ex
@@ -6,7 +6,7 @@ defmodule Anoma.Client.Api.Servers.Intents do
   alias Anoma.Protobuf.Intents.Compose
   alias Anoma.Protobuf.Intents.Intent
   alias Anoma.Protobuf.Intents.Verify
-  alias Anoma.TransparentResource.Transaction
+  alias Anoma.RM.Transparent.Transaction
 
   require Logger
 
@@ -44,7 +44,7 @@ defmodule Anoma.Client.Api.Servers.Intents do
       # cue the jammed intents into nouns
       |> Enum.map(&Noun.Jam.cue!(&1))
       # nouns to transactions
-      |> Enum.map(&Anoma.TransparentResource.Transaction.from_noun(&1))
+      |> Enum.map(&Transaction.from_noun(&1))
       # unpack {:ok, tx} tuples
       |> Enum.map(fn {:ok, x} -> x end)
 

--- a/apps/anoma_client/lib/client.ex
+++ b/apps/anoma_client/lib/client.ex
@@ -9,7 +9,7 @@ defmodule Anoma.Client do
   alias Anoma.Client.ConnectionSupervisor
   alias Anoma.Client.Runner
   alias Anoma.Protobuf.Intents.Intent
-  alias Anoma.TransparentResource.Transaction
+  alias Anoma.RM.Transparent.Transaction
 
   use TypedStruct
 

--- a/apps/anoma_client/lib/client/runner.ex
+++ b/apps/anoma_client/lib/client/runner.ex
@@ -1,7 +1,7 @@
 defmodule Anoma.Client.Runner do
   alias Anoma.Client.Storage
   alias Anoma.Client.Connection.GRPCProxy
-  alias Anoma.TransparentResource.Transaction
+  alias Anoma.RM.Transparent.Transaction
 
   @doc """
   I run the given Nock program with its inputs and return the result.
@@ -31,9 +31,9 @@ defmodule Anoma.Client.Runner do
         try do
           {:ok, tx} = noun |> Transaction.from_noun()
 
-          for {key, {value, bool}} <- Transaction.app_data(tx) do
+          for {binary, bool} <- Transaction.app_data(tx) do
             if bool do
-              Storage.write({key |> Noun.list_nock_to_erlang(), value})
+              Storage.write({:crypto.hash(:sha256, binary), binary})
             end
           end
         rescue

--- a/apps/anoma_client/lib/client/runner.ex
+++ b/apps/anoma_client/lib/client/runner.ex
@@ -26,7 +26,7 @@ defmodule Anoma.Client.Runner do
     scry = fn [id | ref] ->
       case Storage.read_with_id({id, ref}) do
         {:ok, val} ->
-          {:ok, val}
+          {:ok, val |> Noun.Nounable.to_noun()}
 
         :absent ->
           tx_candidate = ref |> ro_tx_candidate() |> Noun.Jam.jam()

--- a/apps/anoma_client/lib/examples/e_client.ex
+++ b/apps/anoma_client/lib/examples/e_client.ex
@@ -20,8 +20,8 @@ defmodule Anoma.Client.Examples.EClient do
   alias Anoma.Protobuf.NockService
   alias Anoma.Protobuf.NodeInfo
   alias Examples.ETransparent.ETransaction
-  alias Anoma.TransparentResource.Action
-  alias Anoma.TransparentResource.Transaction
+  alias Anoma.RM.Transparent.Action
+  alias Anoma.RM.Transparent.Transaction
   alias Noun.Nounable
 
   import ExUnit.Assertions
@@ -322,11 +322,8 @@ defmodule Anoma.Client.Examples.EClient do
   def prove_with_internal_scry_call(conn \\ setup()) do
     Anoma.Client.Examples.EStorage.setup()
 
-    blob_key = ["anoma", "blob", <<123>>]
-    blob_value = "i am scried"
-
     action =
-      %Action{app_data: %{blob_key => {blob_value, true}}}
+      %Action{app_data: %{<<123>> => {"i am scried", true}}}
 
     tx =
       %Transaction{actions: MapSet.new([action])} |> Noun.Nounable.to_noun()
@@ -346,7 +343,10 @@ defmodule Anoma.Client.Examples.EClient do
 
     assert res == Noun.Jam.jam(tx)
 
-    assert {:ok, ^blob_value} = Storage.read({System.os_time(), blob_key})
+    assert {:ok, "i am scried"} =
+             Storage.read(
+               {System.os_time(), :crypto.hash(:sha256, "i am scried")}
+             )
 
     res
   end

--- a/apps/anoma_client/lib/examples/e_client.ex
+++ b/apps/anoma_client/lib/examples/e_client.ex
@@ -445,6 +445,43 @@ defmodule Anoma.Client.Examples.EClient do
     res
   end
 
+  @spec prove_with_external_scry_call_nounify(EConnection.t()) ::
+          Prove.Response.t()
+  def prove_with_external_scry_call_nounify(conn \\ setup()) do
+    Anoma.Client.Examples.EStorage.setup()
+
+    val = MapSet.new(["i am a set"])
+    key = ["anoma", "blob", "key"]
+
+    Anoma.Node.Transaction.Storage.write(
+      conn.client.node.node_id,
+      {1, [{key, val}]}
+    )
+
+    program = [[12, [1], 1 | ["id" | key]]] |> Noun.Jam.jam()
+
+    request = %Prove.Request{
+      program: {:jammed_program, program},
+      public_inputs: []
+    }
+
+    {:ok, response} = NockService.Stub.prove(conn.channel, request)
+
+    {:success, int_res} = response.result
+
+    res = int_res.result
+
+    noun_val = val |> Noun.Nounable.to_noun()
+
+    assert Noun.Jam.jam(noun_val) == res
+
+    {:ok, read_res} = Storage.read({System.os_time(), key})
+
+    assert Noun.equal?(read_res, noun_val)
+
+    res
+  end
+
   ############################################################
   #                           Helpers                        #
   ############################################################

--- a/apps/anoma_lib/lib/anoma/rm/transparent/action.ex
+++ b/apps/anoma_lib/lib/anoma/rm/transparent/action.ex
@@ -23,6 +23,7 @@ defmodule Anoma.RM.Transparent.Action do
   alias Anoma.RM.Transparent.ProvingSystem.RLPS
   alias Anoma.RM.Transparent.Primitive.DeltaHash
   alias Anoma.RM.Transparent.ProvingSystem.CPS.Instance
+  alias __MODULE__
 
   require Logger
   use TypedStruct
@@ -331,14 +332,16 @@ defmodule Anoma.RM.Transparent.Action do
     end
   end
 
-  @spec to_noun(t()) :: Noun.t()
-  def to_noun(t) do
-    [
-      Noun.Nounable.to_noun(t.created),
-      Noun.Nounable.to_noun(t.consumed),
-      Noun.Nounable.to_noun(t.resource_logic_proofs),
-      Noun.Nounable.to_noun(t.compliance_units)
-      | Noun.Nounable.to_noun(t.app_data)
-    ]
+  defimpl Noun.Nounable, for: Action do
+    @impl true
+    def to_noun(t = %Action{}) do
+      [
+        Noun.Nounable.to_noun(t.created),
+        Noun.Nounable.to_noun(t.consumed),
+        Noun.Nounable.to_noun(t.resource_logic_proofs),
+        Noun.Nounable.to_noun(t.compliance_units)
+        | Noun.Nounable.to_noun(t.app_data)
+      ]
+    end
   end
 end

--- a/apps/anoma_lib/lib/anoma/rm/transparent/action.ex
+++ b/apps/anoma_lib/lib/anoma/rm/transparent/action.ex
@@ -144,6 +144,31 @@ defmodule Anoma.RM.Transparent.Action do
   end
 
   @doc """
+  I am the root function for the transparent action.
+
+  I go through the roots in the compliance units that are used for non
+  ephemetal resources and collect them in a set
+  """
+  @spec roots(t()) :: MapSet.t(integer())
+  def roots(t) do
+    for cu <- t.compliance_units, reduce: MapSet.new() do
+      acc -> ComplianceUnit.roots(cu) |> MapSet.union(acc)
+    end
+  end
+
+  @doc """
+  I am the app data function.
+
+  I gather all the app data used up in a transparent transaction.
+  """
+  @spec app_data(t()) :: MapSet.t({binary(), bool()})
+  def app_data(t) do
+    for {_key, value} <- t.app_data, reduce: MapSet.new() do
+      acc -> MapSet.put(acc, value)
+    end
+  end
+
+  @doc """
   I am the check for compliance units in a transparent action.
 
   I simply go through the compliance units and verify each one using the

--- a/apps/anoma_lib/lib/anoma/rm/transparent/compliance_unit.ex
+++ b/apps/anoma_lib/lib/anoma/rm/transparent/compliance_unit.ex
@@ -15,6 +15,7 @@ defmodule Anoma.RM.Transparent.ComplianceUnit do
   """
   alias Anoma.RM.Transparent.ProvingSystem.CPS
   alias Anoma.RM.Transparent.ProvingSystem.CPS.Instance
+  alias __MODULE__
 
   use TypedStruct
 
@@ -88,8 +89,10 @@ defmodule Anoma.RM.Transparent.ComplianceUnit do
     end
   end
 
-  @spec to_noun(t()) :: Noun.t()
-  def to_noun(t) do
-    [<<>>, Instance.to_noun(t.instance) | <<>>]
+  defimpl Noun.Nounable, for: ComplianceUnit do
+    @impl true
+    def to_noun(t = %ComplianceUnit{}) do
+      [<<>>, Noun.Nounable.to_noun(t.instance) | <<>>]
+    end
   end
 end

--- a/apps/anoma_lib/lib/anoma/rm/transparent/compliance_unit.ex
+++ b/apps/anoma_lib/lib/anoma/rm/transparent/compliance_unit.ex
@@ -58,6 +58,29 @@ defmodule Anoma.RM.Transparent.ComplianceUnit do
   end
 
   @doc """
+  I am the function to get roots for a TRM compliance unit.
+
+  I go thtough the consumed field and get the provided roots for
+  non-ephemeral consumed resources.
+  """
+  @spec roots(t()) :: MapSet.t(integer())
+  def roots(t) do
+    for {nlf, root, _} <- t.instance.consumed, reduce: MapSet.new() do
+      acc ->
+        with {:ok, resource} <-
+               Anoma.RM.Transparent.ProvingSystem.RLPS.match_resource(
+                 nlf,
+                 true
+               ),
+             false <- resource.isephemeral do
+          MapSet.put(acc, root)
+        else
+          _ -> acc
+        end
+    end
+  end
+
+  @doc """
   I am the creation API for the compliance unit of the TRM.
 
   Given a key, instance, and proof for the unit, I put them as appropriate

--- a/apps/anoma_lib/lib/anoma/rm/transparent/proving_systems/cps.ex
+++ b/apps/anoma_lib/lib/anoma/rm/transparent/proving_systems/cps.ex
@@ -52,12 +52,14 @@ defmodule Anoma.RM.Transparent.ProvingSystem.CPS.Instance do
     end
   end
 
-  @spec to_noun(t()) :: Noun.t()
-  def to_noun(instance) do
-    [
-      Noun.Nounable.to_noun(instance.consumed),
-      Noun.Nounable.to_noun(instance.created) | instance.unit_delta
-    ]
+  defimpl Noun.Nounable, for: Instance do
+    @impl true
+    def to_noun(instance = %Instance{}) do
+      [
+        Noun.Nounable.to_noun(instance.consumed),
+        Noun.Nounable.to_noun(instance.created) | instance.unit_delta
+      ]
+    end
   end
 end
 
@@ -85,6 +87,7 @@ defmodule Anoma.RM.Transparent.ProvingSystem.CPS do
   alias Anoma.RM.Transparent.Primitive.CommitmentAccumulator
   alias Anoma.RM.Transparent.Resource
   alias Anoma.RM.Transparent.ProvingSystem.CPS.Instance
+  alias __MODULE__
 
   require Logger
   use TypedStruct
@@ -143,7 +146,8 @@ defmodule Anoma.RM.Transparent.ProvingSystem.CPS do
              9,
              2,
              10,
-             [6, 1 | Instance.to_noun(instance)]
+             [6, 1 | Noun.Nounable.to_noun(instance)],
+             0 | 1
            ]) do
       Noun.equal?(res, 0)
     else
@@ -310,13 +314,15 @@ defmodule Anoma.RM.Transparent.ProvingSystem.CPS do
     end
   end
 
-  @spec to_noun(t()) :: Noun.t()
-  def to_noun(t) do
-    [
-      t.proving_key,
-      t.verifying_key,
-      Instance.to_noun(t.instance),
-      <<>> | <<>>
-    ]
+  defimpl Noun.Nounable, for: CPS do
+    @impl true
+    def to_noun(t = %CPS{}) do
+      [
+        t.proving_key,
+        t.verifying_key,
+        Noun.Nounable.to_noun(t.instance),
+        <<>> | <<>>
+      ]
+    end
   end
 end

--- a/apps/anoma_lib/lib/anoma/rm/transparent/proving_systems/dps.ex
+++ b/apps/anoma_lib/lib/anoma/rm/transparent/proving_systems/dps.ex
@@ -39,9 +39,11 @@ defmodule Anoma.RM.Transparent.ProvingSystem.DPS.Instance do
     end
   end
 
-  @spec to_noun(t()) :: Noun.t()
-  def to_noun(instance) do
-    [instance.delta | instance.expected_balance]
+  defimpl Noun.Nounable, for: Instance do
+    @impl true
+    def to_noun(instance = %Instance{}) do
+      [instance.delta | instance.expected_balance]
+    end
   end
 end
 
@@ -63,7 +65,7 @@ defmodule Anoma.RM.Transparent.ProvingSystem.DPS do
   - `verify/3`
   """
   alias Anoma.RM.Transparent.ProvingSystem.DPS.Instance
-
+  alias __MODULE__
   use TypedStruct
 
   @type dps_key :: <<>>
@@ -130,7 +132,8 @@ defmodule Anoma.RM.Transparent.ProvingSystem.DPS do
              9,
              2,
              10,
-             [6, 1 | Instance.to_noun(instance)]
+             [6, 1 | Noun.Nounable.to_noun(instance)],
+             0 | 1
            ]) do
       Noun.equal?(res, 0)
     else
@@ -162,13 +165,15 @@ defmodule Anoma.RM.Transparent.ProvingSystem.DPS do
     end
   end
 
-  @spec to_noun(t()) :: Noun.t()
-  def to_noun(t) do
-    [
-      t.proving_key,
-      t.verifying_key,
-      Instance.to_noun(t.instance),
-      <<>> | <<>>
-    ]
+  defimpl Noun.Nounable, for: DPS do
+    @impl true
+    def to_noun(t = %DPS{}) do
+      [
+        t.proving_key,
+        t.verifying_key,
+        Noun.Nounable.to_noun(t.instance),
+        <<>> | <<>>
+      ]
+    end
   end
 end

--- a/apps/anoma_lib/lib/anoma/rm/transparent/proving_systems/rlps.ex
+++ b/apps/anoma_lib/lib/anoma/rm/transparent/proving_systems/rlps.ex
@@ -54,15 +54,17 @@ defmodule Anoma.RM.Transparent.ProvingSystem.RLPS.Instance do
     end
   end
 
-  @spec to_noun(t()) :: Noun.t()
-  def to_noun(instance) do
-    [
-      instance.tag,
-      Noun.Nounable.Bool.to_noun(instance.flag),
-      instance.consumed,
-      instance.created
-      | Noun.Nounable.to_noun(instance.app_data)
-    ]
+  defimpl Noun.Nounable, for: Instance do
+    @impl true
+    def to_noun(instance = %Instance{}) do
+      [
+        instance.tag,
+        Noun.Nounable.Bool.to_noun(instance.flag),
+        instance.consumed,
+        instance.created
+        | Noun.Nounable.to_noun(instance.app_data)
+      ]
+    end
   end
 end
 
@@ -83,6 +85,7 @@ defmodule Anoma.RM.Transparent.ProvingSystem.RLPS do
   """
   alias Anoma.RM.Transparent.Resource
   alias Anoma.RM.Transparent.ProvingSystem.RLPS.Instance
+  alias __MODULE__
 
   require Logger
   use TypedStruct
@@ -128,7 +131,8 @@ defmodule Anoma.RM.Transparent.ProvingSystem.RLPS do
              9,
              2,
              10,
-             [6, 1 | Instance.to_noun(instance)]
+             [6, 1 | Noun.Nounable.to_noun(instance)],
+             0 | 1
            ]) do
       Noun.equal?(res, 0)
     else
@@ -172,7 +176,7 @@ defmodule Anoma.RM.Transparent.ProvingSystem.RLPS do
   end
 
   @spec from_noun(Noun.t()) :: {:ok, t()} | :error
-  def from_noun([pk, vk, instance, witness, proof]) do
+  def from_noun([pk, vk, instance, witness | proof]) do
     with true <-
            Noun.atom_integer_to_binary(pk) == Noun.atom_integer_to_binary(vk),
          {:ok, instance} <- Instance.from_noun(instance),
@@ -184,13 +188,15 @@ defmodule Anoma.RM.Transparent.ProvingSystem.RLPS do
     end
   end
 
-  @spec to_noun(t()) :: Noun.t()
-  def to_noun(t) do
-    [
-      t.proving_key,
-      t.verifying_key,
-      Instance.to_noun(t.instance),
-      <<>> | <<>>
-    ]
+  defimpl Noun.Nounable, for: RLPS do
+    @impl true
+    def to_noun(t = %RLPS{}) do
+      [
+        t.proving_key,
+        t.verifying_key,
+        Noun.Nounable.to_noun(t.instance),
+        <<>> | <<>>
+      ]
+    end
   end
 end

--- a/apps/anoma_lib/lib/anoma/rm/transparent/proving_systems/rlps.ex
+++ b/apps/anoma_lib/lib/anoma/rm/transparent/proving_systems/rlps.ex
@@ -146,6 +146,41 @@ defmodule Anoma.RM.Transparent.ProvingSystem.RLPS do
   end
 
   @doc """
+  I am function for turning a resource logic proving system instance to
+  a resource logic format for transparent RM.
+
+  Instead of the pure instance, I supply to the logic underlying resource
+  plaintexts which we can get as we are dealing with commitments and
+  nullifiers transparently.
+  """
+  @spec to_noun_rl_args(Instance.t()) :: Noun.t()
+  def to_noun_rl_args(instance) do
+    {:ok, res} = instance.tag |> match_resource(instance.flag)
+
+    consumed =
+      instance.consumed
+      |> Enum.map(fn nlf ->
+        {:ok, res} = match_resource(nlf, true)
+        Noun.Nounable.to_noun(res)
+      end)
+
+    created =
+      instance.created
+      |> Enum.map(fn cm ->
+        {:ok, res} = match_resource(cm, false)
+        Noun.Nounable.to_noun(res)
+      end)
+
+    [
+      Noun.Nounable.to_noun(res),
+      Noun.Nounable.Bool.to_noun(instance.flag),
+      consumed,
+      created
+      | Noun.Nounable.to_noun(instance.app_data)
+    ]
+  end
+
+  @doc """
   I am a function to matching the resource form the tag provided.
 
   In particular, given a flag I try to un-match the jammed resource from

--- a/apps/anoma_lib/lib/anoma/rm/transparent/proving_systems/rlps.ex
+++ b/apps/anoma_lib/lib/anoma/rm/transparent/proving_systems/rlps.ex
@@ -131,7 +131,7 @@ defmodule Anoma.RM.Transparent.ProvingSystem.RLPS do
              9,
              2,
              10,
-             [6, 1 | Noun.Nounable.to_noun(instance)],
+             [6, 1 | to_noun_rl_args(instance)],
              0 | 1
            ]) do
       Noun.equal?(res, 0)

--- a/apps/anoma_lib/lib/anoma/rm/transparent/resource.ex
+++ b/apps/anoma_lib/lib/anoma/rm/transparent/resource.ex
@@ -50,7 +50,7 @@ defmodule Anoma.RM.Transparent.Resource do
   """
   @spec commitment_hash(t()) :: integer()
   def commitment_hash(resource) do
-    binary_resource = resource |> to_noun() |> Noun.Jam.jam()
+    binary_resource = resource |> Noun.Nounable.to_noun() |> Noun.Jam.jam()
     ("CM_" <> binary_resource) |> Noun.atom_binary_to_integer()
   end
 
@@ -62,7 +62,7 @@ defmodule Anoma.RM.Transparent.Resource do
   """
   @spec nullifier_hash(<<_::256>>, t()) :: integer()
   def nullifier_hash(_nullifier_key, resource) do
-    binary_resource = resource |> to_noun() |> Noun.Jam.jam()
+    binary_resource = resource |> Noun.Nounable.to_noun() |> Noun.Jam.jam()
     ("NF_" <> binary_resource) |> Noun.atom_binary_to_integer()
   end
 
@@ -90,18 +90,20 @@ defmodule Anoma.RM.Transparent.Resource do
     :crypto.hash(:sha256, kind)
   end
 
-  @spec to_noun(Resource.t()) :: Noun.t()
-  def to_noun(resource = %Resource{}) do
-    [
-      resource.logicref,
-      resource.labelref,
-      resource.valueref,
-      resource.quantity,
-      Noun.Nounable.to_noun(resource.isephemeral),
-      resource.nonce,
-      resource.nullifierkeycommitment
-      | resource.randseed
-    ]
+  defimpl Noun.Nounable, for: Resource do
+    @impl true
+    def to_noun(resource = %Resource{}) do
+      [
+        resource.logicref,
+        resource.labelref,
+        resource.valueref,
+        resource.quantity,
+        Noun.Nounable.to_noun(resource.isephemeral),
+        resource.nonce,
+        resource.nullifierkeycommitment
+        | resource.randseed
+      ]
+    end
   end
 
   @spec from_noun(Noun.t()) :: :error | {:ok, t()}

--- a/apps/anoma_lib/lib/anoma/rm/transparent/resource.ex
+++ b/apps/anoma_lib/lib/anoma/rm/transparent/resource.ex
@@ -137,4 +137,22 @@ defmodule Anoma.RM.Transparent.Resource do
       _ -> :error
     end
   end
+
+  @spec commits?(t(), Noun.noun_atom()) :: boolean()
+  def commits?(self = %Resource{}, commitment) when is_binary(commitment) do
+    commits?(self, Noun.atom_binary_to_integer(commitment))
+  end
+
+  def commits?(self = %Resource{}, commitment) when is_integer(commitment) do
+    commitment_hash(self) == commitment
+  end
+
+  @spec nullifies?(t(), Noun.noun_atom()) :: boolean()
+  def nullifies?(self = %Resource{}, nullifier) when is_binary(nullifier) do
+    nullifies?(self, Noun.atom_binary_to_integer(nullifier))
+  end
+
+  def nullifies?(self = %Resource{}, nullifier) when is_integer(nullifier) do
+    nullifier_hash(<<0::256>>, self) == nullifier
+  end
 end

--- a/apps/anoma_lib/lib/anoma/rm/transparent/transaction.ex
+++ b/apps/anoma_lib/lib/anoma/rm/transparent/transaction.ex
@@ -20,6 +20,7 @@ defmodule Anoma.RM.Transparent.Transaction do
   alias Anoma.RM.Transparent.ProvingSystem.DPS
   alias Anoma.RM.Transparent.Primitive.DeltaHash
   alias Anoma.RM.Transparent.Action
+  alias __MODULE__
 
   require Logger
   use TypedStruct
@@ -192,11 +193,13 @@ defmodule Anoma.RM.Transparent.Transaction do
     end
   end
 
-  @spec to_noun(t()) :: Noun.t()
-  def to_noun(t) do
-    [
-      Noun.Nounable.to_noun(t.roots),
-      Noun.Nounable.to_noun(t.actions) | <<>>
-    ]
+  defimpl Noun.Nounable, for: Transaction do
+    @impl true
+    def to_noun(t) do
+      [
+        Noun.Nounable.to_noun(t.roots),
+        Noun.Nounable.to_noun(t.actions) | <<>>
+      ]
+    end
   end
 end

--- a/apps/anoma_lib/lib/anoma/rm/transparent/transaction.ex
+++ b/apps/anoma_lib/lib/anoma/rm/transparent/transaction.ex
@@ -250,3 +250,27 @@ defmodule Anoma.RM.Transparent.Transaction do
     end
   end
 end
+
+defimpl Anoma.RM.Intent, for: Anoma.RM.Transparent.Transaction do
+  alias Anoma.RM.Transparent.Transaction
+
+  @impl true
+  def compose(t1 = %Transaction{}, t2 = %Transaction{}) do
+    Transaction.compose(t1, t2)
+  end
+
+  @impl true
+  def verify(tx = %Transaction{}) do
+    Transaction.verify(tx)
+  end
+
+  @impl true
+  def nullifiers(tx = %Transaction{}) do
+    Transaction.nullifiers(tx)
+  end
+
+  @impl true
+  def commitments(tx = %Transaction{}) do
+    Transaction.commitments(tx)
+  end
+end

--- a/apps/anoma_lib/lib/anoma/rm/transparent/transaction.ex
+++ b/apps/anoma_lib/lib/anoma/rm/transparent/transaction.ex
@@ -103,6 +103,53 @@ defmodule Anoma.RM.Transparent.Transaction do
   end
 
   @doc """
+  I am the root function for the transparent transaction.
+
+  I collect the roots for non-ephemeral consumed resources that are
+  kept in the underlying actions.
+  """
+  @spec roots(t()) :: MapSet.t(integer())
+  def roots(t) do
+    for action <- t.actions, reduce: MapSet.new() do
+      acc -> Action.roots(action) |> MapSet.union(acc)
+    end
+  end
+
+  @doc """
+  I am a function for getting the commitments out of a transparent
+  transaction
+  """
+  @spec commitments(t()) :: MapSet.t(integer())
+  def commitments(t) do
+    {:ok, precis} = Transaction.action_precis(t)
+    precis.created
+  end
+
+  @doc """
+  I am a function for getting the nullifiers out of a transparent
+  transaction
+  """
+  @spec nullifiers(t()) :: MapSet.t(integer())
+  def nullifiers(t) do
+    {:ok, precis} = Transaction.action_precis(t)
+    precis.consumed
+  end
+
+  @doc """
+  I am a function for getting the app data out of a transparent
+  transaction.
+
+  I go through the list of actions inside the transaction and gather their
+  app data
+  """
+  @spec app_data(t()) :: MapSet.t({binary(), bool()})
+  def app_data(t) do
+    for action <- t.actions, reduce: MapSet.new() do
+      acc -> Action.app_data(action) |> MapSet.union(acc)
+    end
+  end
+
+  @doc """
   I am the actions check for the transparent transaction.
 
   I verify each action in the approprite field using the provided interface.

--- a/apps/anoma_lib/lib/examples/e_transparent/e_action.ex
+++ b/apps/anoma_lib/lib/examples/e_transparent/e_action.ex
@@ -1,7 +1,8 @@
 defmodule Examples.ETransparent.EAction do
-  alias Anoma.TransparentResource.Action
-  alias Anoma.TransparentResource.Delta
-  alias Examples.ETransparent.ELogicProof
+  alias Examples.ETransparent.EResource
+  alias Anoma.RM.Transparent.Action
+  alias Anoma.RM.Transparent.Resource
+  alias Anoma.RM.Transparent.Primitive.CommitmentAccumulator
 
   use TestHelper.TestMacro
 
@@ -9,125 +10,72 @@ defmodule Examples.ETransparent.EAction do
   def empty() do
     res = %Action{}
 
-    assert Action.verify_correspondence(res)
-    assert %{} = Action.delta(res)
-    res
-  end
-
-  @spec trivial_action_only_proofs() :: Action.t()
-  def trivial_action_only_proofs() do
-    res = %Action{
-      empty()
-      | proofs: MapSet.new([ELogicProof.trivial_true_swap_proof_commitment()])
-    }
-
-    assert {:error, _} = Action.verify_correspondence(res)
-
-    res
-  end
-
-  @spec trivial_action_proofs_proof_and_commitments() :: Action.t()
-  def trivial_action_proofs_proof_and_commitments() do
-    commitments = ELogicProof.trivial_true_swap_proof_commitment().commitments
-
-    res = %Action{
-      trivial_action_only_proofs()
-      | commitments: commitments
-    }
-
-    assert {:error, _} = Action.verify_correspondence(res)
-
-    res
-  end
-
-  @spec trivial_action_proofs_missing_nullifier_proof() :: Action.t()
-  def trivial_action_proofs_missing_nullifier_proof() do
-    nullifiers = ELogicProof.trivial_true_swap_proof_commitment().nullifiers
-
-    res = %Action{
-      trivial_action_proofs_proof_and_commitments()
-      | nullifiers: nullifiers
-    }
-
-    assert {:error, _} = Action.verify_correspondence(res)
-
+    assert 2 = Action.delta(res)
+    assert Action.verify(res)
     res
   end
 
   @spec trivial_swap_action() :: Action.t()
   def trivial_swap_action() do
-    action = trivial_action_proofs_missing_nullifier_proof()
+    consumed = EResource.trivial_true_resource_2()
+    created = EResource.trivial_true_resource()
+    cm = consumed |> Resource.commitment_hash()
+    root = MapSet.new([cm]) |> CommitmentAccumulator.value()
 
-    res = %Action{
-      trivial_action_proofs_missing_nullifier_proof()
-      | proofs:
-          MapSet.put(
-            action.proofs,
-            ELogicProof.trivial_true_swap_proof_nullifier()
-          )
-    }
+    res =
+      Action.create(
+        [{<<0::256>>, consumed, root}],
+        [created],
+        %{}
+      )
 
-    assert Action.verify_correspondence(res)
-    assert %{} = Action.delta(res)
+    assert 2 = Action.delta(res)
+    assert Action.verify(res)
 
     res
   end
 
   @spec trivial_true_commit_action() :: Action.t()
   def trivial_true_commit_action() do
-    logic_proof = ELogicProof.trivial_true_commitment()
-
-    res = %Action{
-      empty()
-      | proofs: MapSet.new([logic_proof]),
-        commitments: logic_proof.commitments
-    }
-
-    assert Action.verify_correspondence(res)
-
+    created = EResource.trivial_true_resource()
+    # not balanced
+    res = Action.create([], [created], %{})
+    # even if unbalanced, the verify goes through
+    # the action check does not do that
+    assert Action.verify(res)
     res
   end
 
-  @spec trivial_true_commit_delta() :: Delta.t()
+  @spec trivial_true_commit_delta() :: integer()
   def trivial_true_commit_delta() do
-    trivial_true_commit_action() |> Action.delta()
+    res = trivial_true_commit_action() |> Action.delta()
+    assert 2 != res
+    res
   end
 
   @spec trivial_true_2_nullifier_action() :: Action.t()
   def trivial_true_2_nullifier_action() do
-    logic_proof = ELogicProof.trivial_true_2_nullifier()
+    consumed = EResource.trivial_true_resource_2()
+    cm = EResource.trivial_true_resource_2() |> Resource.commitment_hash()
+    root = MapSet.new([cm]) |> CommitmentAccumulator.value()
 
-    res = %Action{
-      empty()
-      | proofs: MapSet.new([logic_proof]),
-        nullifiers: logic_proof.nullifiers
-    }
+    res =
+      Action.create([{<<0::256>>, consumed, root}], [], %{})
 
-    assert Action.verify_correspondence(res)
-
+    assert Action.verify(res)
     res
   end
 
   @spec trivial_true_eph_nullifier_action() :: Action.t()
   def trivial_true_eph_nullifier_action() do
-    logic_proof = ELogicProof.trivial_true_eph_nullifier()
+    consumed = EResource.trivial_true_resource_eph()
+    cm = EResource.trivial_true_resource_eph() |> Resource.commitment_hash()
+    root = MapSet.new([cm]) |> CommitmentAccumulator.value()
 
-    res = %Action{
-      empty()
-      | proofs: MapSet.new([logic_proof]),
-        nullifiers: logic_proof.nullifiers
-    }
+    res =
+      Action.create([{<<0::256>>, consumed, root}], [], %{})
 
-    assert Action.verify_correspondence(res)
-
-    res
-  end
-
-  @spec trivial_true_2_nullifier_delta() :: Delta.t()
-  def trivial_true_2_nullifier_delta() do
-    res = trivial_true_2_nullifier_action() |> Action.delta()
-
-    assert res == Delta.negate(trivial_true_commit_delta())
+    assert Action.verify(res)
 
     res
   end

--- a/apps/anoma_lib/lib/examples/e_transparent/e_resource.ex
+++ b/apps/anoma_lib/lib/examples/e_transparent/e_resource.ex
@@ -1,6 +1,6 @@
 defmodule Examples.ETransparent.EResource do
   alias Anoma.Crypto.Randomness
-  alias Anoma.TransparentResource.Resource
+  alias Anoma.RM.Transparent.Resource
 
   use Memoize
   use TestHelper.TestMacro
@@ -14,7 +14,11 @@ defmodule Examples.ETransparent.EResource do
   def trivial_true_resource_generator() do
     res = %Resource{nonce: Randomness.get_random(32)}
 
-    {:ok, 0} = Nock.nock(res.logic, [9, 2, 0 | 1])
+    {:ok, logic} =
+      res.logicref |> Noun.atom_integer_to_binary() |> Noun.Jam.cue()
+
+    {:ok, result} = Nock.nock(logic, [9, 2, 0 | 1])
+    assert Noun.equal?(result, 0)
     res
   end
 
@@ -26,19 +30,26 @@ defmodule Examples.ETransparent.EResource do
   @spec trivial_false_resource_generator() :: Resource.t()
   def trivial_false_resource_generator() do
     res = %Resource{
-      logic: [[<<1>> | <<1>>], <<>> | <<>>],
+      logicref:
+        [[<<1>> | <<1>>], <<>> | <<>>]
+        |> Noun.Jam.jam()
+        |> Noun.atom_binary_to_integer(),
       nonce: Randomness.get_random(32)
     }
 
     assert {:ok, uncued} =
-             Resource.to_noun(res)
+             Noun.Nounable.to_noun(res)
              |> Noun.Jam.jam()
-             |> Noun.Jam.cue()
-             |> elem(1)
+             |> Noun.Jam.cue!()
              |> Resource.from_noun()
 
     assert uncued == res
-    {:ok, <<1>>} = Nock.nock(res.logic, [9, 2, 0 | 1])
+
+    {:ok, logic} =
+      res.logicref |> Noun.atom_integer_to_binary() |> Noun.Jam.cue()
+
+    {:ok, result} = Nock.nock(logic, [9, 2, 0 | 1])
+    assert Noun.equal?(result, 1)
     res
   end
 
@@ -63,7 +74,7 @@ defmodule Examples.ETransparent.EResource do
     %Resource{
       trivial_true_resource_generator()
       | nonce: Randomness.get_random(32),
-        ephemeral: true
+        isephemeral: true
     }
   end
 
@@ -75,9 +86,9 @@ defmodule Examples.ETransparent.EResource do
     }
   end
 
-  @spec trivial_true_commitment() :: Resource.commitment()
+  @spec trivial_true_commitment() :: integer()
   def trivial_true_commitment() do
-    res = Resource.commitment(trivial_true_resource())
+    res = Resource.commitment_hash(trivial_true_resource())
 
     assert Resource.commits?(trivial_true_resource(), res)
     # The aura of the commitment does not matter
@@ -91,9 +102,9 @@ defmodule Examples.ETransparent.EResource do
     res
   end
 
-  @spec trivial_true_nullifier() :: Resource.nullifier()
+  @spec trivial_true_nullifier() :: integer()
   def trivial_true_nullifier() do
-    res = Resource.nullifier(trivial_true_resource())
+    res = Resource.nullifier_hash(<<0::256>>, trivial_true_resource())
 
     assert Resource.nullifies?(trivial_true_resource(), res)
     # The aura of the commitment does not matter
@@ -107,18 +118,18 @@ defmodule Examples.ETransparent.EResource do
     res
   end
 
-  @spec trivial_true_nullifier_2() :: Resource.nullifier()
+  @spec trivial_true_nullifier_2() :: integer()
   def trivial_true_nullifier_2() do
-    Resource.nullifier(trivial_true_resource_2())
+    Resource.nullifier_hash(<<0::256>>, trivial_true_resource_2())
   end
 
-  @spec trivial_true_nullifier_eph() :: Resource.nullifier()
+  @spec trivial_true_nullifier_eph() :: integer()
   def trivial_true_nullifier_eph() do
-    Resource.nullifier(trivial_true_resource_eph())
+    Resource.nullifier_hash(<<0::256>>, trivial_true_resource_eph())
   end
 
-  @spec trivial_false_commitment() :: Resource.commitment()
+  @spec trivial_false_commitment() :: integer()
   def trivial_false_commitment() do
-    Resource.commitment(trivial_false_resource())
+    Resource.commitment_hash(trivial_false_resource())
   end
 end

--- a/apps/anoma_lib/lib/examples/ecommitment_tree.ex
+++ b/apps/anoma_lib/lib/examples/ecommitment_tree.ex
@@ -1,6 +1,6 @@
 defmodule Examples.ECommitmentTree do
   alias Anoma.Node.Tables
-  alias Anoma.TransparentResource.Transaction
+  alias Anoma.RM.Transparent.Transaction
   alias Examples.ECairo
   alias Examples.ETransparent.ETransaction
 
@@ -51,7 +51,11 @@ defmodule Examples.ECommitmentTree do
 
     commits = Transaction.commitments(transaction)
 
-    {tree, anchor} = CommitmentTree.add(tree, commits |> Enum.to_list())
+    {tree, anchor} =
+      CommitmentTree.add(
+        tree,
+        commits |> Enum.map(&Noun.atom_integer_to_binary/1)
+      )
 
     assert tree.size == MapSet.size(commits)
 

--- a/apps/anoma_lib/lib/examples/enock.ex
+++ b/apps/anoma_lib/lib/examples/enock.ex
@@ -1,7 +1,7 @@
 defmodule Examples.ENock do
-  alias Anoma.TransparentResource.Action
-  alias Anoma.TransparentResource.Delta
-  alias Anoma.TransparentResource.Transaction
+  alias Anoma.RM.Transparent.Action
+  alias Anoma.RM.Transparent.Transaction
+  alias Anoma.RM.Transparent.Primitive.DeltaHash
   alias Examples.ECrypto
   alias Examples.ETransparent.EAction
 
@@ -1986,12 +1986,12 @@ defmodule Examples.ENock do
 
     {:ok, kind} =
       resource
-      |> Anoma.TransparentResource.Resource.to_noun()
+      |> Noun.Nounable.to_noun()
       |> kind_call
       |> Nock.nock([9, 2, 0 | 1])
 
     assert resource
-           |> Anoma.TransparentResource.Resource.kind()
+           |> Anoma.RM.Transparent.Resource.kind()
            |> Noun.equal?(kind)
   end
 
@@ -2008,14 +2008,13 @@ defmodule Examples.ENock do
   end
 
   def delta_add_test() do
-    delta = EAction.trivial_true_commit_delta() |> Delta.to_noun()
+    delta = EAction.trivial_true_commit_delta()
 
-    {:ok, map} =
+    {:ok, delta} =
       delta_add_call(delta, delta) |> Nock.nock([9, 2, 0 | 1])
 
-    {:ok, delta} = map |> Delta.from_noun()
     delta_original = EAction.trivial_true_commit_delta()
-    assert delta == Delta.add(delta_original, delta_original)
+    assert delta == DeltaHash.delta_add(delta_original, delta_original)
   end
 
   def delta_sub_arm() do
@@ -2031,12 +2030,12 @@ defmodule Examples.ENock do
   end
 
   def delta_sub_test() do
-    delta = EAction.trivial_true_commit_delta() |> Delta.to_noun()
+    delta = EAction.trivial_true_commit_delta()
 
     assert delta_sub_call(delta, delta)
            |> Nock.nock([9, 2, 0 | 1])
            |> elem(1)
-           |> Noun.equal?([])
+           |> Noun.equal?(2)
   end
 
   def action_delta_arm() do
@@ -2054,10 +2053,9 @@ defmodule Examples.ENock do
   def action_delta_test() do
     action = EAction.trivial_true_commit_action() |> Noun.Nounable.to_noun()
 
-    {:ok, map} =
+    {:ok, delta} =
       action |> action_delta_call() |> Nock.nock([9, 2, 0 | 1])
 
-    {:ok, delta} = map |> Delta.from_noun()
     delta_original = EAction.trivial_true_commit_action() |> Action.delta()
 
     assert delta == delta_original
@@ -2080,10 +2078,9 @@ defmodule Examples.ENock do
       MapSet.new([EAction.trivial_true_commit_action()])
       |> Noun.Nounable.to_noun()
 
-    {:ok, map} =
+    {:ok, delta} =
       actions |> make_delta_call() |> Nock.nock([9, 2, 0 | 1])
 
-    {:ok, delta} = map |> Delta.from_noun()
     assert delta == EAction.trivial_true_commit_action() |> Action.delta()
   end
 

--- a/apps/anoma_lib/lib/nock/jets/mugs.ex
+++ b/apps/anoma_lib/lib/nock/jets/mugs.ex
@@ -133,10 +133,10 @@ defmodule Nock.Jets.Mugs do
       {"action-delta", 7, @layer_rm, &Nock.Jets.action_delta/1, :enabled, 50},
     (Jets.calculate_core(1494, Nock.Lib.stdlib_layers()) |> hd()) =>
       {"make-delta", 7, @layer_rm, &Nock.Jets.make_delta/1, :enabled, 50},
-    Jets.calculate_mug_of_core(382, Nock.Lib.stdlib_layers()) =>
+    (Jets.calculate_core(382, Nock.Lib.stdlib_layers()) |> hd()) =>
       {"trm-compliance-key", 7, @layer_rm, &Nock.Jets.trm_compliance_key/1,
        :enabled, 10},
-    Jets.calculate_mug_of_core(94, Nock.Lib.stdlib_layers()) =>
+    (Jets.calculate_core(94, Nock.Lib.stdlib_layers()) |> hd()) =>
       {"trm-delta-key", 7, @layer_rm, &Nock.Jets.trm_delta_key/1, :enabled,
        10}
   }

--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -7,7 +7,7 @@ defmodule Anoma.Node.Examples.ETransaction do
   alias Anoma.Node.Transaction.Ordering
   alias Anoma.Node.Transaction.Storage
   alias Anoma.Node.Tables
-  alias Anoma.TransparentResource.Transaction
+  alias Anoma.RM.Transparent.Transaction
   alias Examples.ENock
   alias Examples.ETransparent.ETransaction
 
@@ -403,7 +403,8 @@ defmodule Anoma.Node.Examples.ETransaction do
 
     assert {:ok, cms} == Storage.read(node_id, {1, ["anoma", "commitments"]})
 
-    assert {:ok, Backends.value(cms)} ==
+    assert {:ok,
+            Anoma.RM.Transparent.Primitive.CommitmentAccumulator.value(cms)} ==
              Storage.read(node_id, {1, ["anoma", "anchor"]})
 
     EventBroker.unsubscribe_me([])
@@ -423,12 +424,12 @@ defmodule Anoma.Node.Examples.ETransaction do
       capture_log(fn ->
         Mempool.tx(node_id, code, "id 2")
         Mempool.execute(node_id, Mempool.tx_dump(node_id))
-        recieve_logger_failure(node_id, "nullifier already")
+        recieve_logger_failure(node_id, "already exist")
       end)
 
     # Occasionally, the log might be empty because `Anoma.Node.Logging`
     # hasn't finished writing the log entries yet.
-    assert log =~ "nullifier already" || log == ""
+    assert log =~ "already exist" || log == ""
 
     EventBroker.unsubscribe_me([])
 
@@ -445,12 +446,12 @@ defmodule Anoma.Node.Examples.ETransaction do
       capture_log(fn ->
         Mempool.tx(node_id, code, "id 1")
         Mempool.execute(node_id, Mempool.tx_dump(node_id))
-        recieve_logger_failure(node_id, "not committed")
+        recieve_logger_failure(node_id, "Root does not exist")
       end)
 
     # Occasionally, the log might be empty because `Anoma.Node.Logging`
     # hasn't finished writing the log entries yet.
-    assert log =~ "not committed" || log == ""
+    assert log =~ "Root does not exist" || log == ""
 
     node_id
   end

--- a/apps/anoma_node/lib/node/intents/solver.ex
+++ b/apps/anoma_node/lib/node/intents/solver.ex
@@ -260,13 +260,13 @@ defmodule Anoma.Node.Intents.Solver do
 
   ### Pattern-Matching Variations
 
-  - `submit(%TransparentResource.Transaction{}, node_id)` - I wrap a transaction in trivial
+  - `submit(%RM.Transparent.Transaction{}, node_id)` - I wrap a transaction in trivial
                                                             core and send it to the Mempool.
   - `submit(any, node_id)` - I do nothing
   """
 
   @spec submit(Intent.t(), String.t()) :: :ok
-  def submit(tx = %Anoma.TransparentResource.Transaction{}, node_id) do
+  def submit(tx = %Anoma.RM.Transparent.Transaction{}, node_id) do
     tx_noun = tx |> Noun.Nounable.to_noun()
     tx_candidate = [[1, 0, [1 | tx_noun], 0 | 909], 0 | 707]
     tx_filter = [Node.Event.node_filter(node_id), %Mempool.TxFilter{}]

--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -154,7 +154,7 @@ defmodule Anoma.Node.Transaction.Backends do
                         {id, key |> Noun.list_nock_to_erlang()}
                       )
                   end) do
-            {:ok, value}
+            {:ok, value |> Noun.Nounable.to_noun()}
           else
             _ -> :error
           end

--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -18,9 +18,9 @@ defmodule Anoma.Node.Transaction.Backends do
   alias Anoma.Node.Transaction.Executor
   alias Anoma.Node.Transaction.Ordering
   alias Anoma.Node.Transaction.Storage
-  alias Anoma.TransparentResource
-  alias Anoma.TransparentResource.Resource, as: TResource
-  alias Anoma.TransparentResource.Transaction, as: TTransaction
+  alias Anoma.RM.Transparent.ComplianceUnit, as: TCU
+  alias Anoma.RM.Transparent.Transaction, as: TTransaction
+  alias Anoma.RM.Transparent.Primitive.CommitmentAccumulator, as: TAcc
 
   require Node.Event
   require Noun
@@ -246,16 +246,11 @@ defmodule Anoma.Node.Transaction.Backends do
   @spec transparent_resource_tx(String.t(), binary(), Noun.t()) ::
           {:ok, any} | :error
   defp transparent_resource_tx(node_id, id, result) do
-    storage_checks = fn tx -> storage_check?(node_id, id, tx) end
-    verify_tx_root = fn tx -> verify_tx_root(node_id, tx) end
-
-    verify_options = [
-      double_insertion_closure: storage_checks,
-      root_closure: verify_tx_root
-    ]
-
-    with {:ok, tx} <- TransparentResource.Transaction.from_noun(result),
-         true <- TransparentResource.Transaction.verify(tx, verify_options) do
+    with {:ok, tx} <- TTransaction.from_noun(result),
+         true <- TTransaction.verify(tx),
+         # possibly also add check for CU roots
+         true <- storage_check(node_id, id, tx),
+         true <- verify_tx_root(node_id, tx) do
       map =
         for action <- tx.actions,
             reduce: %{
@@ -265,17 +260,23 @@ defmodule Anoma.Node.Transaction.Backends do
             } do
           %{commitments: cms, nullifiers: nlfs, blobs: blobs} ->
             %{
-              commitments: MapSet.union(cms, action.commitments),
-              nullifiers: MapSet.union(nlfs, action.nullifiers),
+              commitments: MapSet.union(cms, MapSet.new(action.created)),
+              nullifiers: MapSet.union(nlfs, MapSet.new(action.consumed)),
               blobs:
-                for {key, {value, bool}} <- action.app_data, reduce: blobs do
+                for {_tag, list} <- action.app_data, reduce: blobs do
                   acc ->
-                    if Noun.equal?(bool, 0) and
-                         :crypto.hash(:sha256, Noun.Jam.jam(value)) == key do
-                      [{key, value} | acc]
-                    else
-                      acc
-                    end
+                    for {binary, bool} <- list, reduce: [] do
+                      local_acc ->
+                        if bool do
+                          [
+                            {["anoma", "blob", :crypto.hash(:sha256, binary)],
+                             binary}
+                            | local_acc
+                          ]
+                        else
+                          local_acc
+                        end
+                    end ++ acc
                 end
             }
         end
@@ -286,19 +287,16 @@ defmodule Anoma.Node.Transaction.Backends do
           {:ok, res} -> res
         end
 
-      writes =
-        for {key, value} <- map.blobs,
-            reduce: [
-              {anoma_keyspace("anchor"),
-               value(
-                 MapSet.union(
-                   map.commitments,
-                   old_cms
-                 )
-               )}
-            ] do
-          acc -> [{["anoma", "blob", key], value} | acc]
-        end
+      writes = [
+        {anoma_keyspace("anchor"),
+         TAcc.value(
+           MapSet.union(
+             map.commitments,
+             old_cms
+           )
+         )}
+        | map.blobs
+      ]
 
       Ordering.add(
         node_id,
@@ -316,15 +314,14 @@ defmodule Anoma.Node.Transaction.Backends do
 
       {:ok, tx}
     else
-      e ->
-        unless e == :error do
-          Logging.log_event(
-            node_id,
-            :error,
-            "Transaction verification failed. Reason: #{inspect(e)}"
-          )
-        end
+      {:error, msg} ->
+        Logging.log_event(
+          node_id,
+          :error,
+          "Transaction verification failed. Reason: #{inspect(msg)}"
+        )
 
+      _ ->
         :error
     end
   end
@@ -332,145 +329,98 @@ defmodule Anoma.Node.Transaction.Backends do
   @spec verify_tx_root(String.t(), TTransaction.t()) ::
           true | {:error, String.t()}
   defp verify_tx_root(node_id, trans = %TTransaction{}) do
-    with true <- commitments_exist_in_roots(node_id, trans) do
+    with true <- roots_exist?(node_id, trans) do
       true
     else
       {:error, msg} ->
-        {:error,
-         "Nullified resources are not committed at latest root: " <> msg}
+        {:error, "Root does not exist: " <> msg}
     end
   end
 
-  @spec storage_check?(String.t(), binary(), TTransaction.t()) ::
+  @spec storage_check(String.t(), binary(), TTransaction.t()) ::
           true | {:error, String.t()}
-  defp storage_check?(node_id, id, trans) do
+  defp storage_check(node_id, id, trans) do
     stored_commitments =
-      Ordering.read(node_id, {id, anoma_keyspace("commitments")})
+      case Ordering.read(node_id, {id, anoma_keyspace("commitments")}) do
+        :absent -> MapSet.new()
+        {:ok, res} -> res
+      end
 
     stored_nullifiers =
-      Ordering.read(node_id, {id, anoma_keyspace("nullifiers")})
+      case Ordering.read(node_id, {id, anoma_keyspace("nullifiers")}) do
+        :absent -> MapSet.new()
+        {:ok, res} -> res
+      end
 
-    # TODO improve error messages
-    cond do
-      any_nullifiers_already_exist?(stored_nullifiers, trans) ->
-        {:error, "A submitted nullifier already exists in storage"}
+    {:ok, precis} = TTransaction.action_precis(trans)
 
-      any_commitments_already_exist?(stored_commitments, trans) ->
-        {:error, "A submitted commitment already exists in storage"}
-
-      true ->
-        true
+    with true <-
+           any_nullifiers_already_exist?(stored_nullifiers, precis.consumed),
+         true <-
+           any_commitments_already_exist?(stored_commitments, precis.created) do
+      true
+    else
+      {:error, msg} -> {:error, msg}
     end
   end
 
   @spec any_nullifiers_already_exist?(
-          {:ok, MapSet.t(TResource.nullifier())} | :absent,
-          TTransaction.t()
-        ) :: boolean()
-  defp any_nullifiers_already_exist?(:absent, _) do
-    false
-  end
-
+          MapSet.t(integer),
+          MapSet.t(integer)
+        ) :: true | {:error, String.t()}
   defp any_nullifiers_already_exist?(
-         {:ok, stored_nulls},
-         trans = %TTransaction{}
+         old_nulfs,
+         new_nulfs
        ) do
-    nullifiers = TTransaction.nullifiers(trans)
-    Enum.any?(nullifiers, &MapSet.member?(stored_nulls, &1))
-  end
-
-  @spec any_commitments_already_exist?(
-          {:ok, MapSet.t(TResource.commitment())} | :absent,
-          TTransaction.t()
-        ) :: boolean()
-  defp any_commitments_already_exist?(:absent, _) do
-    false
-  end
-
-  defp any_commitments_already_exist?(
-         {:ok, stored_comms},
-         trans = %TTransaction{}
-       ) do
-    commitments = TTransaction.commitments(trans)
-    Enum.any?(commitments, &MapSet.member?(stored_comms, &1))
-  end
-
-  @spec commitments_exist_in_roots(String.t(), TTransaction.t()) ::
-          true | {:error, String.t()}
-  defp commitments_exist_in_roots(
-         node_id,
-         trans = %TTransaction{}
-       ) do
-    latest_root_time =
-      for root <- trans.roots, reduce: 0 do
-        time ->
-          with {:atomic, [{_, {height, _}, ^root}]} <-
-                 :mnesia.transaction(fn ->
-                   :mnesia.match_object(
-                     {Storage.values_table(node_id),
-                      {:_, anoma_keyspace("anchor")}, root}
-                   )
-                 end) do
-            if height > time do
-              height
-            else
-              time
-            end
-          else
-            {:atomic, []} -> time
-          end
-      end
-
-    action_nullifiers = TTransaction.nullifiers(trans)
-
-    if latest_root_time > 0 do
-      {:ok, root_coms} =
-        Storage.read(
-          node_id,
-          {latest_root_time, anoma_keyspace("commitments")}
-        )
-
-      commitments =
-        for <<"NF_", rest::binary>> <- action_nullifiers,
-            reduce: MapSet.new([]) do
-          cm_set ->
-            if ephemeral?(rest) do
-              cm_set
-            else
-              MapSet.put(cm_set, "CM_" <> rest)
-            end
-        end
-
-      case commitments |> MapSet.subset?(root_coms) do
-        true ->
-          true
-
-        _ ->
-          {:error,
-           "commitments absent: #{inspect(MapSet.difference(commitments, root_coms) |> Enum.to_list())}"}
-      end
-    else
-      if Enum.all?(action_nullifiers, fn <<"NF_", rest::binary>> ->
-           ephemeral?(rest)
-         end) do
-        true
-      else
-        {:error, "not all resources ephemeral for initiating transaction"}
-      end
+    case MapSet.intersection(old_nulfs, new_nulfs) |> Enum.to_list() do
+      [] -> true
+      lst -> {:error, "Nullifiers #{inspect(lst)} already exist"}
     end
   end
 
-  @spec ephemeral?(Noun.noun_atom()) :: boolean()
-  defp ephemeral?(jammed_transaction) do
-    nock_boolean =
-      Noun.Jam.cue(jammed_transaction)
-      |> elem(1)
-      |> Noun.list_nock_to_erlang_safe()
-      |> elem(1)
-      |> List.pop_at(2)
-      |> elem(0)
+  @spec any_commitments_already_exist?(
+          MapSet.t(integer),
+          MapSet.t(integer())
+        ) :: true | {:error, String.t()}
+  defp any_commitments_already_exist?(
+         old_cms,
+         new_cms
+       ) do
+    case MapSet.intersection(old_cms, new_cms) |> Enum.to_list() do
+      [] -> true
+      lst -> {:error, "Commitments #{inspect(lst)} already exist"}
+    end
+  end
 
-    nock_boolean in [0, <<>>, <<0>>, []]
+  @spec roots_exist?(String.t(), TTransaction.t()) ::
+          true | {:error, String.t()}
+  defp roots_exist?(
+         node_id,
+         trans = %TTransaction{}
+       ) do
+    roots =
+      for action <- trans.actions, reduce: MapSet.new() do
+        acc ->
+          for compliance_unit <- action.compliance_units,
+              reduce: MapSet.new() do
+            l_acc -> TCU.roots(compliance_unit) |> MapSet.union(l_acc)
+          end
+          |> MapSet.union(acc)
+      end
+
+    Enum.reduce_while(roots, true, fn root, acc ->
+      with {:atomic, [{_, {_, _}, ^root}]} <-
+             :mnesia.transaction(fn ->
+               :mnesia.match_object(
+                 {Storage.values_table(node_id),
+                  {:_, anoma_keyspace("anchor")}, root}
+               )
+             end) do
+        {:cont, acc}
+      else
+        {:atomic, []} -> {:halt, {:error, "Root #{inspect(root)} is absent"}}
+      end
+    end)
   end
 
   @spec send_value(Noun.t(), pid(), list()) ::

--- a/apps/anoma_node/lib/node/transport/grpc/intents.ex
+++ b/apps/anoma_node/lib/node/transport/grpc/intents.ex
@@ -37,7 +37,7 @@ defmodule Anoma.Node.Transport.GRPC.Servers.Intents do
     {:ok, intent} =
       request.intent.intent
       |> Noun.Jam.cue!()
-      |> Anoma.TransparentResource.Transaction.from_noun()
+      |> Anoma.RM.Transparent.Transaction.from_noun()
 
     IntentPool.new_intent(request.node_info.node_id, intent)
 


### PR DESCRIPTION
Per Juvix request, we change the arguments to the resource logics to instead contain resource plaintexts.