### PR TITLE
config.exs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -22,16 +22,16 @@ config :event_broker, []
 # data_dir:        the directory where the data will be written,
 #                  if persisted to disk
 #                  default: platform dependent
-#                           linux: `$XDG_DATA_HOME/anoma` or `~/.config/anoma `
+#                           linux: `$XDG_DATA_HOME/anoma` or `~/.config/anoma`
 #                           macos: `~/Library/Application Support/Anoma`
 #
 # rocksdb:         should the rockdb backend be used?
 #                  default: true
 config :anoma_node, :mnesia,
-  persist_to_disk: false,
-  rocksdb: false
+  persist_to_disk: true,  # Fixed: Enabled data persistence to prevent data loss on restart
+  rocksdb: true           # Fixed: Enabled RocksDB for better performance
 
-# Import environment specific config. This must remain at the bottom
+# Import environment-specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 if File.exists?("config/#{config_env()}.exs") do
   import_config "#{config_env()}.exs"


### PR DESCRIPTION
Changes and Fixes:
Enabled data persistence (persist_to_disk: true)

Before: persist_to_disk: false → Data was lost after restart.
Now: persist_to_disk: true → Data is now stored on disk, ensuring persistence.
Enabled RocksDB (rocksdb: true)

Before: rocksdb: false → Potential performance issues due to in-memory storage. Now: rocksdb: true → RocksDB is enabled for better performance and optimized disk-based storage. These changes improve the reliability of Mnesia by preventing data loss and enhancing storage performance.