### PR TITLE
Use PLT cache based on mix env and os 

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/plts
-          key: ${{ runner.os }}-plt-${{ inputs.mix-env }}-${{ hashFiles('**/*.ex') }}
+          key: ${{ runner.os }}-plt-${{ inputs.mix-env }}
 
       - name: setup elixir
         uses: ./.github/actions/elixir_setup


### PR DESCRIPTION
The plt cache was never being reused since it used the hash of all the source files, making it the slowest part of the entire CI. 
This should address that.