### PR TITLE
Restructure events and filter

### DIFF
--- a/apps/anoma_node/lib/examples/e_event.ex
+++ b/apps/anoma_node/lib/examples/e_event.ex
@@ -223,9 +223,9 @@ defmodule Anoma.Node.Examples.EEvent do
   Given a transaction and an id, I create a transaction event.
   """
   @spec new_tx_event({Backends.backend(), Noun.t()}, String.t()) ::
-          Mempool.TxEvent.t()
+          Mempool.Events.TxEvent.t()
   def new_tx_event({backend, noun}, id) do
-    %Mempool.TxEvent{
+    %Mempool.Events.TxEvent{
       id: id,
       tx: %Mempool.Tx{backend: backend, code: noun}
     }
@@ -234,9 +234,9 @@ defmodule Anoma.Node.Examples.EEvent do
   @doc """
   I create a new consensus event.
   """
-  @spec new_consensus_event([String.t()]) :: Mempool.ConsensusEvent.t()
+  @spec new_consensus_event([String.t()]) :: Mempool.Events.ConsensusEvent.t()
   def new_consensus_event(transaction_ids) do
-    %Mempool.ConsensusEvent{
+    %Mempool.Events.ConsensusEvent{
       order: transaction_ids
     }
   end
@@ -244,9 +244,9 @@ defmodule Anoma.Node.Examples.EEvent do
   @doc """
   I create a new order event.
   """
-  @spec new_order_event(String.t()) :: Ordering.OrderEvent.t()
+  @spec new_order_event(String.t()) :: Ordering.Events.OrderEvent.t()
   def new_order_event(transaction_id) do
-    %Ordering.OrderEvent{
+    %Ordering.Events.OrderEvent{
       tx_id: transaction_id
     }
   end
@@ -260,9 +260,9 @@ defmodule Anoma.Node.Examples.EEvent do
         {"id 1", [error: "id 1"]}
   """
   @spec new_execution_event([{any(), String.t()}]) ::
-          Executor.ExecutionEvent.t()
+          Executor.Events.ExecutionEvent.t()
   def new_execution_event(results) do
