### PR TITLE
Make Merkle Tree Hash Field an Atom

### DIFF
--- a/apps/anoma_lib/lib/commitment_tree/node.ex
+++ b/apps/anoma_lib/lib/commitment_tree/node.ex
@@ -16,10 +16,12 @@ defmodule CommitmentTree.Node do
   """
   @spec new(CommitmentTree.Spec.t(), tuple()) :: CommitmentTree.Node.t()
   def new(spec, children) do
+    hash = CommitmentTree.Spec.hash_ref_to_hash(spec.hash)
+
     %CommitmentTree.Node{
       children: children,
       hash:
-        spec.hash.(
+        hash.(
           map_tuple(children, fn x ->
             if is_binary(x) do
               x

--- a/apps/anoma_lib/lib/commitment_tree/proof.ex
+++ b/apps/anoma_lib/lib/commitment_tree/proof.ex
@@ -44,8 +44,10 @@ defmodule CommitmentTree.Proof do
           binary()
         ) :: {binary(), boolean()}
   def verifyx(spec, depth, path, proof, cm) do
+    hash_fun = CommitmentTree.Spec.hash_ref_to_hash(spec.hash)
+
     if depth == 0 do
-      {spec.hash.(proof), cm == elem(proof, path)}
+      {hash_fun.(proof), cm == elem(proof, path)}
     else
       i = Integer.mod(path, spec.splay)
 
@@ -58,7 +60,7 @@ defmodule CommitmentTree.Proof do
           cm
         )
 
-      {spec.hash.(put_elem(proof, i, hash)), valid}
+      {hash_fun.(put_elem(proof, i, hash)), valid}
     end
   end
 end

--- a/apps/anoma_lib/lib/commitment_tree/spec.ex
+++ b/apps/anoma_lib/lib/commitment_tree/spec.ex
@@ -4,6 +4,11 @@ defmodule CommitmentTree.Spec do
   """
   use TypedStruct
 
+  @typedoc """
+  A type of possible merkle tree hashes currently supported.
+  """
+  @type accumulator_hash :: :sha256 | :poseidon
+
   typedstruct enforce: true do
     # the (fixed) depth of the tree
     field(:depth, integer())
@@ -12,8 +17,8 @@ defmodule CommitmentTree.Spec do
     field(:splay, integer())
     # the number of bits in a commitment
     field(:key_size, integer())
-    # a function taking a tuple of splay hashes and returning a new hash
-    field(:hash, function())
+    # an atom specifying the appropriate hash function to use
+    field(:hash, accumulator_hash)
     # cached <<0::size(key_size)>>
     field(:key_zero, binary())
 
@@ -21,7 +26,7 @@ defmodule CommitmentTree.Spec do
     field(:splay_suff_prod, list(integer()))
   end
 
-  @spec new(integer(), integer(), integer(), function()) :: t()
+  @spec new(integer(), integer(), integer(), accumulator_hash()) :: t()
   def new(depth, splay, key_size, hash) do
     %CommitmentTree.Spec{
       depth: depth,
@@ -36,26 +41,34 @@ defmodule CommitmentTree.Spec do
   # It's a sha256 tree spec by default
   @spec cm_tree_spec() :: CommitmentTree.Spec.t()
   def cm_tree_spec() do
-    new(32, 2, 256, fn {x, y} ->
-      :crypto.hash(:sha256, x <> y)
-    end)
+    new(32, 2, 256, :sha256)
   end
 
   # cairo poseidon cm tree spec
   @spec cairo_poseidon_cm_tree_spec() :: CommitmentTree.Spec.t()
   def cairo_poseidon_cm_tree_spec() do
-    new(32, 2, 256, fn {x, y} ->
-      Cairo.poseidon(:binary.bin_to_list(x), :binary.bin_to_list(y))
-      |> :binary.list_to_bin()
-    end)
+    new(32, 2, 256, :poseidon)
   end
 
   # cairo poseidon resource tree spec for action
   @spec cairo_poseidon_resource_tree_spec() :: CommitmentTree.Spec.t()
   def cairo_poseidon_resource_tree_spec() do
-    new(4, 2, 256, fn {x, y} ->
+    new(4, 2, 256, :poseidon)
+  end
+
+  @doc """
+  I take an atom representation of the hash function used for the merkle
+  tree and turn it into the appropriate function.
+  """
+  @spec hash_ref_to_hash(accumulator_hash()) :: function()
+  def hash_ref_to_hash(:sha256) do
+    fn {x, y} -> :crypto.hash(:sha256, x <> y) end
+  end
+
+  def hash_ref_to_hash(:poseidon) do
+    fn {x, y} ->
       Cairo.poseidon(:binary.bin_to_list(x), :binary.bin_to_list(y))
       |> :binary.list_to_bin()
-    end)
+    end
   end
 end


### PR DESCRIPTION
In order to nounify the trees in the future, instead of storing things as Elixir functions, store their appropriate names instead to be matched for hashing.

Termporary solution for making it appropriate for scrying.