### PR TITLE
Protocol for Bool does not exist

### DIFF
--- a/apps/anoma_lib/lib/anoma/rm/transparent/proving_systems/rlps.ex
+++ b/apps/anoma_lib/lib/anoma/rm/transparent/proving_systems/rlps.ex
@@ -33,7 +33,7 @@ defmodule Anoma.RM.Transparent.ProvingSystem.RLPS.Instance do
 
   @spec from_noun(Noun.t()) :: {:ok, t()} | :error
   def from_noun([tag, flag, consumed, created | app_data]) do
-    with {:ok, bool} <- Noun.Nounable.Bool.from_noun(flag),
+    with {:ok, bool} <- Noun.Nounable.Atom.from_noun(flag),
          {:ok, list_consumed} <- Noun.Nounable.List.from_noun(consumed),
          {:ok, list_created} <- Noun.Nounable.List.from_noun(created),
          {:ok, list_app_data} <- Noun.Nounable.List.from_noun(app_data) do
@@ -58,7 +58,7 @@ defmodule Anoma.RM.Transparent.ProvingSystem.RLPS.Instance do
   def to_noun(instance) do
     [
       instance.tag,
-      Noun.Nounable.Bool.to_noun(instance.flag),
+      Noun.Nounable.Atom.to_noun(instance.flag),
       instance.consumed,
       instance.created
       | Noun.Nounable.to_noun(instance.app_data)

--- a/apps/anoma_lib/lib/anoma/rm/transparent/resource.ex
+++ b/apps/anoma_lib/lib/anoma/rm/transparent/resource.ex
@@ -118,7 +118,7 @@ defmodule Anoma.RM.Transparent.Resource do
         nullifierkeycm
         | rseed
       ]) do
-    with {:ok, boolean} <- Noun.Nounable.Bool.from_noun(ephemerality) do
+    with {:ok, boolean} <- Noun.Nounable.Atom.from_noun(ephemerality) do
       {:ok,
        %__MODULE__{
          logicref: Noun.atom_binary_to_integer(logicref),

--- a/apps/anoma_lib/lib/noun/nounable.ex
+++ b/apps/anoma_lib/lib/noun/nounable.ex
@@ -48,27 +48,6 @@ defimpl Nounable, for: List do
   end
 end
 
-defimpl Nounable, for: Bool do
-  import Noun
-  @behaviour Kind
-
-  def to_noun(bool) when bool in [true, false] do
-    Nounable.to_noun(bool)
-  end
-
-  def to_noun(), do: :error
-
-  @doc """
-  I convert the given Nock boolean to Elixir boolean.
-  """
-  @spec from_noun(Noun.t()) :: {:ok, bool()} | :error
-  def from_noun(zero) when is_noun_zero(zero), do: {:ok, true}
-
-  def from_noun(one) when one in [1, <<1>>], do: {:ok, false}
-
-  def from_noun(_), do: :error
-end
-
 defimpl Nounable, for: Integer do
   def to_noun(x) when x >= 0, do: x
   # We should support this in time?
@@ -81,9 +60,21 @@ defimpl Nounable, for: BitString do
 end
 
 defimpl Nounable, for: Atom do
+  import Noun
+
   def to_noun(true), do: 0
   def to_noun(false), do: 1
   def to_noun(atom), do: Atom.to_string(atom)
+
+  @doc """
+  I convert the given Nock boolean to Elixir boolean.
+  """
+  @spec from_noun(Noun.t()) :: {:ok, bool()} | :error
+  def from_noun(zero) when is_noun_zero(zero), do: {:ok, true}
+
+  def from_noun(one) when one in [1, <<1>>], do: {:ok, false}
+
+  def from_noun(_), do: :error
 end
 
 defimpl Nounable, for: Tuple do


### PR DESCRIPTION
We had an implementation for `Noun.Nounable` for `Bool`, but that type does not exist. It is actually Atom. 

Migrating to 1.19 brought this to my attention. 

This PR fixes that.