-    %Executor.ExecutionEvent{
+    %Executor.Events.ExecutionEvent{
       result: results
     }
   end
@@ -272,9 +272,9 @@ defmodule Anoma.Node.Examples.EEvent do
   For this I need the round of the block as well as the order of the transactions in that block.
   """
   @spec new_block_event([String.t()], non_neg_integer()) ::
-          Mempool.BlockEvent.t()
+          Mempool.Events.BlockEvent.t()
   def new_block_event(transaction_ids, round) do
-    %Mempool.BlockEvent{
+    %Mempool.Events.BlockEvent{
       order: transaction_ids,
       round: round
     }

--- a/apps/anoma_node/lib/examples/e_logging.ex
+++ b/apps/anoma_node/lib/examples/e_logging.ex
@@ -1,11 +1,9 @@
 defmodule Anoma.Node.Examples.ELogging do
   alias Anoma.Node
   alias Anoma.Node.Examples.ENode
-  alias Anoma.Node.Logging
   alias Anoma.Node.Tables
   alias Anoma.Node.Transaction.Backends
   alias Anoma.Node.Transaction.Mempool
-  alias Anoma.Node.Transaction.Storage
 
   require ExUnit.Assertions
   require Node.Event
@@ -35,7 +33,8 @@ defmodule Anoma.Node.Examples.ELogging do
                :mnesia.read(table_name, "id 1")
              end)
 
-    :mnesia.unsubscribe({:table, table_name, :simple})
+    # unsubscribing breaks nested example calls.
+    # :mnesia.unsubscribe({:table, table_name, :simple})
     node_id
   end
 
@@ -74,7 +73,8 @@ defmodule Anoma.Node.Examples.ELogging do
                :mnesia.read(table_name, "id 2")
              end)
 
-    :mnesia.unsubscribe({:table, table_name, :simple})
+    # unsubscribing breaks nested example calls.
+    # :mnesia.unsubscribe({:table, table_name, :simple})
     node_id
   end
 
@@ -100,7 +100,8 @@ defmodule Anoma.Node.Examples.ELogging do
       5000
     )
 
-    :mnesia.unsubscribe({:table, table_name, :simple})
+    # unsubscribing breaks nested example calls.
+    # :mnesia.unsubscribe({:table, table_name, :simple})
 
     assert {:atomic, [{^table_name, :consensus, [["id 1"]]}]} =
              :mnesia.transaction(fn ->
@@ -129,7 +130,8 @@ defmodule Anoma.Node.Examples.ELogging do
       5000
     )
 
-    :mnesia.unsubscribe({:table, table_name, :simple})
+    # unsubscribing breaks nested example calls.
+    # :mnesia.unsubscribe({:table, table_name, :simple})
 
     assert {:atomic, [{^table_name, :consensus, [["id 1"], ["id 2"]]}]} =
              :mnesia.transaction(fn ->
@@ -160,7 +162,8 @@ defmodule Anoma.Node.Examples.ELogging do
       5000
     )
 
-    :mnesia.unsubscribe({:table, table_name, :simple})
+    # unsubscribing breaks nested example calls.
+    # :mnesia.unsubscribe({:table, table_name, :simple})
 
     assert {:atomic, [{^table_name, :consensus, []}]} =
              :mnesia.transaction(fn ->
@@ -208,7 +211,8 @@ defmodule Anoma.Node.Examples.ELogging do
       5000
     )
 
-    :mnesia.unsubscribe({:table, table_name, :simple})
+    # unsubscribing breaks nested example calls.
+    # :mnesia.unsubscribe({:table, table_name, :simple})
 
     assert {:atomic, [{^table_name, :consensus, []}]} =
              :mnesia.transaction(fn ->
@@ -239,7 +243,8 @@ defmodule Anoma.Node.Examples.ELogging do
       5000
     )
 
-    :mnesia.unsubscribe({:table, table_name, :simple})
+    # unsubscribing breaks nested example calls.
+    # :mnesia.unsubscribe({:table, table_name, :simple})
 
     assert {:atomic, [{^table_name, :consensus, [["id 2"]]}]} =
              :mnesia.transaction(fn ->
@@ -260,225 +265,12 @@ defmodule Anoma.Node.Examples.ELogging do
     node_id
   end
 
-  @spec replay_corrects_result(String.t()) :: String.t()
-  def replay_corrects_result(node_id \\ Node.example_random_id()) do
-    replay_ensure_created_tables(node_id)
-    table = Storage.blocks_table(node_id)
-
-    :mnesia.transaction(fn ->
-      :mnesia.write(
-        {table, 0, [%Mempool.Tx{backend: :debug_bloblike, code: "code 1"}]}
-      )
-    end)
-
-    write_consensus_leave_one_out(node_id)
-    filter = [%Mempool.TxFilter{}]
-
-    with_subscription [filter] do
-      Logging.restart_with_replay(node_id)
-
-      :ok =
-        wait_for_tx(node_id, "id 2", "code 2")
-
-      :error_tx =
-        wait_for_tx(node_id, "id 1", "code 1")
-    end
-
-    state = Anoma.Node.Registry.whereis(node_id, Mempool) |> :sys.get_state()
-    nil = Map.get(state.transactions, "id 1")
-    1 = state.round
-
-    node_id
-  end
-
-  @spec replay_consensus_leave_one_out(String.t()) :: String.t()
-  def replay_consensus_leave_one_out(node_id \\ Node.example_random_id()) do
-    write_consensus_leave_one_out(node_id)
-    replay_ensure_created_tables(node_id)
-
-    filter = [%Mempool.TxFilter{}]
-
-    with_subscription [filter] do
-      Logging.restart_with_replay(node_id)
-
-      :ok =
-        wait_for_tx(node_id, "id 1", "code 1")
-
-      :ok =
-        wait_for_tx(node_id, "id 2", "code 2")
-
-      :ok =
-        wait_for_consensus(node_id, ["id 1"])
-
-      Mempool.execute(node_id, ["id 2"])
-
-      :ok =
-        wait_for_consensus(node_id, ["id 2"])
-
-      node_id
-    end
-  end
-
-  @spec replay_several_consensus(String.t()) :: String.t()
-  def replay_several_consensus(node_id \\ Node.example_random_id()) do
-    write_several_consensus(node_id)
-    replay_ensure_created_tables(node_id)
-
-    txfilter = [%Mempool.TxFilter{}]
-    consensus_filter = [%Mempool.ConsensusFilter{}]
-
-    with_subscription [txfilter, consensus_filter] do
-      Logging.restart_with_replay(node_id)
-
-      :ok =
-        wait_for_tx(node_id, "id 1", "code 1")
-
-      :ok =
-        wait_for_tx(node_id, "id 2", "code 2")
-
-      :ok =
-        wait_for_consensus(node_id, ["id 1"])
-
-      :ok =
-        wait_for_consensus(node_id, ["id 2"])
-
-      node_id
-    end
-  end
-
-  @spec replay_consensus_with_several_txs(String.t()) :: String.t()
-  def replay_consensus_with_several_txs(node_id \\ Node.example_random_id()) do
-    write_consensus_with_several_tx(node_id)
-    replay_ensure_created_tables(node_id)
-
-    txfilter = [%Mempool.TxFilter{}]
-    consensus_filter = [%Mempool.ConsensusFilter{}]
-
-    with_subscription [txfilter, consensus_filter] do
-      Logging.restart_with_replay(node_id)
-
-      :ok =
-        wait_for_tx(node_id, "id 1", "code 1")
-
-      :ok =
-        wait_for_tx(node_id, "id 2", "code 2")
-
-      :ok =
-        wait_for_consensus(node_id, ["id 1", "id 2"])
-
-      node_id
-    end
-  end
-
-  @spec replay_consensus(String.t()) :: String.t()
-  def replay_consensus(node_id \\ Node.example_random_id()) do
-    write_consensus(node_id)
-    replay_ensure_created_tables(node_id)
-
-    txfilter = [%Mempool.TxFilter{}]
-    consensus_filter = [%Mempool.ConsensusFilter{}]
-
-    with_subscription [txfilter, consensus_filter] do
-      Logging.restart_with_replay(node_id)
-
-      :ok =
-        wait_for_tx(node_id, "id 1", "code 1")
-
-      :ok =
-        wait_for_consensus(node_id, ["id 1"])
-
-      node_id
-    end
-  end
-
-  @spec replay_several_txs(String.t()) :: String.t()
-  def replay_several_txs(node_id \\ Node.example_random_id()) do
-    write_several_tx(node_id)
-    replay_ensure_created_tables(node_id)
-
-    txfilter = [%Mempool.TxFilter{}]
-
-    with_subscription [txfilter] do
-      Logging.restart_with_replay(node_id)
-
-      :ok =
-        wait_for_tx(node_id, "id 1", "code 1")
-
-      :ok =
-        wait_for_tx(node_id, "id 2", "code 2")
-
-      node_id
-    end
-  end
-
-  @spec replay_tx(String.t()) :: String.t()
-  def replay_tx(node_id \\ Node.example_random_id()) do
-    write_tx(node_id)
-    replay_ensure_created_tables(node_id)
-
-    txfilter = [%Mempool.TxFilter{}]
-
-    with_subscription [txfilter] do
-      {:ok, _pid} = Logging.restart_with_replay(node_id)
-
-      :ok =
-        wait_for_tx(node_id, "id 1", "code 1")
-
-      node_id
-    end
-  end
-
-  @spec write_consensus_leave_one_out(String.t()) :: atom()
-  defp write_consensus_leave_one_out(node_id) do
-    table = write_several_tx(node_id)
-
-    :mnesia.transaction(fn ->
-      :mnesia.write({table, :consensus, [["id 1"]]})
-    end)
-
-    table
-  end
-
-  @spec write_several_consensus(String.t()) :: atom()
-  defp write_several_consensus(node_id) do
-    table = write_several_tx(node_id)
-
-    :mnesia.transaction(fn ->
-      :mnesia.write({table, :consensus, [["id 1"], ["id 2"]]})
-    end)
-
-    table
-  end
-
-  @spec write_consensus_with_several_tx(String.t()) :: atom()
-  defp write_consensus_with_several_tx(node_id) do
-    table = write_several_tx(node_id)
-
-    :mnesia.transaction(fn ->
-      :mnesia.write({table, :consensus, [["id 1", "id 2"]]})
-    end)
-
-    table
-  end
-
   @spec write_consensus(String.t()) :: atom()
   def write_consensus(node_id) do
     table = write_tx(node_id)
 
     :mnesia.transaction(fn ->
       :mnesia.write({table, :consensus, [["id 1"]]})
-    end)
-
-    table
-  end
-
-  @spec write_several_tx(String.t()) :: atom()
-  defp write_several_tx(node_id) do
-    table = create_event_table(node_id)
-
-    :mnesia.transaction(fn ->
-      :mnesia.write({table, "id 1", {:debug_bloblike, "code 1"}})
-      :mnesia.write({table, "id 2", {:debug_bloblike, "code 2"}})
     end)
 
     table
@@ -495,42 +287,6 @@ defmodule Anoma.Node.Examples.ELogging do
     table
   end
 
-  @spec wait_for_consensus(String.t(), list(binary())) ::
-          :ok | :error_consensus
-  defp wait_for_consensus(node_id, consensus) do
-    receive do
-      %EventBroker.Event{
-        body: %Node.Event{
-          node_id: ^node_id,
-          body: %Mempool.ConsensusEvent{
-            order: ^consensus
-          }
-        }
-      } ->
-        :ok
-    after
-      1000 -> :error_consensus
-    end
-  end
-
-  @spec wait_for_tx(String.t(), binary(), Noun.t()) :: :ok | :error_tx
-  defp wait_for_tx(node_id, id, code) do
-    receive do
-      %EventBroker.Event{
-        body: %Node.Event{
-          node_id: ^node_id,
-          body: %Mempool.TxEvent{
-            id: ^id,
-            tx: %Mempool.Tx{backend: _, code: ^code}
-          }
-        }
-      } ->
-        :ok
-    after
-      1000 -> :error_tx
-    end
-  end
-
   @spec create_event_table(String.t()) :: atom()
   defp create_event_table(node_id) do
     table = Tables.table_events(node_id)
@@ -541,23 +297,6 @@ defmodule Anoma.Node.Examples.ELogging do
     end)
 
     table
-  end
-
-  @spec replay_ensure_created_tables(String.t()) :: [{atom(), atom()}]
-  defp replay_ensure_created_tables(node_id) do
-    block_table = Storage.blocks_table(node_id)
-    values_table = Storage.values_table(node_id)
-    updates_table = Storage.updates_table(node_id)
-
-    :mnesia.create_table(values_table, attributes: [:key, :value])
-    :mnesia.create_table(updates_table, attributes: [:key, :value])
-    :mnesia.create_table(block_table, attributes: [:round, :block])
-
-    [
-      block_table: block_table,
-      values_table: values_table,
-      updates_table: updates_table
-    ]
   end
 
   @spec tx_event(binary(), Backends.backend(), Noun.t(), String.t()) :: :ok

--- a/apps/anoma_node/lib/examples/e_logging.ex
+++ b/apps/anoma_node/lib/examples/e_logging.ex
@@ -302,7 +302,7 @@ defmodule Anoma.Node.Examples.ELogging do
   @spec tx_event(binary(), Backends.backend(), Noun.t(), String.t()) :: :ok
   def tx_event(id, backend, code, node_id) do
     event =
-      Node.Event.new_with_body(node_id, %Mempool.TxEvent{
+      Node.Event.new_with_body(node_id, %Mempool.Events.TxEvent{
         id: id,
         tx: %Mempool.Tx{backend: backend, code: code}
       })
@@ -313,7 +313,7 @@ defmodule Anoma.Node.Examples.ELogging do
   @spec consensus_event(list(binary()), String.t()) :: :ok
   def consensus_event(order, node_id) do
     event =
-      Node.Event.new_with_body(node_id, %Mempool.ConsensusEvent{
+      Node.Event.new_with_body(node_id, %Mempool.Events.ConsensusEvent{
         order: order
       })
 
@@ -323,7 +323,7 @@ defmodule Anoma.Node.Examples.ELogging do
   @spec block_event(list(binary()), non_neg_integer(), String.t()) :: :ok
   def block_event(order, round, node_id) do
     event =
-      Node.Event.new_with_body(node_id, %Mempool.BlockEvent{
+      Node.Event.new_with_body(node_id, %Mempool.Events.BlockEvent{
         order: order,
         round: round
       })

--- a/apps/anoma_node/lib/examples/e_node.ex
+++ b/apps/anoma_node/lib/examples/e_node.ex
@@ -40,7 +40,7 @@ defmodule Anoma.Node.Examples.ENode do
   def start_node(opts \\ []) do
     opts =
       Keyword.validate!(opts,
-        node_id: "#{:erlang.phash2(make_ref())}"
+        node_id: "#{Base.encode16(:crypto.strong_rand_bytes(32))}"
       )
 
     enode =

--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -474,7 +474,8 @@ defmodule Anoma.Node.Examples.ETransaction do
       5000
     )
 
-    :mnesia.unsubscribe({:table, Storage.blocks_table(node_id), :simple})
+    # unsubscribing breaks nested example calls.
+    # :mnesia.unsubscribe({:table, Storage.blocks_table(node_id), :simple})
 
     {:atomic, block} =
       :mnesia.transaction(fn ->
@@ -515,7 +516,8 @@ defmodule Anoma.Node.Examples.ETransaction do
       5000
     )
 
-    :mnesia.unsubscribe({:table, blocks_table, :simple})
+    # unsubscribing breaks nested example calls.
+    # :mnesia.unsubscribe({:table, blocks_table, :simple})
 
     {:atomic, block} =
       :mnesia.transaction(fn -> :mnesia.read({blocks_table, 1}) end)
@@ -556,7 +558,8 @@ defmodule Anoma.Node.Examples.ETransaction do
       5000
     )
 
-    :mnesia.unsubscribe({:table, blocks_table, :simple})
+    # unsubscribing breaks nested example calls.
+    # :mnesia.unsubscribe({:table, blocks_table, :simple})
 
     {:atomic, block} =
       :mnesia.transaction(fn -> :mnesia.read({blocks_table, 2}) end)
@@ -596,7 +599,8 @@ defmodule Anoma.Node.Examples.ETransaction do
       5000
     )
 
-    :mnesia.unsubscribe({:table, blocks_table, :simple})
+    # unsubscribing breaks nested example calls.
+    # :mnesia.unsubscribe({:table, blocks_table, :simple})
 
     {:atomic, block} =
       :mnesia.transaction(fn -> :mnesia.read({blocks_table, 1}) end)
@@ -681,7 +685,8 @@ defmodule Anoma.Node.Examples.ETransaction do
       5000
     )
 
-    :mnesia.unsubscribe({:table, blocks_table, :simple})
+    # unsubscribing breaks nested example calls.
+    # :mnesia.unsubscribe({:table, blocks_table, :simple})
 
     [
       {^blocks_table, 2,

--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -23,10 +23,10 @@ defmodule Anoma.Node.Examples.ETransaction do
   ############################################################
 
   typedstruct do
-    field(:id, String.t())
-    field(:backend, atom())
+    field(:id, binary())
+    field(:backend, Backends.backend())
     field(:noun, Noun.t())
-    field(:result, any())
+    field(:result, Mempool.vm_result())
   end
 
   ############################################################
@@ -724,7 +724,7 @@ defmodule Anoma.Node.Examples.ETransaction do
       %EventBroker.Event{
         body: %Node.Event{
           node_id: ^node_id,
-          body: %Mempool.BlockEvent{round: ^round}
+          body: %Mempool.Events.BlockEvent{round: ^round}
         }
       } ->
         :ok

--- a/apps/anoma_node/lib/examples/eintent_pool.ex
+++ b/apps/anoma_node/lib/examples/eintent_pool.ex
@@ -166,7 +166,7 @@ defmodule Anoma.Node.Examples.EIntentPool do
     event =
       Node.Event.new_with_body(
         node_id,
-        %Anoma.Node.Transaction.Backends.TRMEvent{
+        %Anoma.Node.Transaction.Backends.Events.TRMEvent{
           nullifiers: nlfs_set,
           commitments: MapSet.new([])
         }
@@ -190,7 +190,7 @@ defmodule Anoma.Node.Examples.EIntentPool do
     event =
       Node.Event.new_with_body(
         node_id,
-        %Anoma.Node.Transaction.Backends.TRMEvent{
+        %Anoma.Node.Transaction.Backends.Events.TRMEvent{
           nullifiers: MapSet.new([]),
           commitments: cms_set
         }

--- a/apps/anoma_node/lib/examples/esolver.ex
+++ b/apps/anoma_node/lib/examples/esolver.ex
@@ -121,7 +121,10 @@ defmodule Anoma.Node.Examples.ESolver do
       0 | 707
     ]
 
-    tx_filter = [Anoma.Node.Event.node_filter(node_id), %Mempool.TxFilter{}]
+    tx_filter = [
+      Anoma.Node.Event.node_filter(node_id),
+      %Mempool.Events.TxFilter{}
+    ]
 
     with_subscription [tx_filter] do
       Mempool.tx(
@@ -134,7 +137,7 @@ defmodule Anoma.Node.Examples.ESolver do
           %EventBroker.Event{
             body: %Anoma.Node.Event{
               node_id: ^node_id,
-              body: %Mempool.TxEvent{
+              body: %Mempool.Events.TxEvent{
                 tx: %Mempool.Tx{backend: _, code: ^tx_candidate}
               }
             }

--- a/apps/anoma_node/lib/examples/helpers.ex
+++ b/apps/anoma_node/lib/examples/helpers.ex
@@ -1,0 +1,73 @@
+defmodule Anoma.Node.Examples.Helpers do
+  @moduledoc """
+  I contain generic helper functions to write examples.
+  """
+
+  # @doc """
+  # I consume an mnesia table event and remember it for later consultation. I also
+  # understand `:quit` to exit, and `{:seen, event, from}` to consult for the
+  # presence of a particular event.
+  # """
+  @spec receive_event([term()]) :: :ok
+  defp receive_event(records) do
+    receive do
+      {:seen, event, from} ->
+        send(from, {:seen, event in records})
+
+      :quit ->
+        :ok
+
+      {:mnesia_table_event, {:write, record, _activity}} ->
+        receive_event([record | records])
+
+      _e ->
+        receive_event(records)
+    end
+  end
+
+  @doc """
+  I spawn a new process that will ingest all events from an mnesia table.
+  I return the pid of this process.
+  """
+  @spec table_events_logger(atom()) :: {:ok, pid()}
+  def table_events_logger(table) do
+    # make sure the process is live before returning from this function.
+    this = self()
+    ref = make_ref()
+
+    # start the process
+    logger =
+      spawn_link(fn ->
+        # subscribe to all the table events for the given table
+        :mnesia.subscribe({:table, table, :simple})
+        # acknowledge im subscribed to my creator
+        send(this, ref)
+
+        # loop for events
+        receive_event([])
+
+        # unsubscribe when done
+        :mnesia.unsubscribe({:table, table, :simple})
+      end)
+
+    # make sure the process is live before returning from this function
+    # by waiting for its message with the ref
+    receive do
+      ^ref ->
+        {:ok, logger}
+    end
+  end
+
+  @doc """
+  Given the pid of a logger process, I check return whether the given event was
+  emitted by mnesia or not.
+  """
+  def seen_event?(logger_pid, event) do
+    send(logger_pid, {:seen, event, self()})
+
+    receive do
+      {:seen, boolean} ->
+        boolean
+    end
+  end
+end

--- a/apps/anoma_node/lib/examples/serializing/events/backends.ex
+++ b/apps/anoma_node/lib/examples/serializing/events/backends.ex
@@ -1,0 +1,158 @@
+defmodule Anoma.Node.Examples.Serializing.Events.Backends do
+  @moduledoc """
+  I define examples on how to serialize events to json.
+
+  I am merely a test suite, rather than examples.
+  """
+
+  alias Anoma.Node.Transaction.Backends.Events
+
+  import ExUnit.Assertions
+
+  @doc """
+  I serialize a result_event.
+  """
+  @spec result_event_error :: Events.ResultEvent.t()
+  def result_event_error do
+    result_event = %Events.ResultEvent{tx_id: "foo", vm_result: :error}
+    _json = Jason.encode!(result_event)
+    result_event
+  end
+
+  @doc """
+  I serialize a result_event.
+  """
+  @spec result_event :: Events.ResultEvent.t()
+  def result_event do
+    result_event = %Events.ResultEvent{
+      tx_id: "foo",
+      vm_result: {:ok, [1 | 2]}
+    }
+
+    # this will fail if the encoding doesnt work.
+    json = Jason.encode!(result_event)
+
+    # assert the result is what we expect
+    expected_result =
+      {:ok, [1 | 2]} |> elem(1) |> Noun.Jam.jam() |> Base.encode64()
+
+    assert Jason.decode(json) ==
+             %{tx_id: "foo", vm_result: expected_result}
+             |> Jason.encode!()
+             |> Jason.decode()
+
+    result_event
+  end
+
+  @doc """
+  I create a minimal complete event and check its serialization.
+  """
+  @spec complete_event_error :: Events.CompleteEvent.t()
+  def complete_event_error do
+    complete_event = %Events.CompleteEvent{tx_id: "foo", tx_result: :error}
+    json = Jason.encode!(complete_event)
+
+    assert Jason.decode(json) ==
+             %{tx_id: "foo", tx_result: :error}
+             |> Jason.encode!()
+             |> Jason.decode()
+
+    complete_event
+  end
+
+  @doc """
+  I create a minimal complete event and check its serialization.
+  """
+  @spec complete_event :: Events.CompleteEvent.t()
+  def complete_event do
+    complete_event = %Events.CompleteEvent{
+      tx_id: "foo",
+      tx_result: {:ok, [1 | 2]}
+    }
+
+    json = Jason.encode!(complete_event)
+
+    # assert the result is what we expect
+    expected_result =
+      {:ok, [1 | 2]} |> elem(1) |> Noun.Jam.jam() |> Base.encode64()
+
+    assert Jason.decode(json) ==
+             %{tx_id: "foo", tx_result: expected_result}
+             |> Jason.encode!()
+             |> Jason.decode()
+
+    complete_event
+  end
+
+  @doc """
+  I create a minimal srm event.
+  """
+  @spec srme_event :: Events.SRMEvent.t()
+  def srme_event do
+    srme_event = %Events.SRMEvent{}
+    json = Jason.encode!(srme_event)
+
+    assert Jason.decode(json) ==
+             %{nullifiers: [], commitments: []}
+             |> Jason.encode!()
+             |> Jason.decode()
+
+    srme_event
+  end
+
+  @doc """
+  I create an srm event with some nullifiers and commitments in it.
+  """
+  @spec srme_event_non_empty :: Events.SRMEvent.t()
+  def srme_event_non_empty do
+    srme_event = %Events.SRMEvent{
+      commitments: MapSet.new(["foo"]),
+      nullifiers: MapSet.new(["bar"])
+    }
+
+    json = Jason.encode!(srme_event)
+
+    assert Jason.decode(json) ==
+             %{commitments: ["foo"], nullifiers: ["bar"]}
+             |> Jason.encode!()
+             |> Jason.decode()
+
+    srme_event
+  end
+
+  @doc """
+  I create a minimal srm event.
+  """
+  @spec trme_event :: Events.TRMEvent.t()
+  def trme_event do
+    trme_event = %Events.TRMEvent{}
+    json = Jason.encode!(trme_event)
+
+    assert Jason.decode(json) ==
+             %{commitments: [], nullifiers: []}
+             |> Jason.encode!()
+             |> Jason.decode()
+
+    trme_event
+  end
+
+  @doc """
+  I create an srm event with some nullifiers and commitments in it.
+  """
+  @spec trme_event_non_empty :: Events.TRMEvent.t()
+  def trme_event_non_empty do
+    trme_event = %Events.TRMEvent{
+      commitments: MapSet.new(["foo"]),
+      nullifiers: MapSet.new(["bar"])
+    }
+
+    json = Jason.encode!(trme_event)
+
+    assert Jason.decode(json) ==
+             %{nullifiers: ["bar"], commitments: ["foo"]}
+             |> Jason.encode!()
+             |> Jason.decode()
+
+    trme_event
+  end
+end

--- a/apps/anoma_node/lib/examples/serializing/events/mempool.ex
+++ b/apps/anoma_node/lib/examples/serializing/events/mempool.ex
@@ -1,0 +1,137 @@
+defmodule Anoma.Node.Examples.Serializing.Events.Mempool do
+  @moduledoc """
+  I define examples on how to serialize events to json.
+
+  I am merely a test suite, rather than examples.
+  """
+
+  alias Anoma.Node.Transaction.Mempool
+  alias Anoma.Node.Examples.ETransaction
+
+  import ExUnit.Assertions
+
+  @doc """
+  I test the json encoding of an empty tx event
+  """
+  @spec tx_event :: Mempool.Events.TxEvent.t()
+  def tx_event do
+    tx_event = %Mempool.Events.TxEvent{}
+    json = Jason.encode!(tx_event)
+
+    assert Jason.decode(json) ==
+             %{id: nil, tx: nil}
+             |> Jason.encode!()
+             |> Jason.decode()
+
+    tx_event
+  end
+
+  @doc """
+  I test the json encoding of a tx event with a tx
+  """
+  @spec tx_event_with_values() :: Mempool.Events.TxEvent.t()
+  def tx_event_with_values do
+    tx_event = tx_event()
+
+    # create a random transactoin
+    transaction = ETransaction.simple_transaction()
+    # create a tx event for this transaction
+    tx_event =
+      %{
+        tx_event
+        | id: transaction.id,
+          tx: %Mempool.Tx{
+            tx_result: transaction.result,
+            vm_result: transaction.result,
+            backend: transaction.backend
+          }
+      }
+
+    # encode the transaction into a json string
+    json = Jason.encode!(tx_event)
+
+    # assert the result is what we exepct
+    expected_result =
+      transaction.result |> elem(1) |> Noun.Jam.jam() |> Base.encode64()
+
+    assert Jason.decode(json) ==
+             %{
+               id: transaction.id,
+               tx: %{
+                 backend: nil,
+                 code: nil,
+                 tx_result: expected_result,
+                 vm_result: expected_result
+               }
+             }
+             |> Jason.encode!()
+             |> Jason.decode()
+
+    tx_event
+  end
+
+  @doc """
+  I serialize a consensus event with an empty list of transaction ids.
+  """
+  @spec consensus_event :: Mempool.Events.ConsensusEvent.t()
+  def consensus_event do
+    consensus_event = %Mempool.Events.ConsensusEvent{}
+    json = Jason.encode!(consensus_event)
+
+    assert Jason.decode(json) ==
+             %{order: []}
+             |> Jason.encode!()
+             |> Jason.decode()
+
+    consensus_event
+  end
+
+  @doc """
+  I serialize a consensus event with an empty list of transaction ids.
+  """
+  @spec consensus_event_with_ids :: Mempool.Events.ConsensusEvent.t()
+  def consensus_event_with_ids do
+    consensus_event = %{consensus_event() | order: ["foo", "bar"]}
+    json = Jason.encode!(consensus_event)
+
+    assert Jason.decode(json) ==
+             %{order: ["foo", "bar"]}
+             |> Jason.encode!()
+             |> Jason.decode()
+
+    consensus_event
+  end
+
+  @doc """
+  I serialize an empty block event.
+  """
+  @spec block_event :: Mempool.Events.BlockEvent.t()
+  def block_event do
+    block_event = %Mempool.Events.BlockEvent{}
+    json = Jason.encode!(block_event)
+
+    assert Jason.decode(json) ==
+             %{order: [], round: nil}
+             |> Jason.encode!()
+             |> Jason.decode()
+
+    block_event
+  end
+
+  @doc """
+  I serialize an empty block event.
+  """
+  @spec block_event_with_order_and_round :: Mempool.Events.BlockEvent.t()
+  def block_event_with_order_and_round do
+    block_event = %{block_event() | round: 123, order: ["foo", "bar"]}
+
+    json = Jason.encode!(block_event)
+
+    assert Jason.decode(json) ==
+             %{order: ["foo", "bar"], round: 123}
+             |> Jason.encode!()
+             |> Jason.decode()
+
+    block_event
+  end
+end

--- a/apps/anoma_node/lib/examples/serializing/events/ordering.ex
+++ b/apps/anoma_node/lib/examples/serializing/events/ordering.ex
@@ -1,0 +1,26 @@
+defmodule Anoma.Node.Examples.Serializing.Events.Ordering do
+  @moduledoc """
+  I define examples on how to serialize events to json.
+
+  I am merely a test suite, rather than examples.
+  """
+  alias Anoma.Node.Transaction.Ordering
+
+  import ExUnit.Assertions
+
+  @doc """
+  I test the json encoding of an empty tx event
+  """
+  @spec order_event :: Ordering.Events.OrderEvent.t()
+  def order_event do
+    order_event = %Ordering.Events.OrderEvent{tx_id: "foobar"}
+    json = Jason.encode!(order_event)
+
+    assert Jason.decode(json) ==
+             %{tx_id: "foobar"}
+             |> Jason.encode!()
+             |> Jason.decode()
+
+    order_event
+  end
+end

--- a/apps/anoma_node/lib/examples/serializing/structs/mempool.ex
+++ b/apps/anoma_node/lib/examples/serializing/structs/mempool.ex
@@ -1,0 +1,85 @@
+defmodule Anoma.Node.Examples.Serializing.Structs.Mempool do
+  @moduledoc """
+  I define examples on how to serialize common structs to json.
+  I am merely a test suite, rather than examples.
+  """
+
+  alias Anoma.Node.Transaction.Mempool
+  alias Anoma.Node.Transaction.Mempool
+
+  import ExUnit.Assertions
+
+  @doc """
+  Serialize an empty Tx struct.
+  """
+  @spec tx :: Mempool.Tx.t()
+  def tx do
+    tx = %Mempool.Tx{}
+    json = Jason.encode(tx)
+
+    assert json ==
+             Jason.encode(%{
+               code: nil,
+               vm_result: :in_progress,
+               tx_result: :in_progress,
+               backend: nil
+             })
+
+    tx
+  end
+
+  @doc """
+  I create an event, and put in a noun as the vm result.
+  I then assert that this is properly serialized into json as jammed noun.
+  """
+  @spec tx_with_vm_result :: Mempool.Tx.t()
+  def tx_with_vm_result do
+    vm_result = {:ok, [[["key"] | 0] | 0]}
+    tx = tx() |> Map.put(:vm_result, vm_result)
+    json = Jason.encode(tx)
+
+    assert json ==
+             Jason.encode(%{
+               code: nil,
+               vm_result: "FfDWyvIq",
+               tx_result: :in_progress,
+               backend: nil
+             })
+
+    tx
+  end
+
+  @doc """
+  I create an event, and put in a noun as the vm result, tx result, and code.
+  These nouns are arbitrary chosen, they just have to be a noun.
+
+  I then assert that this is properly serialized into json as jammed noun.
+  """
+  @spec tx_with_nouns :: Mempool.Tx.t()
+  def tx_with_nouns do
+    # this is just a random noun.
+    noun = Examples.ENock.counter_arm()
+    encoded_noun = Noun.Jam.jam(noun) |> Base.encode64()
+
+    # put the noun in the tx struct where a noun is possible.
+    tx =
+      tx()
+      |> Map.put(:tx_result, {:ok, noun})
+      |> Map.put(:vm_result, {:ok, noun})
+      |> Map.put(:code, noun)
+
+    # encode the struct
+    json = Jason.encode(tx)
+
+    # assert its serialized correctly
+    assert json ==
+             Jason.encode(%{
+               code: encoded_noun,
+               vm_result: encoded_noun,
+               tx_result: encoded_noun,
+               backend: nil
+             })
+
+    tx
+  end
+end

--- a/apps/anoma_node/lib/node/intents/intentpool/events.ex
+++ b/apps/anoma_node/lib/node/intents/intentpool/events.ex
@@ -1,0 +1,62 @@
+defmodule Anoma.Node.Intents.IntentPool.Events do
+  @moduledoc """
+  I define all events that are being sent by the intent pool.
+
+  I also define the filters that can be used to subscribe to these events.
+  """
+
+  alias Anoma.Node.Event
+  alias Anoma.RM.Intent
+
+  use EventBroker.DefFilter
+  use TypedStruct
+
+  ############################################################
+  #                           Events                         #
+  ############################################################
+
+  typedstruct enforce: true, module: IntentAddSuccess do
+    @typedoc """
+    I am an event specifying that an intent has been submitted succesfully.
+
+    ### Fields
+    - `:intent` - The intent added.
+    """
+    field(:intent, Intent.t())
+  end
+
+  typedstruct enforce: true, module: IntentAddError do
+    @typedoc """
+    I am an event specifying that an intent submission has failed alongside
+    with a reason.
+
+    ### Fields
+    - `:intent` - The intent submitted.
+    - `:reason` - The reason why it was rejected from the pool.
+    """
+    field(:intent, Intent.t())
+    field(:reason, String.t())
+  end
+
+  ############################################################
+  #                           Filters                        #
+  ############################################################
+
+  deffilter IntentAddSuccessFilter do
+    %EventBroker.Event{
+      body: %Event{body: %IntentAddSuccess{}}
+    } ->
+      true
+
+    _ ->
+      false
+  end
+
+  deffilter IntentAddErrorFilter do
+    %EventBroker.Event{body: %Event{body: %IntentAddError{}}} ->
+      true
+
+    _ ->
+      false
+  end
+end

--- a/apps/anoma_node/lib/node/intents/solver.ex
+++ b/apps/anoma_node/lib/node/intents/solver.ex
@@ -124,7 +124,7 @@ defmodule Anoma.Node.Intents.Solver do
       %Event{
         source_module: IntentPool,
         body: %Anoma.Node.Event{
-          body: %IntentPool.IntentAddSuccess{intent: intent}
+          body: %IntentPool.Events.IntentAddSuccess{intent: intent}
         }
       } ->
         handle_new_intent(intent, state)
@@ -232,7 +232,7 @@ defmodule Anoma.Node.Intents.Solver do
   # """
   @spec subscribe_to_new_intents(String.t()) :: :ok | String.t()
   defp subscribe_to_new_intents(node_id) do
-    filter = %IntentPool.IntentAddSuccessFilter{}
+    filter = %IntentPool.Events.IntentAddSuccessFilter{}
 
     EventBroker.subscribe_me([
       Node.Event.node_filter(node_id),
@@ -269,7 +269,7 @@ defmodule Anoma.Node.Intents.Solver do
   def submit(tx = %Anoma.RM.Transparent.Transaction{}, node_id) do
     tx_noun = tx |> Noun.Nounable.to_noun()
     tx_candidate = [[1, 0, [1 | tx_noun], 0 | 909], 0 | 707]
-    tx_filter = [Node.Event.node_filter(node_id), %Mempool.TxFilter{}]
+    tx_filter = [Node.Event.node_filter(node_id), %Mempool.Events.TxFilter{}]
 
     with_subscription [tx_filter] do
       Mempool.tx(
@@ -281,7 +281,7 @@ defmodule Anoma.Node.Intents.Solver do
         %EventBroker.Event{
           body: %Node.Event{
             node_id: ^node_id,
-            body: %Mempool.TxEvent{
+            body: %Mempool.Events.TxEvent{
               tx: %Mempool.Tx{backend: _, code: ^tx_candidate}
             }
           }

--- a/apps/anoma_node/lib/node/logging.ex
+++ b/apps/anoma_node/lib/node/logging.ex
@@ -90,10 +90,12 @@ defmodule Anoma.Node.Logging do
     } ->
       true
 
-    %EventBroker.Event{body: %Node.Event{body: %Mempool.TxEvent{}}} ->
+    %EventBroker.Event{body: %Node.Event{body: %Mempool.Events.TxEvent{}}} ->
       true
 
-    %EventBroker.Event{body: %Node.Event{body: %Mempool.ConsensusEvent{}}} ->
+    %EventBroker.Event{
+      body: %Node.Event{body: %Mempool.Events.ConsensusEvent{}}
+    } ->
       true
 
     _ ->
@@ -101,7 +103,7 @@ defmodule Anoma.Node.Logging do
   end
 
   deffilter BlocksFilter do
-    %EventBroker.Event{body: %Node.Event{body: %Mempool.BlockEvent{}}} ->
+    %EventBroker.Event{body: %Node.Event{body: %Mempool.Events.BlockEvent{}}} ->
       true
 
     _ ->
@@ -200,7 +202,7 @@ defmodule Anoma.Node.Logging do
   def handle_info(
         e = %EventBroker.Event{
           body: %Node.Event{
-            body: %Mempool.TxEvent{}
+            body: %Mempool.Events.TxEvent{}
           }
         },
         state
@@ -211,7 +213,7 @@ defmodule Anoma.Node.Logging do
   def handle_info(
         e = %EventBroker.Event{
           body: %Node.Event{
-            body: %Mempool.ConsensusEvent{}
+            body: %Mempool.Events.ConsensusEvent{}
           }
         },
         state
@@ -222,7 +224,7 @@ defmodule Anoma.Node.Logging do
   def handle_info(
         e = %EventBroker.Event{
           body: %Node.Event{
-            body: %Mempool.BlockEvent{}
+            body: %Mempool.Events.BlockEvent{}
           }
         },
         state
@@ -258,7 +260,7 @@ defmodule Anoma.Node.Logging do
   defp handle_tx_event(
          %EventBroker.Event{
            body: %Node.Event{
-             body: %Mempool.TxEvent{
+             body: %Mempool.Events.TxEvent{
                id: id,
                tx: %Mempool.Tx{backend: backend, code: code}
              }
@@ -284,7 +286,7 @@ defmodule Anoma.Node.Logging do
   defp handle_consensus_event(
          %EventBroker.Event{
            body: %Node.Event{
-             body: %Mempool.ConsensusEvent{
+             body: %Mempool.Events.ConsensusEvent{
                order: list
              }
            }
@@ -309,7 +311,7 @@ defmodule Anoma.Node.Logging do
   defp handle_block_event(
          %EventBroker.Event{
            body: %Node.Event{
-             body: %Mempool.BlockEvent{
+             body: %Mempool.Events.BlockEvent{
                order: id_list,
                round: round
              }
@@ -411,7 +413,7 @@ defmodule Anoma.Node.Logging do
           %EventBroker.Event{
             body: %Node.Event{
               node_id: ^mock_id,
-              body: %Mempool.ConsensusEvent{
+              body: %Mempool.Events.ConsensusEvent{
                 order: ^final_consensus
               }
             }

--- a/apps/anoma_node/lib/node/transaction/backends/events.ex
+++ b/apps/anoma_node/lib/node/transaction/backends/events.ex
@@ -1,0 +1,171 @@
+defmodule Anoma.Node.Transaction.Backends.Events do
+  @moduledoc """
+  I define all events that are being sent by the backend.
+
+  I also define the filters that can be used to subscribe to these events.
+  """
+  alias Anoma.Node.Event
+  alias Anoma.Node.Transaction.Executor
+  alias Anoma.Node.Transaction.Mempool
+
+  use EventBroker.DefFilter
+  use TypedStruct
+  ############################################################
+  #                           Events                         #
+  ############################################################
+
+  typedstruct enforce: true, module: ResultEvent do
+    @typedoc """
+    I hold the content of the Result Event, which conveys the result of
+    the transaction candidate code execution on the Anoma VM to
+    the Mempool engine.
+
+    ### Fields
+    - `:tx_id`              - The transaction id.
+    - `:tx_result`          - VM execution result; either :error or an
+                              {:ok, noun} tuple.
+    """
+    field(:tx_id, binary())
+    field(:vm_result, Mempool.vm_result())
+  end
+
+  defimpl Jason.Encoder, for: ResultEvent do
+    defp encode_maybe_noun(noun) when is_atom(noun) do
+      noun
+    end
+
+    defp encode_maybe_noun({:ok, noun}) do
+      encode_maybe_noun(noun)
+    end
+
+    defp encode_maybe_noun(noun) do
+      with jammed <- Noun.Jam.jam(noun),
+           encoded <- Base.encode64(jammed) do
+        encoded
+      end
+    end
+
+    def encode(%ResultEvent{} = event, opts) do
+      with vm_result <- encode_maybe_noun(event.vm_result) do
+        Jason.Encode.map(
+          %{
+            tx_id: event.tx_id,
+            vm_result: vm_result
+          },
+          opts
+        )
+      end
+    end
+  end
+
+  typedstruct enforce: true, module: CompleteEvent do
+    @typedoc """
+    I hold the content of the Complete Event, which communicates the result
+    of the transaction candidate execution to the Executor engine.
+
+    ### Fields
+    - `:tx_id`              - The transaction id.
+    - `:tx_result`          - Execution result; either :error or an
+                              {:ok, value} tuple.
+    """
+    field(:tx_id, binary())
+    field(:tx_result, Mempool.vm_result())
+  end
+
+  defimpl Jason.Encoder, for: CompleteEvent do
+    defp encode_maybe_noun(noun) when is_atom(noun) do
+      noun
+    end
+
+    defp encode_maybe_noun({:ok, noun}) do
+      encode_maybe_noun(noun)
+    end
+
+    defp encode_maybe_noun(noun) do
+      with jammed <- Noun.Jam.jam(noun),
+           encoded <- Base.encode64(jammed) do
+        encoded
+      end
+    end
+
+    def encode(%CompleteEvent{} = event, opts) do
+      with tx_result <- encode_maybe_noun(event.tx_result) do
+        Jason.Encode.map(
+          %{
+            tx_id: event.tx_id,
+            tx_result: tx_result
+          },
+          opts
+        )
+      end
+    end
+  end
+
+  typedstruct enforce: true, module: TRMEvent do
+    @derive Jason.Encoder
+    @typedoc """
+    I hold the content of the The Resource Machine Event, which
+    communicates a set of nullifiers/commitments defined by the actions of the
+    transaction candidate to the Intent Pool.
+
+    ### Fields
+
+    - `:commitments`        - The set of commitments.
+    - `:nullifiers`         - The set of nullifiers.
+    - `:commitments`        - The set of commitments.
+    """
+    field(:commitments, MapSet.t(binary()), default: MapSet.new())
+    field(:nullifiers, MapSet.t(binary()), default: MapSet.new())
+  end
+
+  # todo: where to put this?
+  defimpl Jason.Encoder, for: MapSet do
+    def encode(mapset, opts) do
+      Jason.Encode.list(Enum.into(mapset, []), opts)
+    end
+  end
+
+  typedstruct enforce: true, module: SRMEvent do
+    @derive Jason.Encoder
+    @typedoc """
+    I hold the content of the The Shielded Resource Machine Event, which
+    communicates a set of nullifiers/commitments defined by the actions of the
+    transaction candidate to the Intent Pool.
+
+    ### Fields
+
+    - `:commitments`        - The set of commitments.
+    - `:nullifiers`         - The set of nullifiers.
+    """
+    field(:commitments, MapSet.t(binary()), default: MapSet.new())
+    field(:nullifiers, MapSet.t(binary()), default: MapSet.new())
+  end
+
+  ############################################################
+  #                           Filters                        #
+  ############################################################
+
+  deffilter CompleteFilter do
+    %EventBroker.Event{body: %Event{body: %CompleteEvent{}}} ->
+      true
+
+    _ ->
+      false
+  end
+
+  deffilter ForMempoolFilter do
+    %EventBroker.Event{body: %Event{body: %ResultEvent{}}} ->
+      true
+
+    _ ->
+      false
+  end
+
+  deffilter ForMempoolExecutionFilter do
+    %EventBroker.Event{body: %Event{body: %Executor.Events.ExecutionEvent{}}} ->
+      true
+
+    _ ->
+      false
+  end
+end

--- a/apps/anoma_node/lib/node/transaction/executor.ex
+++ b/apps/anoma_node/lib/node/transaction/executor.ex
@@ -186,9 +186,7 @@ defmodule Anoma.Node.Transaction.Executor do
   # """
   @spec handle_launch({Backends.backend(), Noun.t()}, binary(), t()) :: :ok
   defp handle_launch(tw_w_backend, id, state = %Executor{}) do
-    tx_supervisor = Registry.via(state.node_id, TxSupervisor)
-
-    Task.Supervisor.start_child(tx_supervisor, fn ->
+    spawn(fn ->
       try do
         Backends.execute(state.node_id, tw_w_backend, id)
       rescue

--- a/apps/anoma_node/lib/node/transaction/executor/events.ex
+++ b/apps/anoma_node/lib/node/transaction/executor/events.ex
@@ -1,0 +1,41 @@
+defmodule Anoma.Node.Transaction.Executor.Events do
+  @moduledoc """
+  I define all events that are being sent by the mempool.
+
+  I also define the filters that can be used to subscribe to these events.
+  """
+  alias Anoma.Node.Transaction.Mempool
+
+  use EventBroker.DefFilter
+  use TypedStruct
+
+  ############################################################
+  #                           Events                         #
+  ############################################################
+
+  typedstruct enforce: true, module: ExecutionEvent do
+    @typedoc """
+    I am the type of an execution event.
+
+    I am launched when transactions for a specific block have been
+    succesfully processed by their respective workers.
+
+    I hence signal the results with a message containing the result list.
+    The order of the results should coincide with the ordering of the
+    corresponding transactions.
+    """
+
+    field(:result, [Mempool.vm_result()], default: [])
+  end
+
+  typedstruct enforce: true, module: TaskCrash do
+    @typedoc """
+    I am a crash event for a task that failed.
+    """
+    field(:task, pid())
+  end
+
+  ############################################################
+  #                           Filters                        #
+  ############################################################
+end

--- a/apps/anoma_node/lib/node/transaction/mempool/events.ex
+++ b/apps/anoma_node/lib/node/transaction/mempool/events.ex
@@ -1,0 +1,98 @@
+defmodule Anoma.Node.Transaction.Mempool.Events do
+  @moduledoc """
+  I define all events that are being sent by the mempool.
+
+  I also define the filters that can be used to subscribe to these events.
+  """
+
+  alias Anoma.Node.Event
+  alias Anoma.Node.Transaction.Mempool
+
+  use EventBroker.DefFilter
+  use TypedStruct
+
+  ############################################################
+  #                           Events                         #
+  ############################################################
+
+  typedstruct module: TxEvent do
+    @derive Jason.Encoder
+    @typedoc """
+    I am the type of a transaction event.
+
+    I am sent upon a launch of a transaction, signaling that a specific
+    transaction has been launched.
+
+    ### Fileds
+
+    - `:id` - The ID of a launched transaction.
+    - `:tx` - The transaction info as stored in Mempool state.
+    """
+
+    field(:id, binary())
+    field(:tx, Mempool.Tx.t())
+  end
+
+  typedstruct module: ConsensusEvent do
+    @derive Jason.Encoder
+    @typedoc """
+    I am the type of a consensus event.
+
+    I am sent upon receiving a consensus, signaling that ordering has been
+    assigned to a specific subset of pending transactions.
+
+    ### Fileds
+
+    - `:order` - The list of transaction IDs in apporpriate consensus
+                 specified order.
+    """
+
+    field(:order, [binary()], default: [])
+  end
+
+  typedstruct module: BlockEvent do
+    @derive Jason.Encoder
+    @typedoc """
+    I am the type of a block execition event.
+
+    I am sent upon a completion of all transactions submitted by consensus
+    and subsequent creation of a table-backed block.
+
+    ### Fileds
+
+    - `:order` - The consensus info executed, a list of transaction IDs.
+    - `:round` - The block number committed.
+    """
+
+    field(:order, [binary()], default: [])
+    field(:round, non_neg_integer())
+  end
+
+  ############################################################
+  #                           Filters                        #
+  ############################################################
+
+  deffilter TxFilter do
+    %EventBroker.Event{body: %Event{body: %TxEvent{}}} ->
+      true
+
+    _ ->
+      false
+  end
+
+  deffilter ConsensusFilter do
+    %EventBroker.Event{body: %Event{body: %ConsensusEvent{}}} ->
+      true
+
+    _ ->
+      false
+  end
+
+  deffilter BlockFilter do
+    %EventBroker.Event{body: %Event{body: %BlockEvent{}}} ->
+      true
+
+    _ ->
+      false
+  end
+end

--- a/apps/anoma_node/lib/node/transaction/ordering/events.ex
+++ b/apps/anoma_node/lib/node/transaction/ordering/events.ex
@@ -1,0 +1,39 @@
+defmodule Anoma.Node.Transaction.Ordering.Events do
+  @moduledoc """
+  I define the events and event filters for the ordering engine.
+  """
+  alias Anoma.Node.Event
+
+  use EventBroker.DefFilter
+  use TypedStruct
+
+  use EventBroker.DefFilter
+
+  ############################################################
+  #                           Events                         #
+  ############################################################
+  typedstruct enforce: true, module: OrderEvent do
+    @derive Jason.Encoder
+    @typedoc """
+    I am the type of an ordering Event.
+
+    I am sent whenever the transaction with which I am associated gets a
+    global timestamp.
+
+    ### Fields
+
+    - `tx_id` - The ID of the transaction which was ordered.
+    """
+
+    field(:tx_id, binary())
+  end
+
+  ############################################################
+  #                           Filters                        #
+  ############################################################
+
+  deffilter TxIdFilter, tx_id: binary() do
+    %EventBroker.Event{body: %Event{body: %{tx_id: ^tx_id}}} -> true
+    _ -> false
+  end
+end

--- a/apps/anoma_node/lib/node/transaction/storage/events.ex
+++ b/apps/anoma_node/lib/node/transaction/storage/events.ex
@@ -1,0 +1,41 @@
+defmodule Anoma.Node.Transaction.Storage.Events do
+  @moduledoc """
+  I define all events that are being sent by the storage engine.
+
+  I also define the filters that can be used to subscribe to these events.
+  """
+
+  alias Anoma.Node.Event
+
+  use EventBroker.DefFilter
+  use TypedStruct
+
+  ############################################################
+  #                           Events                         #
+  ############################################################
+
+  typedstruct enforce: true, module: WriteEvent do
+    @typedoc """
+    I am the type of a write event.
+
+    I am sent whenever something has been written at a particular height.
+
+    ### Fields
+
+    - `:height` - The height at which something was just written.
+    - `:writes` - A list of tuples {key, value}
+    """
+
+    field(:height, non_neg_integer())
+    field(:writes, list({Anoma.Node.Transaction.Storage.bare_key(), term()}))
+  end
+
+  ############################################################
+  #                           Filters                        #
+  ############################################################
+
+  deffilter HeightFilter, height: non_neg_integer() do
+    %EventBroker.Event{body: %Event{body: %{height: ^height}}} -> true
+    _ -> false
+  end
+end

--- a/apps/anoma_node/lib/node/transaction/supervisor.ex
+++ b/apps/anoma_node/lib/node/transaction/supervisor.ex
@@ -5,7 +5,6 @@ defmodule Anoma.Node.Transaction.Supervisor do
 
   use Supervisor
 
-  alias Anoma.Node.Registry
   alias Anoma.Node.Transaction.Mempool
   alias Anoma.Node.Transaction.Ordering
 
@@ -40,10 +39,9 @@ defmodule Anoma.Node.Transaction.Supervisor do
        [node_id: args[:node_id]] ++ Keyword.get(args, :ordering, [])},
       {Anoma.Node.Transaction.Storage,
        [node_id: args[:node_id]] ++ Keyword.get(args, :storage, [])},
+      {Anoma.Node.Transaction.Executor, [node_id: args[:node_id]]},
       {Anoma.Node.Transaction.Mempool,
-       [node_id: args[:node_id]] ++ Keyword.get(args, :mempool, [])},
-      {Task.Supervisor, name: Registry.via(args[:node_id], TxSupervisor)},
-      {Anoma.Node.Transaction.Executor, [node_id: args[:node_id]]}
+       [node_id: args[:node_id]] ++ Keyword.get(args, :mempool, [])}
     ]
 
     Supervisor.init(children, strategy: :one_for_all)

--- a/apps/anoma_node/test/replay_test.exs
+++ b/apps/anoma_node/test/replay_test.exs
@@ -1,0 +1,9 @@
+defmodule ReplayTest do
+  use ExUnit.Case, async: true
+
+  use TestHelper.GenerateExampleTests,
+    for: Anoma.Node.Examples.EReplay.StartState
+
+  use TestHelper.GenerateExampleTests,
+    for: Anoma.Node.Examples.EReplay
+end

--- a/apps/anoma_node/test/serialize_test.exs
+++ b/apps/anoma_node/test/serialize_test.exs
@@ -1,0 +1,16 @@
+defmodule Examples.SerializeTest do
+  use ExUnit.Case, async: true
+  use TestHelper.TestMacro
+
+  use TestHelper.GenerateExampleTests,
+    for: Anoma.Node.Examples.Serializing.Structs.Mempool
+
+  use TestHelper.GenerateExampleTests,
+    for: Anoma.Node.Examples.Serializing.Events.Mempool
+
+  use TestHelper.GenerateExampleTests,
+    for: Anoma.Node.Examples.Serializing.Events.Backends
+
+  use TestHelper.GenerateExampleTests,
+    for: Anoma.Node.Examples.Serializing.Events.Ordering
+end

--- a/global_deps.exs
+++ b/global_deps.exs
@@ -12,7 +12,6 @@
   {:kino_kroki, "~> 0.1.0"},
   {:memoize, "~> 1.4.3"},
   {:mnesia_rocksdb, git: "https://github.com/aeternity/mnesia_rocksdb"},
-  {:mock, "~> 0.3.0"},
   {:msgpack, "~> 0.8.1"},
   {:murmur, "~> 2.0"},
   {:optimus, "~> 0.2"},


### PR DESCRIPTION
This PR restructures all events and filters into separate modules. This reduces the complexity of each engine drastically, and makes it easier to navigate what's what.