### PR TITLE
Nounability for Merkle Tree

### DIFF
--- a/apps/anoma_lib/lib/anoma/cairo_resource/shielded_transaction.ex
+++ b/apps/anoma_lib/lib/anoma/cairo_resource/shielded_transaction.ex
@@ -330,10 +330,7 @@ defmodule Anoma.CairoResource.Transaction do
 
   @spec cm_tree() :: CommitmentTree.t()
   def cm_tree() do
-    CommitmentTree.new(
-      CommitmentTree.Spec.cairo_poseidon_cm_tree_spec(),
-      nil
-    )
+    CommitmentTree.new(CommitmentTree.Spec.cairo_poseidon_cm_tree_spec())
   end
 
   @doc """

--- a/apps/anoma_lib/lib/anoma/cairo_resource/tree.ex
+++ b/apps/anoma_lib/lib/anoma/cairo_resource/tree.ex
@@ -17,7 +17,7 @@ defmodule Anoma.CairoResource.Tree do
 
   @spec construct(CommitmentTree.Spec.t(), list(binary())) :: t()
   def construct(spec, leaves) do
-    empty_rt = CommitmentTree.new(spec, nil)
+    empty_rt = CommitmentTree.new(spec)
     {rt, anchor} = CommitmentTree.add(empty_rt, leaves)
 
     %__MODULE__{

--- a/apps/anoma_lib/lib/commitment_tree.ex
+++ b/apps/anoma_lib/lib/commitment_tree.ex
@@ -10,8 +10,6 @@ defmodule CommitmentTree do
 
   Fiats that empty subtrees have a hash of 0 for simplicity.
   """
-  alias Anoma.Node.Tables
-
   use TypedStruct
 
   typedstruct enforce: true do
@@ -21,60 +19,26 @@ defmodule CommitmentTree do
     field(:root, CommitmentTree.Node.t())
     # the current number of commitments in the tree
     field(:size, integer())
-
-    # the name of the mnesia table where the commitments will be stored.  may be nil
-    field(:table, term())
   end
 
   ############################################################
   #                         Public Functions                 #
   ############################################################
 
-  @spec init_storage(String.t()) :: :ok
-  def init_storage(node_id \\ "") do
-    {:ok, _} = Tables.initialize_tables_for_node(node_id)
-
-    :ok
-  end
-
   @doc """
   Creates a new `CommitmentTree` struct.
   """
-  @spec new(CommitmentTree.Spec.t(), term()) :: CommitmentTree.t()
-  def new(spec, table) do
+  @spec new(CommitmentTree.Spec.t()) :: CommitmentTree.t()
+  def new(spec) do
     # create an empty tree
-    tree = %CommitmentTree{
+    %CommitmentTree{
       spec: spec,
       size: 0,
       # technically, this gives us an initial anchor of H(zero, zero, zero...)
       # instead of zero, but it simplifies the logic, and you can't prove
       # anything against an empty tree anyway
-      root: CommitmentTree.Node.new_empty(spec),
-      table: table
+      root: CommitmentTree.Node.new_empty(spec)
     }
-
-    if table do
-      # read all the commitments out of the table and replay them into the tree
-      # there seems to not be a better way to do this
-      n = :mnesia.table_info(table, :size)
-
-      {:atomic, cms} =
-        :mnesia.transaction(fn ->
-          Enum.map(
-            0..(n - 1)//1,
-            fn i ->
-              :mnesia.read(table, i)
-              |> hd
-              |> elem(2)
-            end
-          )
-        end)
-
-      {tree, _anchor} = add_mem(tree, cms, n)
-      tree
-    else
-      tree
-    end
   end
 
   @doc """
@@ -84,21 +48,7 @@ defmodule CommitmentTree do
   @spec add(CommitmentTree.t(), list(binary())) :: tuple()
   def add(tree, cms) do
     n = length(cms)
-
-    if tree.table do
-      add_mnesia(tree, cms)
-    end
-
     add_mem(tree, cms, n)
-  end
-
-  defp add_mnesia(tree, cms) do
-    :mnesia.transaction(fn ->
-      Enum.reduce(cms, tree.size, fn cm, i ->
-        :mnesia.write({tree.table, i, cm})
-        i + 1
-      end)
-    end)
   end
 
   defp add_mem(tree, cms, n) do

--- a/apps/anoma_lib/lib/commitment_tree/node.ex
+++ b/apps/anoma_lib/lib/commitment_tree/node.ex
@@ -16,10 +16,12 @@ defmodule CommitmentTree.Node do
   """
   @spec new(CommitmentTree.Spec.t(), tuple()) :: CommitmentTree.Node.t()
   def new(spec, children) do
+    hash = CommitmentTree.Spec.hash_ref_to_hash(spec.hash)
+
     %CommitmentTree.Node{
       children: children,
       hash:
-        spec.hash.(
+        hash.(
           map_tuple(children, fn x ->
             if is_binary(x) do
               x

--- a/apps/anoma_lib/lib/commitment_tree/proof.ex
+++ b/apps/anoma_lib/lib/commitment_tree/proof.ex
@@ -3,6 +3,9 @@ defmodule CommitmentTree.Proof do
   I represent a compact proof that a particular element is contained within the
   commitment tree.
   """
+  alias __MODULE__
+
+  import Noun
   use TypedStruct
 
   # Not sure if there is a nice way to represent this for sending over the wire
@@ -63,4 +66,53 @@ defmodule CommitmentTree.Proof do
       {hash_fun.(put_elem(proof, i, hash)), valid}
     end
   end
+
+  defimpl Noun.Nounable, for: Proof do
+    @impl true
+    def to_noun(prf = %Proof{}) do
+      [
+        prf.path
+        | to_sized_tuple(prf.proof)
+      ]
+    end
+
+    defp to_sized_tuple({a, b}) do
+      size_b = :erlang.byte_size(b)
+      [to_sized_tuple(a), size_b | b]
+    end
+
+    defp to_sized_tuple(a) do
+      size = :erlang.byte_size(a)
+      [size | a]
+    end
+  end
+
+  @spec from_noun(Noun.t()) :: :error | {:ok, t()}
+  def from_noun([path | proof]) do
+    with {:ok, tuple} <- from_sized_tuple(proof) do
+      {:ok,
+       %__MODULE__{
+         path: Noun.atom_binary_to_integer(path),
+         proof: tuple
+       }}
+    else
+      _ -> :error
+    end
+  end
+
+  @spec from_sized_tuple(Noun.t()) :: {:ok, tuple() | binary()} | :error
+  defp from_sized_tuple([a, b_size | b]) do
+    with {:ok, maybe_tuple} <- from_sized_tuple(a) do
+      {:ok, {maybe_tuple, Noun.atom_integer_to_binary(b, b_size)}}
+    else
+      _ -> :error
+    end
+  end
+
+  defp from_sized_tuple([size | atom])
+       when is_noun_atom(size) and is_noun_atom(atom) do
+    {:ok, Noun.atom_integer_to_binary(atom, size)}
+  end
+
+  defp from_sized_tuple(_), do: :error
 end

--- a/apps/anoma_lib/lib/commitment_tree/proof.ex
+++ b/apps/anoma_lib/lib/commitment_tree/proof.ex
@@ -44,8 +44,10 @@ defmodule CommitmentTree.Proof do
           binary()
         ) :: {binary(), boolean()}
   def verifyx(spec, depth, path, proof, cm) do
+    hash_fun = CommitmentTree.Spec.hash_ref_to_hash(spec.hash)
+
     if depth == 0 do
-      {spec.hash.(proof), cm == elem(proof, path)}
+      {hash_fun.(proof), cm == elem(proof, path)}
     else
       i = Integer.mod(path, spec.splay)
 
@@ -58,7 +60,7 @@ defmodule CommitmentTree.Proof do
           cm
         )
 
-      {spec.hash.(put_elem(proof, i, hash)), valid}
+      {hash_fun.(put_elem(proof, i, hash)), valid}
     end
   end
 end

--- a/apps/anoma_lib/lib/commitment_tree/spec.ex
+++ b/apps/anoma_lib/lib/commitment_tree/spec.ex
@@ -4,6 +4,11 @@ defmodule CommitmentTree.Spec do
   """
   use TypedStruct
 
+  @typedoc """
+  A type of possible merkle tree hashes currently supported.
+  """
+  @type accumulator_hash :: :sha256 | :poseidon
+
   typedstruct enforce: true do
     # the (fixed) depth of the tree
     field(:depth, integer())
@@ -12,8 +17,8 @@ defmodule CommitmentTree.Spec do
     field(:splay, integer())
     # the number of bits in a commitment
     field(:key_size, integer())
-    # a function taking a tuple of splay hashes and returning a new hash
-    field(:hash, function())
+    # an atom specifying the appropriate hash function to use
+    field(:hash, accumulator_hash)
     # cached <<0::size(key_size)>>
     field(:key_zero, binary())
 
@@ -21,7 +26,7 @@ defmodule CommitmentTree.Spec do
     field(:splay_suff_prod, list(integer()))
   end
 
-  @spec new(integer(), integer(), integer(), function()) :: t()
+  @spec new(integer(), integer(), integer(), accumulator_hash()) :: t()
   def new(depth, splay, key_size, hash) do
     %CommitmentTree.Spec{
       depth: depth,
@@ -36,26 +41,34 @@ defmodule CommitmentTree.Spec do
   # It's a sha256 tree spec by default
   @spec cm_tree_spec() :: CommitmentTree.Spec.t()
   def cm_tree_spec() do
-    new(32, 2, 256, fn {x, y} ->
-      :crypto.hash(:sha256, x <> y)
-    end)
+    new(32, 2, 256, :sha256)
   end
 
   # cairo poseidon cm tree spec
   @spec cairo_poseidon_cm_tree_spec() :: CommitmentTree.Spec.t()
   def cairo_poseidon_cm_tree_spec() do
-    new(32, 2, 256, fn {x, y} ->
-      Cairo.poseidon(:binary.bin_to_list(x), :binary.bin_to_list(y))
-      |> :binary.list_to_bin()
-    end)
+    new(32, 2, 256, :poseidon)
   end
 
   # cairo poseidon resource tree spec for action
   @spec cairo_poseidon_resource_tree_spec() :: CommitmentTree.Spec.t()
   def cairo_poseidon_resource_tree_spec() do
-    new(4, 2, 256, fn {x, y} ->
+    new(4, 2, 256, :poseidon)
+  end
+
+  @doc """
+  I take an atom representation of the hash function used for the merkle
+  tree and turn it into the appropriate function.
+  """
+  @spec hash_ref_to_hash(accumulator_hash()) :: function()
+  def hash_ref_to_hash(:sha256) do
+    fn {x, y} -> :crypto.hash(:sha256, x <> y) end
+  end
+
+  def hash_ref_to_hash(:poseidon) do
+    fn {x, y} ->
       Cairo.poseidon(:binary.bin_to_list(x), :binary.bin_to_list(y))
       |> :binary.list_to_bin()
-    end)
+    end
   end
 end

--- a/apps/anoma_lib/lib/examples/ecommitment_tree.ex
+++ b/apps/anoma_lib/lib/examples/ecommitment_tree.ex
@@ -1,5 +1,4 @@
 defmodule Examples.ECommitmentTree do
-  alias Anoma.Node.Tables
   alias Anoma.TransparentResource.Transaction
   alias Examples.ECairo
   alias Examples.ETransparent.ETransaction
@@ -30,12 +29,11 @@ defmodule Examples.ECommitmentTree do
     tree
   end
 
-  @spec memory_backed_ct(CommitmentTree.Spec.t()) :: CommitmentTree.t()
-  def memory_backed_ct(spec \\ sha256_32_spec()) do
-    tree = CommitmentTree.new(spec, nil)
+  @spec new_ct(CommitmentTree.Spec.t()) :: CommitmentTree.t()
+  def new_ct(spec \\ sha256_32_spec()) do
+    tree = CommitmentTree.new(spec)
 
     assert tree.size == 0
-    assert tree.table == nil
 
     tree
   end
@@ -43,10 +41,10 @@ defmodule Examples.ECommitmentTree do
   @doc """
   A commitment tree with commits from ETransaction.swap_from_actions/1
   """
-  @spec memory_backed_ct_with_trivial_swap(term()) ::
+  @spec ct_with_trivial_swap(term()) ::
           {CommitmentTree.t(), binary()}
-  def memory_backed_ct_with_trivial_swap(spec \\ sha256_32_spec()) do
-    tree = memory_backed_ct(spec)
+  def ct_with_trivial_swap(spec \\ sha256_32_spec()) do
+    tree = new_ct(spec)
     transaction = ETransaction.swap_from_actions()
 
     commits = Transaction.commitments(transaction)
@@ -58,40 +56,10 @@ defmodule Examples.ECommitmentTree do
     {tree, anchor}
   end
 
-  @spec empty_mnesia_backed_ct(CommitmentTree.Spec.t()) :: CommitmentTree.t()
-  def empty_mnesia_backed_ct(spec \\ sha256_32_spec()) do
-    CommitmentTree.init_storage("no_node")
-
-    table_name = Tables.table_commitment_tree()
-    Tables.clear_table(Tables.table_commitment_tree())
-    tree = CommitmentTree.new(spec, table_name)
-
-    assert tree.size == 0
-    assert tree.table == table_name
-
-    tree
-  end
-
-  # @doc """
-  # This fetches the current mnesia tree storage
-
-  # This value is expected to differ, and will be a fixture for other
-  # tests to assert about.
-  # """
-  @spec current_tree_mnesia_ct(CommitmentTree.Spec.t()) :: CommitmentTree.t()
-  def current_tree_mnesia_ct(spec) do
-    table_name = Tables.table_commitment_tree()
-    tree = CommitmentTree.new(spec, table_name)
-
-    assert :mnesia.table_info(table_name, :size) == tree.size
-
-    tree
-  end
-
-  @spec babylon_mnesia_ct(CommitmentTree.Spec.t()) :: CommitmentTree.t()
-  def babylon_mnesia_ct(spec \\ sha256_32_spec()) do
+  @spec babylon_ct(CommitmentTree.Spec.t()) :: CommitmentTree.t()
+  def babylon_ct(spec \\ sha256_32_spec()) do
     # This resets the table, this binding is important!
-    empty_ct = empty_mnesia_backed_ct(spec)
+    empty_ct = new_ct(spec)
 
     # It's fine the adding hashes come from sha256. Cuz Cairo poseidon hash also
     # returns 256bits.
@@ -103,10 +71,6 @@ defmodule Examples.ECommitmentTree do
     {ct, anchor} = CommitmentTree.add(empty_ct, hashes)
 
     assert length(hashes) == ct.size
-
-    restored_tc = current_tree_mnesia_ct(spec)
-
-    assert ct == restored_tc, "Restoring from storage gives the same tree"
 
     for {hash, index} <- Enum.with_index(hashes) do
       prove = CommitmentTree.prove(ct, index)
@@ -121,7 +85,7 @@ defmodule Examples.ECommitmentTree do
 
   @spec lots_of_inserts_ct(CommitmentTree.Spec.t()) :: CommitmentTree.t()
   def lots_of_inserts_ct(spec \\ sha256_32_spec()) do
-    ct = memory_backed_ct(spec)
+    ct = new_ct(spec)
 
     {ct_batches, keys} =
       Enum.reduce(1..100, {ct, []}, fn _, {ct, keys} ->
@@ -155,7 +119,7 @@ defmodule Examples.ECommitmentTree do
   def a_merkle_proof() do
     cairo_spec = cairo_poseidon_spec()
 
-    cm_tree = empty_mnesia_backed_ct(cairo_spec)
+    cm_tree = new_ct(cairo_spec)
     input_resource_cm = ECairo.EResource.a_resource_commitment()
 
     # Insert the input resource to the tree
@@ -169,13 +133,13 @@ defmodule Examples.ECommitmentTree do
   @doc """
   A commitment tree with commits from Examples.ERM.EShielded.ETransaction.a_shielded_transaction/0
   """
-  @spec memory_backed_ct_with_trivial_cairo_tx(term()) ::
+  @spec ct_with_trivial_cairo_tx(term()) ::
           {CommitmentTree.t(), binary()}
-  def memory_backed_ct_with_trivial_cairo_tx(
+  def ct_with_trivial_cairo_tx(
         cms,
         spec \\ cairo_poseidon_spec()
       ) do
-    tree = memory_backed_ct(spec)
+    tree = new_ct(spec)
 
     {tree, anchor} = CommitmentTree.add(tree, cms)
 

--- a/apps/anoma_lib/lib/examples/ecommitment_tree.ex
+++ b/apps/anoma_lib/lib/examples/ecommitment_tree.ex
@@ -170,4 +170,32 @@ defmodule Examples.ECommitmentTree do
 
     {tree, anchor}
   end
+
+  @spec nouned_tree_info(
+          {CommitmentTree.t(), CommitmentTree.Proof.t(), binary()}
+        ) :: {Noun.t(), Noun.t(), binary()}
+  def nouned_tree_info({ct, proof, anchor} \\ a_merkle_proof()) do
+    noun_ct = Noun.Nounable.to_noun(ct)
+    noun_proof = Noun.Nounable.to_noun(proof)
+
+    {:ok, unnouned_ct} = CommitmentTree.from_noun(noun_ct)
+    {:ok, unnouned_proof} = CommitmentTree.Proof.from_noun(noun_proof)
+
+    assert ct == unnouned_ct
+    assert proof == unnouned_proof
+
+    {noun_ct, noun_proof, anchor}
+  end
+
+  @spec nouned_empty_tree() :: Noun.t()
+  def nouned_empty_tree() do
+    tree = new_ct()
+    noun_ct = tree |> Noun.Nounable.to_noun()
+
+    {:ok, unnouned_ct} = noun_ct |> CommitmentTree.from_noun()
+
+    assert tree == unnouned_ct
+
+    noun_ct
+  end
 end

--- a/apps/anoma_lib/lib/examples/ecommitment_tree.ex
+++ b/apps/anoma_lib/lib/examples/ecommitment_tree.ex
@@ -120,7 +120,25 @@ defmodule Examples.ECommitmentTree do
       refute CommitmentTree.Proof.verify(spec, wrong, anchor, hash)
     end
 
+    for hash <- hashes do
+      prove = CommitmentTree.prove(ct, hash)
+      assert CommitmentTree.Proof.verify(spec, prove, anchor, hash)
+    end
+
     ct
+  end
+
+  @spec babylon_ct_new_hash(CommitmentTree.Spec.t()) :: CommitmentTree.t()
+  def babylon_ct_new_hash(spec \\ sha256_32_spec()) do
+    ct = babylon_mnesia_ct(spec)
+    new_hash = :crypto.hash(:sha256, "nice")
+
+    {new_ct, anchor} = CommitmentTree.add(ct, [new_hash])
+
+    path = CommitmentTree.prove(new_ct, new_hash)
+    assert CommitmentTree.Proof.verify(spec, path, anchor, new_hash)
+
+    new_ct
   end
 
   @spec lots_of_inserts_ct(CommitmentTree.Spec.t()) :: CommitmentTree.t()
@@ -166,6 +184,9 @@ defmodule Examples.ECommitmentTree do
     {ct, anchor} = CommitmentTree.add(cm_tree, [input_resource_cm])
     # Get the merkle proof of the input resource
     merkle_proof = CommitmentTree.prove(ct, 0)
+    merkle_proof_2 = CommitmentTree.prove(ct, input_resource_cm)
+
+    assert merkle_proof == merkle_proof_2
 
     {ct, merkle_proof, anchor}
   end

--- a/apps/anoma_lib/lib/tables.ex
+++ b/apps/anoma_lib/lib/tables.ex
@@ -20,7 +20,6 @@ defmodule Anoma.Node.Tables do
 
   @tables [
     {Events, [:type, :body]},
-    {CommitmentTree, [:index, :hash]},
     {Blocks, [:round, :block]},
     {Values, [:key, :value]},
     {Updates, [:key, :value]},
@@ -41,15 +40,6 @@ defmodule Anoma.Node.Tables do
   @spec table_events(String.t()) :: atom()
   def table_events(node_id) do
     node_table_name(node_id, Events)
-  end
-
-  @doc """
-  I return the table name for the given node its commitment tree.
-  I can be called without a node id too. In that case I use "no_node" as node id.
-  """
-  @spec table_commitment_tree(String.t()) :: atom()
-  def table_commitment_tree(node_id \\ "no_node") do
-    node_table_name(node_id, CommitmentTree)
   end
 
   @doc """

--- a/apps/anoma_node/lib/examples/e_shielded_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_shielded_transaction.ex
@@ -35,7 +35,7 @@ defmodule Anoma.Node.Examples.EShieldedTransaction do
       |> Anoma.CairoResource.Resource.commitment()
 
     {tree, anchor} =
-      Examples.ECommitmentTree.memory_backed_ct_with_trivial_cairo_tx([
+      Examples.ECommitmentTree.ct_with_trivial_cairo_tx([
         output_resource_cm
       ])
 
@@ -98,7 +98,7 @@ defmodule Anoma.Node.Examples.EShieldedTransaction do
       |> Anoma.CairoResource.Resource.commitment()
 
     {tree, anchor} =
-      Examples.ECommitmentTree.memory_backed_ct_with_trivial_cairo_tx([
+      Examples.ECommitmentTree.ct_with_trivial_cairo_tx([
         output_cm_1,
         output_cm_2
       ])
@@ -161,12 +161,12 @@ defmodule Anoma.Node.Examples.EShieldedTransaction do
       |> Anoma.CairoResource.Resource.commitment()
 
     {_, anchor_1} =
-      Examples.ECommitmentTree.memory_backed_ct_with_trivial_cairo_tx([
+      Examples.ECommitmentTree.ct_with_trivial_cairo_tx([
         output_cm_1
       ])
 
     {tree, anchor_2} =
-      Examples.ECommitmentTree.memory_backed_ct_with_trivial_cairo_tx([
+      Examples.ECommitmentTree.ct_with_trivial_cairo_tx([
         output_cm_1,
         output_cm_2
       ])


### PR DESCRIPTION
Makes Merkle Tree nounability. This paves way to scrying the RSM keyspaces.