### PR TITLE
Sharding Implementation

### DIFF
--- a/apps/anoma_lib/lib/examples/enock.ex
+++ b/apps/anoma_lib/lib/examples/enock.ex
@@ -2765,4 +2765,154 @@ defmodule Examples.ENock do
 
     code
   end
+
+  @spec a_int() :: integer()
+  @spec b_int() :: integer()
+  @spec c_int() :: integer()
+  def a_int(), do: Noun.atom_binary_to_integer("a")
+  def b_int(), do: Noun.atom_binary_to_integer("b")
+  def c_int(), do: Noun.atom_binary_to_integer("c")
+
+  @spec abc_list() :: Noun.t()
+  def abc_list() do
+    [[0 | a_int()], [0 | b_int()], [1 | c_int()] | 0]
+  end
+
+  ####################################################################
+  ##                     Shard Backend Examples                     ##
+  ####################################################################
+
+  # Write Program Generator (writes a constant value to a key)
+  def write_code_gen(key_int, value) do
+    reservations = [[1 | key_int] | 0]
+    writes_logic = [1 | [[key_int | value] | 0]]
+    [[0 | 3] | [reservations | [writes_logic | [0 | 0]]]]
+  end
+
+  @doc """
+  Nock program for reading "a", "b", adding, and writing sum to "c". Used in EShardBackend tests.
+  """
+  @spec read_ab_write_c_sum() :: Noun.t()
+  def read_ab_write_c_sum() do
+    key_a = a_int()
+    key_b = b_int()
+    key_c = c_int()
+
+    reservations = abc_list()
+
+    scryA = [12 | [[1 | 0] | [1 | key_a]]]
+    scryB = [12 | [[1 | 0] | [1 | key_b]]]
+    addFormula = [4 | [4 | [4 | [4 | [0 | 2]]]]]
+    sumFormula = [7 | [[scryA | scryB] | addFormula]]
+    writes_logic = [[[1 | key_c] | sumFormula] | [1 | 0]]
+
+    [[0 | 3] | [reservations | [writes_logic | [0 | 0]]]]
+  end
+
+  @doc """
+  Nock program for copying value from "a" to "b". Used in EShardBackend tests.
+  """
+  @spec copy_a_to_b() :: Noun.t()
+  def copy_a_to_b() do
+    key_a = a_int()
+    key_b = b_int()
+
+    reservations = [[0 | key_a], [1 | key_b] | 0]
+    scryA = [12 | [[1 | 0] | [1 | key_a]]]
+    writes_logic = [[[1 | key_b] | scryA] | [1 | 0]]
+
+    [[0 | 3] | [reservations | [writes_logic | [0 | 0]]]]
+  end
+
+  @doc """
+  Nock program that reserves write on 'a', then crashes. Used in EShardBackend tests.
+  """
+  @spec crash_after_reserve_a() :: Noun.t()
+  def crash_after_reserve_a() do
+    reservations = [[1 | a_int()] | 0]
+    # Invalid Nock [0 | [0 | 0]] for the writes stage causes a crash
+    [[0 | 3] | [reservations | [0 | [0 | 0]]]]
+  end
+
+  @doc """
+  I test a Nock program for writing 3 to "a".
+
+  I verify stage 1 (reservation/code split) and stage 2 (execution).
+  """
+  @spec test_nock_program_tx1() :: :ok
+  def test_nock_program_tx1() do
+    # Setup
+    dummy_tx_id = "test_tx_id_1"
+    tx_code = write_code_gen(a_int(), 3)
+    expected_reservations = [[1 | a_int()] | 0]
+    expected_writes = [[a_int() | 3] | 0]
+
+    # Stage 1: Execute the core using the backend's formula to extract reservations
+    {:ok, stage1_result} = Nock.nock(tx_code, [9, 2, 0 | 1], %Nock{})
+
+    # Extract components from stage 1 result
+    [reservations | stage2_code] = stage1_result
+    assert reservations == expected_reservations
+
+    # Stage 2: Execute using the exact sequence from Backends.vm_execute_stage2
+    env_tx1 = %Nock{}
+
+    # Step 1: Apply formula [10, [6, 1 | id], 0 | 1] - this inserts the tx_id into the code
+    {:ok, ordered_tx1} =
+      Nock.nock(stage2_code, [10, [6, 1 | dummy_tx_id], 0 | 1], env_tx1)
+
+    # Step 2: Apply formula [9, 2, 0 | 1] - this executes the transaction
+    {:ok, result1} = Nock.nock(ordered_tx1, [9, 2, 0 | 1], env_tx1)
+
+    # This is the expected format that backends.ex receives from vm_execute_stage2
+    assert result1 == expected_writes
+
+    :ok
+  end
+
+  @doc """
+  I test a Nock program for the sequence (read a, read b, add a and b, write result to c).
+
+  I verify stage 1 (reservation/code split) and stage 2 (execution with mock scry).
+  """
+  @spec test_nock_program_tx3() :: :ok
+  def test_nock_program_tx3() do
+    # Setup
+    dummy_tx_id = "test_tx_id_3"
+    tx_code = read_ab_write_c_sum()
+    expected_reservations = abc_list()
+    expected_writes = [[c_int() | 7] | 0]
+
+    # Stage 1: Execute the core using the backend's formula
+    {:ok, [reservations | stage2_code]} =
+      Nock.nock(tx_code, [9, 2, 0 | 1], %Nock{})
+
+    # Extract the components
+    assert reservations == expected_reservations
+
+    # Create a mock scry function that simulates reading values from storage
+    a_val = a_int()
+    b_val = b_int()
+
+    mock_scry_tx3 = fn
+      ^a_val -> {:ok, 3}
+      ^b_val -> {:ok, 4}
+      _ -> :error
+    end
+
+    env_tx3 = %Nock{scry_function: mock_scry_tx3}
+
+    # Stage 2: Execute using the exact sequence from Backends.vm_execute_stage2
+    # Step 1: Apply formula [10, [6, 1 | id], 0 | 1] - inserts tx_id
+    {:ok, ordered_tx3} =
+      Nock.nock(stage2_code, [10, [6, 1 | dummy_tx_id], 0 | 1], env_tx3)
+
+    # Step 2: Apply formula [9, 2, 0 | 1] - executes transaction
+    {:ok, result3} = Nock.nock(ordered_tx3, [9, 2, 0 | 1], env_tx3)
+
+    # Expected sum and result format
+    assert result3 == expected_writes
+
+    :ok
+  end
 end

--- a/apps/anoma_lib/lib/tables.ex
+++ b/apps/anoma_lib/lib/tables.ex
@@ -24,7 +24,9 @@ defmodule Anoma.Node.Tables do
     {Blocks, [:round, :block]},
     {Values, [:key, :value]},
     {Updates, [:key, :value]},
-    {Intents, [:type, :body]}
+    {Intents, [:type, :body]},
+    {ShardKeyMap, [:key, :value]},
+    {ShardBackups, [:shard_id_key_height, :value]}
   ]
 
   @doc """
@@ -74,6 +76,22 @@ defmodule Anoma.Node.Tables do
   @spec table_updates(String.t()) :: atom()
   def table_updates(node_id) do
     node_table_name(node_id, Values)
+  end
+
+  @doc """
+  I return the table name for the given node its shard key map.
+  """
+  @spec table_shard_key_map(String.t()) :: atom()
+  def table_shard_key_map(node_id) do
+    node_table_name(node_id, ShardKeyMap)
+  end
+
+  @doc """
+  I return the table name for the given node its shard backups.
+  """
+  @spec table_shard_backups(String.t()) :: atom()
+  def table_shard_backups(node_id) do
+    node_table_name(node_id, ShardBackups)
   end
 
   @doc """

--- a/apps/anoma_node/lib/examples/e_node.ex
+++ b/apps/anoma_node/lib/examples/e_node.ex
@@ -75,7 +75,8 @@ defmodule Anoma.Node.Examples.ENode do
     opts =
       Keyword.validate!(opts,
         node_id: "#{:erlang.phash2(make_ref())}",
-        grpc_port: 0
+        grpc_port: 0,
+        transaction: []
       )
 
     enode =

--- a/apps/anoma_node/lib/examples/e_shard.ex
+++ b/apps/anoma_node/lib/examples/e_shard.ex
@@ -1,0 +1,952 @@
+defmodule Anoma.Node.Examples.EShard do
+  @moduledoc """
+  I contain examples on how to interact with the Shard module.
+  """
+
+  alias Anoma.Node.Registry
+  alias Anoma.Node.Transaction.Shard
+  alias Anoma.Node.Examples.ENode
+
+  import ExUnit.Assertions
+
+  @doc """
+  I start a node with shards "a", "b", "c", initializing "a" and "c"
+  with specific values, and verify the initial state.
+  """
+  @spec spawn_node_with_initial_state() :: {:ok, ENode.t()}
+  def spawn_node_with_initial_state() do
+    # Generate a unique node_id for test isolation
+    unique_suffix = System.unique_integer([:positive, :monotonic])
+    node_id = "shard_test_node_#{unique_suffix}"
+
+    # Define the schema: keys "a", "b", "c". "a" and "c" have initial values.
+    schema = [{"a", 5}, "b", {"c", 15}]
+    shard_config = [strategy: :one_per_key, schema: schema]
+    opts = [node_id: node_id, transaction: [shards: shard_config]]
+
+    # Start the node
+    enode = ENode.start_node(opts)
+    assert %ENode{node_id: ^node_id} = enode
+
+    # Get shard PIDs
+    pid_a = Registry.whereis(node_id, Shard, :a)
+    pid_b = Registry.whereis(node_id, Shard, :b)
+    pid_c = Registry.whereis(node_id, Shard, :c)
+
+    assert is_pid(pid_a), "Shard 'a' PID not found."
+    assert is_pid(pid_b), "Shard 'b' PID not found."
+    assert is_pid(pid_c), "Shard 'c' PID not found."
+
+    # Get initial states
+    state_a = Shard.debug_get_state(pid_a)
+    state_b = Shard.debug_get_state(pid_b)
+    state_c = Shard.debug_get_state(pid_c)
+
+    # Verify initial states at height 0
+    assert Map.get(state_a.kv, "a", %{})[0].value == 5,
+           "Shard 'a' initial value mismatch at height 0"
+
+    assert Map.get(state_c.kv, "c", %{})[0].value == 15,
+           "Shard 'c' initial value mismatch at height 0"
+
+    # Shard "b" should have no entry for key "b" at height 0
+    b_key_map = Map.get(state_b.kv, "b", %{})
+
+    refute Map.has_key?(b_key_map, 0),
+           "Shard 'b' should not have an initial value at height 0"
+
+    {:ok, enode}
+  end
+
+  @doc """
+  I start a Shard with a predefined initial state and verify that
+  reading the initial state (at height 1) returns the correct values.
+  """
+  @spec start_and_initial_state() :: {:ok, ENode.t()}
+  def start_and_initial_state() do
+    {:ok, enode} = spawn_node_with_initial_state()
+    %ENode{node_id: node_id} = enode
+
+    shard_a_via = Registry.via(node_id, Shard, :a)
+    shard_b_via = Registry.via(node_id, Shard, :b)
+    shard_c_via = Registry.via(node_id, Shard, :c)
+
+    # --- Simulate Watermark Advancement prior to acquiring reservations ---
+    Shard.advance_write_watermark(shard_c_via, "c", 5)
+
+    # --- Acquire Reservations First ---
+    assert :ok == Shard.reserve(shard_a_via, "a", 1, :read)
+    assert :ok == Shard.reserve(shard_b_via, "b", 5, :read)
+    assert :ok == Shard.reserve(shard_c_via, "c", 4, :read)
+
+    # --- Simulate Watermark Advancement after acquiring reservations ---
+    Shard.advance_write_watermark(shard_a_via, "a", 1)
+    Shard.advance_write_watermark(shard_b_via, "b", 10)
+
+    # --- Test Reads (Now that watermarks allow immediate resolution) ---
+
+    # Test key "a"
+    assert Shard.read(shard_a_via, "a", 1) == {:ok, 5}
+
+    # Test key "b"
+    assert Shard.read(shard_b_via, "b", 5) == :absent
+
+    # Test key "c"
+    assert Shard.read(shard_c_via, "c", 4) == {:ok, 15}
+
+    {:ok, enode}
+  end
+
+  @doc """
+  I test a scenario where a read is requested before the watermark allows,
+  then the watermark advances, and the read completes.
+  """
+  @spec queued_read() :: {:ok, ENode.t()}
+  def queued_read() do
+    {:ok, enode} = spawn_node_with_initial_state()
+    %ENode{node_id: node_id} = enode
+
+    shard_via = Registry.via(node_id, Shard, :a)
+
+    key = "a"
+    height = 7
+
+    # 1. Acquire Reservation
+    assert :ok == Shard.reserve(shard_via, key, height, :read)
+
+    # 2. Start the read in a separate task (it will block)
+    read_task =
+      Task.async(fn ->
+        Shard.read(shard_via, key, height)
+      end)
+
+    # 2.5 Verify the read task is initially blocked
+    assert Task.yield(read_task, 100) == nil,
+           "Read task should be blocked before watermark advances"
+
+    # 3. Advance the watermark *after* the read call is blocked
+    Shard.advance_write_watermark(shard_via, key, height + 1)
+
+    # 4. Wait for the result from the task (should unblock now)
+    result = Task.await(read_task, 1000)
+
+    # 5. Assert the result
+    assert result == {:ok, 5}
+
+    {:ok, enode}
+  end
+
+  @doc """
+  I test a variation of queued read where a write reservation is acquired and
+  a write is performed *after* the read is queued but *before* the read resolves,
+  affecting the read's outcome.
+  """
+  @spec queued_read_with_intermediate_write() :: {:ok, ENode.t()}
+  def queued_read_with_intermediate_write() do
+    {:ok, enode} = spawn_node_with_initial_state()
+    %ENode{node_id: node_id} = enode
+
+    shard_via = Registry.via(node_id, Shard, :a)
+
+    key = "a"
+    read_height = 7
+    # Height for the intermediate write
+    write_height = 5
+    # Value for the intermediate write
+    write_value = 10
+
+    # 1. Acquire Read Reservation for the future read
+    assert :ok == Shard.reserve(shard_via, key, read_height, :read)
+
+    # 2. Start the read in a separate task (it will block)
+    read_task =
+      Task.async(fn ->
+        Shard.read(shard_via, key, read_height)
+      end)
+
+    # 2.5 Verify the read task is initially blocked
+    assert Task.yield(read_task, 100) == nil,
+           "Read task should be blocked initially"
+
+    # 3. Acquire Write Reservation for an intermediate height BEFORE watermark advances
+    assert :ok == Shard.reserve(shard_via, key, write_height, :write)
+
+    # 4. Advance the watermark AFTER the read call is blocked, enabling read resolution
+    # WM >= read_height
+    Shard.advance_write_watermark(shard_via, key, read_height + 1)
+
+    # 5. Perform the Write AFTER watermark advanced but potentially before read task resumes
+    # This write should be visible to the resolving read at height 7.
+    assert :ok ==
+             Shard.write(
+               shard_via,
+               key,
+               write_value,
+               write_height
+             )
+
+    # 6. Await the result from the read task (should unblock due to WM)
+    result = Task.await(read_task, 1000)
+
+    # 7. Assert the result
+    # The read at height 7 should resolve to the latest write strictly below 7.
+    # The write at height 5 (value 10) occurred before the read resolved.
+    # The initial value at 0 is 5.
+    # Therefore, the latest write < 7 is the one at height 5.
+    assert result == {:ok, write_value}
+
+    {:ok, enode}
+  end
+
+  @doc """
+  I test a scenario where a read is requested, but the watermark never
+  advances, causing the read to time out.
+  """
+  @spec read_timeout() :: {:ok, ENode.t()}
+  def read_timeout() do
+    {:ok, enode} = spawn_node_with_initial_state()
+    %ENode{node_id: node_id} = enode
+
+    shard_via = Registry.via(node_id, Shard, :a)
+
+    key = "a"
+    height = 5
+
+    # 1. Acquire Reservation
+    assert :ok == Shard.reserve(shard_via, key, height, :read)
+
+    # 2. Start the read in a separate task (it will block)
+    read_task =
+      Task.async(fn ->
+        # Note: The GenServer.call within Shard.read uses :infinity,
+        # so this task itself won't timeout internally. The timeout
+        # comes from Task.await below.
+        Shard.read(shard_via, key, height)
+      end)
+
+    # 2.5 Verify the read task is initially blocked
+    assert Task.yield(read_task, 100) == nil,
+           "Read task should be blocked before trying to await with timeout"
+
+    # 3. DO NOT advance the watermark
+
+    # 4. Await the result with a short timeout
+    # We expect this to exit with reason :timeout
+    try do
+      Task.await(read_task, 100)
+      # If await succeeds, the test fails
+      flunk("Task.await should have timed out and exited, but it returned.")
+    catch
+      :exit, reason ->
+        assert reason == :timeout or match?({:timeout, _}, reason)
+    end
+
+    if Process.alive?(read_task.pid),
+      do: Task.shutdown(read_task, :brutal_kill)
+
+    {:ok, enode}
+  end
+
+  @doc """
+  I test a scenario with two pending reads at different heights.
+  An intermediate watermark advance unblocks only the lower-height read,
+  while the higher-height read eventually times out.
+  """
+  @spec partial_read_unblocking_with_timeout() :: {:ok, ENode.t()}
+  def partial_read_unblocking_with_timeout() do
+    {:ok, enode} = spawn_node_with_initial_state()
+    %ENode{node_id: node_id} = enode
+
+    shard_via = Registry.via(node_id, Shard, :a)
+
+    key = "a"
+
+    read_height_ok = 5
+    read_height_timeout = 15
+    watermark_height = 10
+
+    # 1. Acquire Reservations
+    assert :ok == Shard.reserve(shard_via, key, read_height_ok, :read)
+
+    assert :ok == Shard.reserve(shard_via, key, read_height_timeout, :read)
+
+    # 2. Start Read Tasks (both will block initially)
+    read_task_ok =
+      Task.async(fn ->
+        Shard.read(shard_via, key, read_height_ok)
+      end)
+
+    read_task_timeout =
+      Task.async(fn ->
+        Shard.read(shard_via, key, read_height_timeout)
+      end)
+
+    # 2.5 Verify both tasks are initially blocked
+    assert Task.yield(read_task_ok, 100) == nil,
+           "Read task (ok) should be blocked initially"
+
+    assert Task.yield(read_task_timeout, 100) == nil,
+           "Read task (timeout) should be blocked initially"
+
+    # 3. Advance Watermark partially (enough for height 5, not for 15)
+    Shard.advance_write_watermark(shard_via, key, watermark_height)
+
+    # 4. Await the read that should succeed
+    result_ok = Task.await(read_task_ok, 1000)
+
+    # Read at height 5 resolves based on latest write < 5, which is initial value 5 at height 0
+    assert result_ok == {:ok, 5}
+
+    # 5. Await the read that should time out
+    try do
+      Task.await(read_task_timeout, 100)
+
+      flunk(
+        "Task for height #{read_height_timeout} should have timed out, but it returned."
+      )
+    catch
+      :exit, reason ->
+        assert reason == :timeout or match?({:timeout, _}, reason)
+    end
+
+    if Process.alive?(read_task_timeout.pid),
+      do: Task.shutdown(read_task_timeout, :brutal_kill)
+
+    {:ok, enode}
+  end
+
+  @doc """
+  I test a more complex scenario involving multiple writes, reads, and
+  write watermark advancements.
+  """
+  @spec complex_write_and_read_scenario() :: {:ok, ENode.t()}
+  def complex_write_and_read_scenario() do
+    {:ok, enode} = spawn_node_with_initial_state()
+    %ENode{node_id: node_id} = enode
+
+    shard_via = Registry.via(node_id, Shard, :a)
+
+    key = "a"
+
+    # --- Acquire Write Reservations ---
+    assert :ok == Shard.reserve(shard_via, key, 5, :write)
+    assert :ok == Shard.reserve(shard_via, key, 6, :write)
+    assert :ok == Shard.reserve(shard_via, key, 10, :write)
+
+    # --- Acquire Read Reservations ---
+    assert :ok == Shard.reserve(shard_via, key, 1, :read)
+    assert :ok == Shard.reserve(shard_via, key, 4, :read)
+    assert :ok == Shard.reserve(shard_via, key, 5, :read)
+    assert :ok == Shard.reserve(shard_via, key, 6, :read)
+    assert :ok == Shard.reserve(shard_via, key, 7, :read)
+    assert :ok == Shard.reserve(shard_via, key, 9, :read)
+    assert :ok == Shard.reserve(shard_via, key, 10, :read)
+    assert :ok == Shard.reserve(shard_via, key, 11, :read)
+
+    # --- Perform Writes ---
+    assert :ok == Shard.write(shard_via, key, 7, 5)
+    assert :ok == Shard.write(shard_via, key, 2, 6)
+    assert :ok == Shard.write(shard_via, key, 8, 10)
+
+    # --- Simulate Watermark Advancements ---
+    # Reads 1, 4, 5 depend on initial state (implied WM >= 1)
+    Shard.advance_write_watermark(shard_via, key, 1)
+
+    # Read 6 needs to see write at 5
+    Shard.advance_write_watermark(shard_via, key, 6)
+
+    # Reads 7, 9, 10 need to see write at 6
+    Shard.advance_write_watermark(shard_via, key, 7)
+
+    # Read 11 needs to see write at 10
+    Shard.advance_write_watermark(shard_via, key, 11)
+
+    # --- Test Reads ---
+    # Read height h resolves based on latest write < h, provided WM >= h
+    # Before any writes. Initial value is 5
+    assert Shard.read(shard_via, key, 1) == {:ok, 5}
+    # Before write@5
+    assert Shard.read(shard_via, key, 4) == {:ok, 5}
+    # Before write@5
+    assert Shard.read(shard_via, key, 5) == {:ok, 5}
+    # Sees write@5 (value 7)
+    assert Shard.read(shard_via, key, 6) == {:ok, 7}
+    # Sees write@6
+    assert Shard.read(shard_via, key, 7) == {:ok, 2}
+    # Sees write@6
+    assert Shard.read(shard_via, key, 9) == {:ok, 2}
+    # Sees write@6
+    assert Shard.read(shard_via, key, 10) == {:ok, 2}
+    # Sees write@10
+    assert Shard.read(shard_via, key, 11) == {:ok, 8}
+
+    {:ok, enode}
+  end
+
+  @doc """
+  I test the internal state changes related to Garbage Collection (GC)
+  and the state of entries after reservations are released.
+  """
+  @spec gc_and_reserve_release_state() :: {:ok, ENode.t()}
+  def gc_and_reserve_release_state() do
+    {:ok, enode} = spawn_node_with_initial_state()
+    %ENode{node_id: node_id} = enode
+
+    shard_via = Registry.via(node_id, Shard, :a)
+
+    key = "a"
+
+    # --- Writes ---
+    write_ops = %{
+      9 => 5,
+      15 => 12,
+      30 => 16,
+      32 => 8
+    }
+
+    Enum.each(write_ops, fn {h, v} ->
+      assert :ok == Shard.reserve(shard_via, key, h, :write)
+      assert :ok == Shard.write(shard_via, key, v, h)
+    end)
+
+    # --- Direct State Check (Post-Write) ---
+    state1 = Shard.debug_get_state(shard_via)
+    kv1 = Map.get(state1.kv, key, %{})
+
+    assert Map.get(kv1, 0).value == 5
+    assert !Map.get(kv1, 0).write_reserved?
+
+    assert Map.get(kv1, 9).value == 5 and !Map.get(kv1, 9).write_reserved?
+    assert Map.get(kv1, 15).value == 12 and !Map.get(kv1, 15).write_reserved?
+    assert Map.get(kv1, 30).value == 16 and !Map.get(kv1, 30).write_reserved?
+    assert Map.get(kv1, 32).value == 8 and !Map.get(kv1, 32).write_reserved?
+
+    # 0, 9, 15, 30, 32
+    assert map_size(kv1) == 5
+
+    # --- Read Reservation ---
+    assert :ok == Shard.reserve(shard_via, key, 17, :read)
+
+    # Verify reservation presence in state
+    state2 = Shard.debug_get_state(shard_via)
+    kv2 = Map.get(state2.kv, key, %{})
+    assert Map.has_key?(kv2, 17)
+    assert kv2[17].read_reserved_count > 0
+    assert is_nil(kv2[17].value)
+    assert !kv2[17].write_reserved?
+    # Added entry for height 17
+    assert map_size(kv2) == 6
+
+    # --- Advance Read Watermark (GC Trigger) ---
+    Shard.advance_read_watermark(shard_via, key, 33)
+
+    # --- Direct State Check (Post-GC) ---
+    state3 = Shard.debug_get_state(shard_via)
+    kv3 = Map.get(state3.kv, key, %{})
+
+    # Expected remaining heights:
+    # - 15: Kept because it's needed for read reservation at 17 (max_h < 17)
+    # - 17: Kept because it holds the active read reservation.
+    # - 32: Kept because it's the latest entry <= the watermark 33.
+    assert Map.has_key?(kv3, 15)
+    # Check value consistency
+    assert Map.get(kv3, 15).value == 12
+    assert Map.has_key?(kv3, 17)
+    # Reservation still held
+    assert kv3[17].read_reserved_count > 0
+    assert Map.has_key?(kv3, 32)
+    # Check value consistency
+    assert Map.get(kv3, 32).value == 8
+    assert map_size(kv3) == 3
+    # Ensure others are gone
+    refute Map.has_key?(kv3, 0)
+    refute Map.has_key?(kv3, 9)
+    refute Map.has_key?(kv3, 30)
+
+    # --- Read Operation (at 17) ---
+    # Advance WRITE watermark so read can resolve
+    Shard.advance_write_watermark(shard_via, key, 18)
+    # Perform the read
+    assert Shard.read(shard_via, key, 17) == {:ok, 12}
+
+    # --- Direct State Check (Post-Read) ---
+    state4 = Shard.debug_get_state(shard_via)
+    kv4 = Map.get(state4.kv, key, %{})
+    # Entry should still exist
+    assert Map.has_key?(kv4, 17)
+    # Reservation should be released
+    assert kv4[17].read_reserved_count == 0
+    assert is_nil(kv4[17].value)
+    assert !kv4[17].write_reserved?
+    # Size remains same, just reservation released
+    assert map_size(kv4) == 3
+
+    # --- Advance Read Watermark Again (Clean up entry 17) ---
+    Shard.advance_read_watermark(shard_via, key, 34)
+
+    # --- Direct State Check (Final) ---
+    state5 = Shard.debug_get_state(shard_via)
+    kv5 = Map.get(state5.kv, key, %{})
+
+    # Expected remaining heights:
+    # - 32: Kept because it's the latest entry <= the new watermark 34.
+    # Entries 15 and 17 should now be GC'd.
+    assert Map.has_key?(kv5, 32)
+    assert Map.get(kv5, 32).value == 8
+    assert map_size(kv5) == 1
+    # Ensure others are gone
+    refute Map.has_key?(kv5, 15)
+    refute Map.has_key?(kv5, 17)
+
+    {:ok, enode}
+  end
+
+  @doc """
+  I test various scenarios of reservation acquisition failures due to watermarks,
+  existing values, and successful re-acquisition of existing reservations.
+  """
+  @spec reserve_failures_and_reacquisition() :: {:ok, ENode.t()}
+  def reserve_failures_and_reacquisition() do
+    {:ok, enode} = spawn_node_with_initial_state()
+    %ENode{node_id: node_id} = enode
+
+    shard_via = Registry.via(node_id, Shard, :a)
+
+    key = "a"
+
+    # --- Setup Watermarks ---
+    Shard.advance_read_watermark(shard_via, key, 10)
+    Shard.advance_write_watermark(shard_via, key, 10)
+
+    # --- Test Reserving Below Watermarks (Height 5) ---
+    assert Shard.reserve(shard_via, key, 5, :read) ==
+             {:error, :reserving_read_under_read_watermark}
+
+    assert Shard.reserve(shard_via, key, 5, :write) ==
+             {:error, :reserving_write_under_write_watermark}
+
+    # Write check happens first for :read_write
+    assert Shard.reserve(shard_via, key, 5, :read_write) ==
+             {:error, :reserving_write_under_write_watermark}
+
+    # --- Test Reservation Re-acquisition (Height 15) ---
+    # Sequence: read -> read -> write -> write -> read
+
+    # 1st Read
+    assert :ok == Shard.reserve(shard_via, key, 15, :read)
+
+    # 2nd Read (should be ok, idempotent)
+    assert :ok == Shard.reserve(shard_via, key, 15, :read)
+
+    # 1st Write (acquire alongside read)
+    assert :ok == Shard.reserve(shard_via, key, 15, :write)
+
+    # 2nd Write (should be ok, idempotent)
+    assert :ok == Shard.reserve(shard_via, key, 15, :write)
+
+    # 3rd Read (should be ok, idempotent)
+    assert :ok == Shard.reserve(shard_via, key, 15, :read)
+
+    # Check state: both read and write should be reserved
+    state_after_reacquire = Shard.debug_get_state(shard_via)
+    kv_after_reacquire = Map.get(state_after_reacquire.kv, key, %{})
+    assert Map.has_key?(kv_after_reacquire, 15)
+    assert kv_after_reacquire[15].read_reserved_count > 0
+    assert kv_after_reacquire[15].write_reserved?
+
+    # --- Test Write Blocking Reservation Acquisition (Height 20) ---
+    # First, reserve and write a value to height 20
+    assert :ok == Shard.reserve(shard_via, key, 20, :write)
+
+    assert :ok == Shard.write(shard_via, key, "value_at_20", 20)
+
+    # Sequence: write -> write -> read -> read -> write
+
+    # 1st Write (should fail due to existing value)
+    assert Shard.reserve(shard_via, key, 20, :write) ==
+             {:error, :slot_occupied_by_value}
+
+    # 2nd Write (should fail)
+    assert Shard.reserve(shard_via, key, 20, :write) ==
+             {:error, :slot_occupied_by_value}
+
+    # 1st Read (should succeed even with value)
+    assert :ok == Shard.reserve(shard_via, key, 20, :read)
+
+    # 2nd Read (should succeed, idempotent)
+    assert :ok == Shard.reserve(shard_via, key, 20, :read)
+
+    # 3rd Write (should fail)
+    assert Shard.reserve(shard_via, key, 20, :write) ==
+             {:error, :slot_occupied_by_value}
+
+    # Check state: read should be reserved, write should not
+    state_after_blocking = Shard.debug_get_state(shard_via)
+    kv_after_blocking = Map.get(state_after_blocking.kv, key, %{})
+    assert Map.has_key?(kv_after_blocking, 20)
+    assert kv_after_blocking[20].read_reserved_count > 0
+    assert !kv_after_blocking[20].write_reserved?
+
+    {:ok, enode}
+  end
+
+  @doc """
+  I test that a read can resolve successfully even if an older write reservation
+  (at a height lower than the height of the value the read depends on)
+  is still held. This verifies a fix for overly broad write reservation blocking.
+  """
+  @spec read_past_old_write_reserve() :: {:ok, ENode.t()}
+  def read_past_old_write_reserve() do
+    {:ok, enode} = spawn_node_with_initial_state()
+    %ENode{node_id: node_id} = enode
+
+    shard_via = Registry.via(node_id, Shard, :a)
+
+    key = "a"
+
+    h_reserve = 5
+    h_write = 7
+    write_value = 10
+    h_read = 9
+
+    # 1. Acquire write reservation at h_reserve (and HOLD it)
+    assert :ok == Shard.reserve(shard_via, key, h_reserve, :write)
+
+    # 2. Write successfully at h_write
+    assert :ok == Shard.reserve(shard_via, key, h_write, :write)
+    assert :ok == Shard.write(shard_via, key, write_value, h_write)
+
+    # 3. Acquire read reservation at h_read
+    assert :ok == Shard.reserve(shard_via, key, h_read, :read)
+
+    # 4. Advance write watermark to allow the read at h_read
+    # WM >= 9
+    Shard.advance_write_watermark(shard_via, key, h_read + 1)
+
+    # 5. Perform the read at h_read
+    result = Shard.read(shard_via, key, h_read)
+
+    # 6. Assert: Read at 9 should resolve to value written at 7,
+    #    despite the older write reservation still held at 5.
+    assert result == {:ok, write_value}
+
+    # 7. Verify the reservation at h_reserve is still held (for sanity)
+    state = Shard.debug_get_state(shard_via)
+    kv_state = Map.get(state.kv, key, %{})
+    assert Map.has_key?(kv_state, h_reserve)
+    assert kv_state[h_reserve].write_reserved?
+
+    {:ok, enode}
+  end
+
+  @doc """
+  I test writing to an initially empty shard, advancing the write watermark,
+  and then performing reads both below and above the write height.
+  """
+  @spec write_then_reads_empty_start() :: {:ok, ENode.t()}
+  def write_then_reads_empty_start() do
+    {:ok, enode} = spawn_node_with_initial_state()
+    %ENode{node_id: node_id} = enode
+
+    shard_via = Registry.via(node_id, Shard, :b)
+
+    key = "b"
+    write_height = 10
+    write_value = 5
+    wm_height = 20
+    read_height_absent = 5
+    read_height_ok = 15
+
+    # 1. Reserve and write value at write_height
+    assert :ok == Shard.reserve(shard_via, key, write_height, :write)
+    assert :ok == Shard.write(shard_via, key, write_value, write_height)
+
+    # 2. Advance write watermark past the write and reads
+    Shard.advance_write_watermark(shard_via, key, wm_height)
+
+    # 3. Read at height_absent (should be absent as latest < 5 is nothing)
+    assert :ok == Shard.reserve(shard_via, key, read_height_absent, :read)
+    assert Shard.read(shard_via, key, read_height_absent) == :absent
+
+    # 4. Read at height_ok (should see write_value as latest < 15 is at 10)
+    assert :ok == Shard.reserve(shard_via, key, read_height_ok, :read)
+    assert Shard.read(shard_via, key, read_height_ok) == {:ok, write_value}
+
+    {:ok, enode}
+  end
+
+  @doc """
+  I test the unreserve function by creating read reservations for key "a" and write reservations
+  for key "b" at multiple heights, then unreserving at a specific height and verifying that only
+  those reservations are released.
+  """
+  @spec unreserve() :: {:ok, ENode.t()}
+  def unreserve() do
+    {:ok, enode} = spawn_node_with_initial_state()
+    %ENode{node_id: node_id} = enode
+
+    shard_a_via = Registry.via(node_id, Shard, :a)
+    shard_b_via = Registry.via(node_id, Shard, :b)
+
+    # Create read reservations for key "a" at heights 1, 2, 3, 4, 5
+    Enum.each(1..5, fn height ->
+      assert :ok == Shard.reserve(shard_a_via, "a", height, :read)
+    end)
+
+    # Create write reservations for key "b" at heights 1, 2, 3, 4, 5
+    Enum.each(1..5, fn height ->
+      assert :ok == Shard.reserve(shard_b_via, "b", height, :write)
+    end)
+
+    # Verify that all reservations were made correctly
+    state_before_unreserve_a = Shard.debug_get_state(shard_a_via)
+    state_before_unreserve_b = Shard.debug_get_state(shard_b_via)
+
+    # Check "a" reservations (read)
+    a_heights = Map.get(state_before_unreserve_a.kv, "a", %{})
+
+    Enum.each(1..5, fn height ->
+      assert Map.has_key?(a_heights, height)
+      assert a_heights[height].read_reserved_count > 0
+      assert !a_heights[height].write_reserved?
+    end)
+
+    # Check "b" reservations (write)
+    b_heights = Map.get(state_before_unreserve_b.kv, "b", %{})
+
+    Enum.each(1..5, fn height ->
+      assert Map.has_key?(b_heights, height)
+      assert b_heights[height].read_reserved_count == 0
+      assert b_heights[height].write_reserved?
+    end)
+
+    # Unreserve at height 3
+    assert :ok == Shard.unreserve(shard_a_via, "a", 3, :read)
+    assert :ok == Shard.unreserve(shard_a_via, "a", 3, :write)
+    assert :ok == Shard.unreserve(shard_b_via, "b", 3, :read)
+    assert :ok == Shard.unreserve(shard_b_via, "b", 3, :write)
+
+    # Verify that only height 3 reservations were removed
+    state_after_unreserve_a = Shard.debug_get_state(shard_a_via)
+    state_after_unreserve_b = Shard.debug_get_state(shard_b_via)
+
+    # Check "a" reservations after unreserve
+    a_heights_after = Map.get(state_after_unreserve_a.kv, "a", %{})
+    assert Map.has_key?(a_heights_after, 3)
+    assert a_heights_after[3].read_reserved_count == 0
+
+    # Other heights should still have read_reserved_count > 0
+    Enum.each([1, 2, 4, 5], fn height ->
+      assert Map.has_key?(a_heights_after, height)
+      assert a_heights_after[height].read_reserved_count > 0
+    end)
+
+    # Check "b" reservations after unreserve
+    b_heights_after = Map.get(state_after_unreserve_b.kv, "b", %{})
+    # Height 3 should have write_reserved? = false
+    assert Map.has_key?(b_heights_after, 3)
+    assert !b_heights_after[3].write_reserved?
+
+    # Other heights should still have write_reserved? = true
+    Enum.each([1, 2, 4, 5], fn height ->
+      assert Map.has_key?(b_heights_after, height)
+      assert b_heights_after[height].write_reserved?
+    end)
+
+    {:ok, enode}
+  end
+
+  @doc """
+  I test that GC preserves the latest *committed* state below the read
+  watermark, even if a later read reservation was acquired and released.
+  """
+  @spec gc_preserves_committed_state_before_watermark() :: {:ok, ENode.t()}
+  def gc_preserves_committed_state_before_watermark() do
+    {:ok, enode} = spawn_node_with_initial_state()
+    %ENode{node_id: node_id} = enode
+
+    shard_via = Registry.via(node_id, Shard, :c)
+
+    key = "c"
+
+    # 1. Write a value at height 3
+    assert :ok == Shard.reserve(shard_via, key, 3, :write)
+    assert :ok == Shard.write(shard_via, key, 100, 3)
+
+    # 2. Reserve read at height 4
+    assert :ok == Shard.reserve(shard_via, key, 4, :read)
+
+    # 3. Release reservation at height 4 (e.g., tx rollback)
+    assert :ok == Shard.unreserve(shard_via, key, 4, :read)
+
+    # 4. Advance read watermark past height 3 and 4, triggering GC
+    Shard.advance_read_watermark(shard_via, key, 5)
+
+    # 5. Verify state
+    state = Shard.debug_get_state(shard_via)
+    key_height_map = Map.get(state.kv, key, %{})
+
+    # Check that the entry at height 3 (committed write) still exists
+    assert Map.has_key?(key_height_map, 3)
+
+    assert %{value: 100, read_reserved_count: 0, write_reserved?: false} ==
+             key_height_map[3],
+           "Committed state at height 3 should be preserved by GC"
+
+    # Check that the initial value at 0 is gone
+    refute Map.has_key?(key_height_map, 0),
+           "Initial state at height 0 should be GC'd"
+
+    # Check that the entry for height 4 (only reserved, then released) is gone
+    refute Map.has_key?(key_height_map, 4),
+           "State at height 4 should be GC'd"
+
+    {:ok, enode}
+  end
+
+  @doc """
+  I test that unreserving a write reservation triggers the check for pending reads,
+  allowing a previously blocked read (blocked by the reservation, not the watermark)
+  to complete.
+  """
+  @spec unreserve_triggers_pending_read() :: {:ok, ENode.t()}
+  def unreserve_triggers_pending_read() do
+    {:ok, enode} = spawn_node_with_initial_state()
+    %ENode{node_id: node_id} = enode
+
+    shard_via = Registry.via(node_id, Shard, :a)
+
+    # Initial state %{"a" => 5} handled by spawn_node_with_initial_state
+    key = "a"
+
+    h_write = 2
+    write_value = 100
+    h_blocking_reserve = 3
+    h_read = 4
+    wm_height = 5
+
+    # 1. Reserve and Write at h_write
+    assert :ok == Shard.reserve(shard_via, key, h_write, :write)
+    assert :ok == Shard.write(shard_via, key, write_value, h_write)
+
+    # 2. Reserve Write at h_blocking_reserve (will block the read)
+    assert :ok == Shard.reserve(shard_via, key, h_blocking_reserve, :write)
+
+    # 3. Reserve Read at h_read
+    assert :ok == Shard.reserve(shard_via, key, h_read, :read)
+
+    # 4. Start Read Task (will block due to h_blocking_reserve)
+    read_task =
+      Task.async(fn ->
+        Shard.read(shard_via, key, h_read)
+      end)
+
+    # 4.5 Verify the read task is initially blocked (before watermark advance)
+    assert Task.yield(read_task, 100) == nil,
+           "Read task should be blocked initially by reservation"
+
+    # 5. Advance Write Watermark (enough for h_read, but still blocked by reservation)
+    Shard.advance_write_watermark(shard_via, key, wm_height)
+
+    # 6. Verify Read is Still Blocked (yield returns nil if task hasn't finished)
+    assert Task.yield(read_task, 100) == nil,
+           "Read task should still be blocked by the write reservation at height #{h_blocking_reserve}"
+
+    # 7. Unreserve the Blocking Height
+    assert :ok == Shard.unreserve(shard_via, key, h_blocking_reserve, :write)
+
+    # 8. Await Read Result (should now complete)
+    result = Task.await(read_task, 1000)
+
+    # 9. Assert the result is the value from h_write
+    # Read at h_read(4) sees latest committed write < 4, which is at h_write(2)
+    assert result == {:ok, write_value},
+           "Read should have resolved to #{write_value} after unreserve"
+
+    {:ok, enode}
+  end
+
+  @doc """
+  I test the backup_state functionality by initializing a shard with specific
+  values, performing writes, backing up the state, and verifying the backup
+  contents in Mnesia.
+  """
+  @spec backup_state() :: {:ok, ENode.t()}
+  def backup_state() do
+    {:ok, enode} = spawn_node_with_initial_state()
+    %ENode{node_id: node_id} = enode
+
+    shard_a_via = Registry.via(node_id, Shard, :a)
+    shard_b_via = Registry.via(node_id, Shard, :b)
+
+    # --- Perform Writes ---
+    # Key "a" writes
+    assert :ok == Shard.reserve(shard_a_via, "a", 2, :write)
+    assert :ok == Shard.write(shard_a_via, "a", 1, 2)
+    assert :ok == Shard.reserve(shard_a_via, "a", 5, :write)
+    assert :ok == Shard.write(shard_a_via, "a", 2, 5)
+    assert :ok == Shard.reserve(shard_a_via, "a", 7, :write)
+    assert :ok == Shard.write(shard_a_via, "a", 3, 7)
+
+    # Key "b" writes (starts empty)
+    assert :ok == Shard.reserve(shard_b_via, "b", 5, :write)
+    assert :ok == Shard.write(shard_b_via, "b", 6, 5)
+    assert :ok == Shard.reserve(shard_b_via, "b", 6, :write)
+    assert :ok == Shard.write(shard_b_via, "b", 10, 6)
+
+    assert :ok == Shard.backup_state(shard_a_via)
+    assert :ok == Shard.backup_state(shard_b_via)
+
+    # Define the expected values in the backup table
+    expected_backed_up_values = %{
+      # Shard 'a' from node_id
+      {:a, "a", 0} => 5,
+      {:a, "a", 2} => 1,
+      {:a, "a", 5} => 2,
+      {:a, "a", 7} => 3,
+      # Shard 'b' from node_id
+      {:b, "b", 5} => 6,
+      {:b, "b", 6} => 10
+    }
+
+    # Get the backup table name
+    backup_table = Anoma.Node.Tables.table_shard_backups(node_id)
+
+    # Verify the Mnesia table contents within a transaction
+    {:atomic, read_results} =
+      :mnesia.transaction(fn ->
+        # Read all expected records
+        read_results =
+          Enum.map(expected_backed_up_values, fn {{shard_id, key, height},
+                                                  _value} ->
+            record_key = {shard_id, key, height}
+
+            {{shard_id, key, height},
+             :mnesia.read({backup_table, record_key})}
+          end)
+          |> Map.new()
+
+        read_results
+      end)
+
+    # Assert the expected records exist and have the correct details
+    Enum.each(expected_backed_up_values, fn {{shard_id, key, height},
+                                             expected_value} ->
+      lookup_key = {shard_id, key, height}
+
+      assert Map.has_key?(read_results, lookup_key),
+             "Result for shard #{shard_id} key '#{key}' height #{height} missing from backup"
+
+      read_result = read_results[lookup_key]
+
+      expected_record = [
+        {backup_table, {shard_id, key, height}, expected_value}
+      ]
+
+      assert read_result == expected_record,
+             "Mismatch for backup of shard #{shard_id} key '#{key}' height #{height}. Expected #{inspect(expected_record)}, got #{inspect(read_result)}"
+    end)
+
+    {:ok, enode}
+  end
+end

--- a/apps/anoma_node/lib/examples/e_shard_supervisor.ex
+++ b/apps/anoma_node/lib/examples/e_shard_supervisor.ex
@@ -1,0 +1,141 @@
+defmodule Anoma.Node.Examples.EShardSupervisor do
+  @moduledoc """
+  I contain examples demonstrating the ShardSupervisor functionality.
+  """
+
+  alias Anoma.Node.Examples.ENode
+  alias Anoma.Node.Registry
+  alias Anoma.Node.Transaction.Shard
+  alias Anoma.Node.Tables
+  alias Anoma.Node.Transaction.ShardSupervisor
+
+  import ExUnit.Assertions
+
+  @doc """
+  I test starting a node with a shard configuration, verifying that the
+  ShardSupervisor starts the correct Shard processes via async setup,
+  and that the router correctly maps keys to shard names.
+
+  I create a unique node ID on each call to avoid state collision.
+  I return the started `ENode` struct.
+  """
+  @spec shard_supervisor_startup_and_routing() :: ENode.t()
+  def shard_supervisor_startup_and_routing() do
+    # Generate unique node ID for isolation
+    node_id =
+      "shard_sup_node_" <>
+        (System.unique_integer([:positive]) |> Integer.to_string())
+
+    # 1. Define Schema and Start Node
+    schema = [{"a", 5}, "b", {"c", 7}]
+    shard_config = [strategy: :one_per_key, schema: schema]
+    opts = [node_id: node_id, transaction: [shards: shard_config]]
+
+    enode = ENode.start_node(opts)
+    assert %ENode{node_id: ^node_id} = enode
+
+    # 2. Verify Shard Processes Exist (now safe to check)
+    pid_shard_a = Registry.whereis(node_id, Shard, :a)
+    pid_shard_b = Registry.whereis(node_id, Shard, :b)
+    pid_shard_c = Registry.whereis(node_id, Shard, :c)
+
+    assert is_pid(pid_shard_a), "Shard 'a' should be registered and alive."
+    assert is_pid(pid_shard_b), "Shard 'b' should be registered and alive."
+    assert is_pid(pid_shard_c), "Shard 'c' should be registered and alive."
+
+    # 3. Verify Initial State within Shards (don't use stateful Shard.read)
+    state_a = Shard.debug_get_state(pid_shard_a)
+    state_b = Shard.debug_get_state(pid_shard_b)
+    state_c = Shard.debug_get_state(pid_shard_c)
+
+    # Check initial value at height 0
+    assert state_a.kv["a"][0].value == 5, "Shard 'a' initial value mismatch"
+    assert state_b.kv == %{}, "Shard 'b' should have an empty initial kv map"
+    assert state_c.kv["c"][0].value == 7, "Shard 'c' initial value mismatch"
+
+    # 4. Query the Mnesia table for key -> shard_label mapping
+    table_name = Tables.table_shard_key_map(node_id)
+
+    read_tx = fn key ->
+      :mnesia.transaction(fn ->
+        :mnesia.read({table_name, key})
+      end)
+    end
+
+    assert read_tx.("a") == {:atomic, [{table_name, "a", :a}]},
+           "Mnesia lookup for 'a' failed"
+
+    assert read_tx.("b") == {:atomic, [{table_name, "b", :b}]},
+           "Mnesia lookup for 'b' failed"
+
+    assert read_tx.("c") == {:atomic, [{table_name, "c", :c}]},
+           "Mnesia lookup for 'c' failed"
+
+    assert read_tx.("d") == {:atomic, []},
+           "Mnesia lookup for unknown key 'd' should return empty list"
+
+    enode
+  end
+
+  @doc """
+  I test dynamically adding new shards using `ShardSupervisor.start_shard/3`
+  after initial setup is complete.
+
+  I reuse the node started by `shard_supervisor_startup_and_routing/0`.
+  """
+  @spec dynamic_shard_start_test() :: ENode.t()
+  def dynamic_shard_start_test() do
+    # 1. Get a node with initial shards (a, b, c)
+    # shard_supervisor_startup_and_routing creates a unique node
+    enode = shard_supervisor_startup_and_routing()
+    # Use the unique node_id from the setup
+    node_id = enode.node_id
+
+    # 2. Dynamically start a new shard 'd' with an initial value
+    assert {:ok, pid_shard_d} = ShardSupervisor.start_shard(node_id, "d", 10)
+    assert is_pid(pid_shard_d)
+    assert pid_shard_d == Registry.whereis(node_id, Shard, :d)
+
+    # 3. Dynamically start a new shard 'e' without an initial value
+    assert {:ok, pid_shard_e} = ShardSupervisor.start_shard(node_id, "e")
+    assert is_pid(pid_shard_e)
+    assert pid_shard_e == Registry.whereis(node_id, Shard, :e)
+
+    # 4. Try to start an existing shard 'a' again (should fail)
+    # DynamicSupervisor returns {:error, {:already_started, pid}} if the child
+    # process with the same registered name is already running.
+    assert {:error, {:already_started, existing_pid_a}} =
+             ShardSupervisor.start_shard(node_id, "a", 99)
+
+    assert is_pid(existing_pid_a)
+    assert existing_pid_a == Registry.whereis(node_id, Shard, :a)
+
+    # 5. Verify initial state within new shards 'd' and 'e'
+    state_d = Shard.debug_get_state(pid_shard_d)
+    state_e = Shard.debug_get_state(pid_shard_e)
+
+    assert state_d.kv["d"][0].value == 10, "Shard 'd' initial value mismatch"
+    assert state_e.kv == %{}, "Shard 'e' should have an empty initial kv map"
+
+    # 6. Query the Mnesia table for new key mappings
+    table_name = Tables.table_shard_key_map(node_id)
+
+    read_tx = fn key ->
+      :mnesia.transaction(fn ->
+        :mnesia.read({table_name, key})
+      end)
+    end
+
+    # Verify 'a' IS in the map (from initial setup of this unique node)
+    assert read_tx.("a") == {:atomic, [{table_name, "a", :a}]},
+           "Mnesia lookup for 'a' failed"
+
+    assert read_tx.("d") == {:atomic, [{table_name, "d", :d}]},
+           "Mnesia lookup for 'd' failed"
+
+    assert read_tx.("e") == {:atomic, [{table_name, "e", :e}]},
+           "Mnesia lookup for 'e' failed"
+
+    enode
+  end
+end

--- a/apps/anoma_node/lib/node/supervisor.ex
+++ b/apps/anoma_node/lib/node/supervisor.ex
@@ -11,6 +11,7 @@ defmodule Anoma.Node.Supervisor do
   alias Anoma.Node.Logging
   alias Anoma.Node.Transaction
   alias Anoma.Node.Transport
+  alias Anoma.Node.Transaction.ShardSupervisor
 
   @typedoc """
   The type of the arguments that the supervisor expects.
@@ -19,7 +20,10 @@ defmodule Anoma.Node.Supervisor do
           node_id: String.t(),
           grpc_port: non_neg_integer(),
           replay: boolean(),
-          transaction: [mempool: any()]
+          transaction: [
+            mempool: any(),
+            shards: ShardSupervisor.supervisor_args_t() | nil
+          ]
         ]
 
   @doc """
@@ -29,7 +33,7 @@ defmodule Anoma.Node.Supervisor do
     :node_id,
     grpc_port: 0,
     replay: true,
-    transaction: [mempool: []]
+    transaction: [mempool: [], shards: nil]
   ]
 
   @spec child_spec(any()) :: map()

--- a/apps/anoma_node/lib/node/transaction/shard.ex
+++ b/apps/anoma_node/lib/node/transaction/shard.ex
@@ -1,0 +1,925 @@
+defmodule Anoma.Node.Transaction.Shard do
+  @moduledoc """
+  I am the Shard module.
+
+  I manage a partition of the distributed key-value store, handling requests
+  for reserving slots, reading, and writing specific keys at specific heights.
+  I maintain versioned state
+  for read resolution and garbage collection based on dual watermarks.
+
+  ### Public API
+
+  I provide the following public functionality:
+
+  - `start_link/1`
+  - `reserve/4`
+  - `read/3`
+  - `write/4`
+  - `unreserve/4`
+  - `backup_state/1`
+  - `advance_read_watermark/3`
+  - `advance_write_watermark/3`
+  - `debug_get_state/1`
+
+  ### Key Concepts
+
+  - **Height:** A transaction-specific identifier used for versioning.
+  - **KV State:** A map storing key -> height -> entry_details.
+  - **Reservations:** Independent read and write reservations associated with a `{key, height}`.
+  - **Watermarks:** Per-key dual watermarks (`:read`, `:write`) control GC and read resolution respectively.
+  - **Synchronous Reads:** Read requests (`read/3`) block the caller until resolved. Resolution may be delayed internally if blocked by watermarks or preceding write reservations. Read completion releases the specific read reservation.
+  """
+
+  alias Anoma.Node.Registry
+
+  require Logger
+
+  use GenServer
+  use TypedStruct
+
+  @default_kv_entry_details %{
+    value: nil,
+    read_reserved_count: 0,
+    write_reserved?: false
+  }
+  @initial_watermarks %{read: 0, write: 0}
+
+  ############################################################
+  #                       Types                              #
+  ############################################################
+
+  @typedoc "The key in the key-value store."
+  @type key :: binary()
+
+  @typedoc "The height associated with an operation."
+  # Allows 0 for initial state
+  @type height :: integer()
+
+  @typedoc "The value stored for a key at a height."
+  @type value :: any()
+
+  @typedoc "The capabilities requested or held by a reservation."
+  @type capabilities :: :read | :write | :read_write
+
+  @typedoc "Stores the details for a specific {key, height}."
+  @type kv_entry_details :: %{
+          # The actual value, nil if not written yet
+          value: value() | nil,
+          # Count of active read reservations
+          read_reserved_count: non_neg_integer(),
+          # True if write-reserved, false otherwise
+          write_reserved?: boolean()
+        }
+
+  ############################################################
+  #                         State                            #
+  ############################################################
+
+  typedstruct enforce: true do
+    @typedoc """
+    I am the state of the Shard GenServer.
+
+    ### Fields
+    - `:id` - The identifier for this shard.
+    - `:node_id` - The ID of the node this shard belongs to.
+    - `:kv` - The core key-value store: `key => height => kv_entry_details`.
+    - `:watermarks` - Per-key watermarks: `key => %{read: height, write: height}`.
+    - `:pending_reads` - Reads blocked by a watermark or write reservation: `key => height => GenServer.from()`.
+    """
+    field(:id, any())
+    field(:node_id, String.t())
+
+    field(
+      :kv,
+      %{required(key()) => %{required(height()) => kv_entry_details()}},
+      default: %{}
+    )
+
+    field(
+      :watermarks,
+      %{required(key()) => %{read: height(), write: height()}},
+      default: %{}
+    )
+
+    field(
+      :pending_reads,
+      %{required(key()) => %{required(height()) => list(GenServer.from())}},
+      default: %{}
+    )
+  end
+
+  ############################################################
+  #                    Public RPC API                      #
+  ############################################################
+
+  @doc """
+  I am the start_link function for the Shard module.
+
+  I start and link a Shard process, register it using the provided `id`,
+  and initialize its KV state based on `initial_kv` options.
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    # id: shard_id, node_id: node_id, initial_kv: %{key => val}
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @doc """
+  I am the reserve function for the Shard module. Use me to reserve a
+  read or write at a specific key at a specific height.
+
+  Reservations exist to inform the KV store that a value will
+  be read or written at a specific height at some point in the future.
+  If I know that an empty entry will be written to, then an immediate read
+  will have to wait until the write occurs. If I know that some entry will
+  be read from, then I know I must keep around immediately preceding committed values at
+  least until the read is completed.
+
+  I request a reservation on a specific key at a given height.
+  Capabilities can be `:read`, `:write`, or `:read_write`.
+  I return `:ok` on success, or an error tuple.
+  """
+  @spec reserve(GenServer.server(), key(), height(), capabilities()) ::
+          :ok
+          | {:error,
+             :reserving_write_under_write_watermark
+             | :reserving_read_under_read_watermark
+             | :slot_occupied_by_value}
+  def reserve(shard_pid, key, height, type) do
+    # Todo: Timeout?
+    GenServer.call(shard_pid, {:reserve, key, height, type}, :infinity)
+  end
+
+  @doc """
+  I am the read function for the Shard module.
+
+  I perform a synchronous read request for a key at a specific height.
+  I require a prior `reserve` call with `:read` or `:read_write` capability for this `{key, height}`.
+  The caller blocks until the read can be resolved (potentially waiting for watermarks)
+  and receives the result directly.
+  Returns `{:ok, value}`, `:absent`, or an error tuple.
+  """
+  @spec read(GenServer.server(), key(), height()) ::
+          {:ok, value()}
+          | :absent
+          | {:error, :read_not_reserved}
+  def read(shard_pid, key, height) do
+    GenServer.call(shard_pid, {:read, key, height}, :infinity)
+  end
+
+  @doc """
+  I am the write function for the Shard module.
+
+  I write a value for a key at a specific height, requiring a prior `reserve` call
+  with `:write` or `:read_write` capability for this `{key, height}`.
+  I return `:ok` on success, or an error tuple.
+  """
+  @spec write(
+          GenServer.server(),
+          key(),
+          value(),
+          height()
+        ) ::
+          :ok | {:error, :write_reservation_required}
+  def write(shard_pid, key, value, height) do
+    GenServer.call(
+      shard_pid,
+      {:write, key, value, height},
+      :infinity
+    )
+  end
+
+  @doc """
+  I release a specific type of reservation (:read or :write) for a given key at a given height.
+
+  This is an asynchronous operation primarily used for rollbacks of failed transactions.
+  """
+  @spec unreserve(GenServer.server(), key(), height(), :read | :write) :: :ok
+  def unreserve(shard_pid, key, height, type) do
+    GenServer.cast(shard_pid, {:unreserve, key, height, type})
+  end
+
+  @doc """
+  I trigger a backup of the shard's internal state to Mnesia.
+
+  This is a synchronous operation.
+  """
+  @spec backup_state(GenServer.server()) :: :ok | {:error, any()}
+  def backup_state(shard_pid) do
+    GenServer.call(shard_pid, :backup_state, :infinity)
+  end
+
+  @doc """
+  I advance the read watermark for a given key.
+
+  This is an asynchronous operation.
+  """
+  @spec advance_read_watermark(GenServer.server(), key(), height()) :: :ok
+  def advance_read_watermark(shard_pid, key, h_read) do
+    GenServer.cast(shard_pid, {:read_watermark_advanced, key, h_read})
+  end
+
+  @doc """
+  I advance the write watermark for a given key.
+
+  This is an asynchronous operation.
+  """
+  @spec advance_write_watermark(GenServer.server(), key(), height()) :: :ok
+  def advance_write_watermark(shard_pid, key, h_write) do
+    GenServer.cast(shard_pid, {:write_watermark_advanced, key, h_write})
+  end
+
+  @doc """
+  I return the internal state of the Shard GenServer. **Use for debugging only.**
+  """
+  @spec debug_get_state(GenServer.server()) :: __MODULE__.t()
+  def debug_get_state(shard_pid) do
+    GenServer.call(shard_pid, :debug_get_state, :infinity)
+  end
+
+  ############################################################
+  #                    Genserver Callbacks                    #
+  ############################################################
+
+  @impl true
+  def init(opts) do
+    Process.set_label(__MODULE__)
+    id = Keyword.fetch!(opts, :id)
+    node_id = Keyword.fetch!(opts, :node_id)
+    initial_kv_arg = Keyword.get(opts, :initial_kv, %{})
+
+    # Register the shard process
+    case Registry.register(node_id, __MODULE__, id) do
+      {:ok, _pid} ->
+        Logger.debug(
+          "Shard #{id} successfully registered for node #{node_id}"
+        )
+
+      {:error, reason} ->
+        Logger.error(
+          "Shard #{id} failed to register for node #{node_id}: #{inspect(reason)}"
+        )
+    end
+
+    # Initialize KV with schema values at height 0
+    kv =
+      Enum.reduce(initial_kv_arg, %{}, fn {key, value}, acc ->
+        # Initial state: has value, no reservations
+        initial_details = %{
+          value: value,
+          read_reserved_count: 0,
+          write_reserved?: false
+        }
+
+        Map.put(acc, key, %{0 => initial_details})
+      end)
+
+    # Initialize watermarks for keys present in initial_kv
+    watermarks =
+      Enum.reduce(initial_kv_arg, %{}, fn {key, _}, acc ->
+        Map.put(acc, key, @initial_watermarks)
+      end)
+
+    state = %__MODULE__{
+      id: id,
+      node_id: node_id,
+      kv: kv,
+      watermarks: watermarks,
+      pending_reads: %{}
+    }
+
+    {:ok, state}
+  end
+
+  # --- Reservation Handling ---
+  @impl true
+  def handle_call({:reserve, key, height, type}, _from, state) do
+    handle_reserve(key, height, type, state)
+  end
+
+  # --- Write Handling ---
+  @impl true
+  def handle_call({:write, key, value, height}, _from, state) do
+    handle_write(key, value, height, state)
+  end
+
+  # --- Read Handling ---
+  @impl true
+  def handle_call({:read, key, height_req}, from, state) do
+    handle_read(key, height_req, from, state)
+  end
+
+  # --- Backup Handling ---
+  @impl true
+  def handle_call(:backup_state, _from, state) do
+    handle_backup_state(state)
+  end
+
+  # --- Debug State Handling ---
+  @impl true
+  def handle_call(:debug_get_state, _from, state) do
+    {:reply, state, state}
+  end
+
+  # --- Watermark Update Handling ---
+  @impl true
+  def handle_cast({:write_watermark_advanced, key, h_write}, state) do
+    handle_write_watermark_advanced(key, h_write, state)
+  end
+
+  @impl true
+  def handle_cast({:read_watermark_advanced, key, h_read}, state) do
+    handle_read_watermark_advanced(key, h_read, state)
+  end
+
+  # --- Unreserve Handling ---
+  @impl true
+  def handle_cast({:unreserve, key, height, type}, state) do
+    handle_unreserve(key, height, type, state)
+  end
+
+  ############################################################
+  #             Internal Callback Handler Functions          #
+  ############################################################
+
+  # Orchestrates the reservation process using helper functions and a `with` statement.
+  # 1. Checks watermarks.
+  # 2. Retrieves or initializes details for the {key, height}.
+  # 3. Processes the specific reservation request (:read, :write, or :read_write).
+  # 4. Updates the state if the reservation was successful and changed the details.
+  @spec handle_reserve(key(), height(), capabilities(), __MODULE__.t()) ::
+          {:reply, :ok | {:error, atom()}, __MODULE__.t()}
+  defp handle_reserve(key, height, type, state) do
+    key_watermarks = Map.get(state.watermarks, key, @initial_watermarks)
+
+    with :ok <- check_watermarks(height, type, key_watermarks),
+         original_details = get_or_initialize_details(state.kv, key, height),
+         {:ok, final_details} <-
+           process_reservation_request(type, original_details) do
+      # Update state only if changes occurred
+      if final_details != original_details do
+        key_height_map = Map.get(state.kv, key, %{})
+        new_key_height_map = Map.put(key_height_map, height, final_details)
+        new_kv = Map.put(state.kv, key, new_key_height_map)
+        new_state = %{state | kv: new_kv}
+        {:reply, :ok, new_state}
+      else
+        # No change in reservation status (e.g., reservations already held)
+        {:reply, :ok, state}
+      end
+    else
+      # Handle errors from check_watermarks or process_reservation_request
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
+    end
+  end
+
+  # Checks if a reservation request conflicts with existing watermarks.
+  @spec check_watermarks(height(), capabilities(), map()) ::
+          :ok | {:error, atom()}
+  defp check_watermarks(height, type, key_watermarks)
+       when type in [:write, :read_write] and height <= key_watermarks.write do
+    {:error, :reserving_write_under_write_watermark}
+  end
+
+  defp check_watermarks(height, type, key_watermarks)
+       when type in [:read, :read_write] and height <= key_watermarks.read do
+    {:error, :reserving_read_under_read_watermark}
+  end
+
+  defp check_watermarks(_height, _type, _key_watermarks), do: :ok
+
+  # Retrieves the kv_entry_details for a {key, height} or returns initial default details.
+  @spec get_or_initialize_details(map(), key(), height()) ::
+          kv_entry_details()
+  defp get_or_initialize_details(kv, key, height) do
+    kv
+    |> Map.get(key, %{})
+    |> Map.get(height, @default_kv_entry_details)
+  end
+
+  # Processes a reservation request based on the type and current details.
+
+  # Handles granting read/write reservations and checks for conflicts like existing values
+  # when attempting a write reservation. Uses function heads for clarity.
+  @spec process_reservation_request(capabilities(), kv_entry_details()) ::
+          {:ok, kv_entry_details()} | {:error, atom()}
+
+  defp process_reservation_request(:read, details) do
+    {:ok, %{details | read_reserved_count: details.read_reserved_count + 1}}
+  end
+
+  defp process_reservation_request(:write, %{value: value})
+       when not is_nil(value) do
+    {:error, :slot_occupied_by_value}
+  end
+
+  defp process_reservation_request(:write, details) do
+    {:ok, %{details | write_reserved?: true}}
+  end
+
+  defp process_reservation_request(:read_write, %{value: value})
+       when not is_nil(value) do
+    {:error, :slot_occupied_by_value}
+  end
+
+  defp process_reservation_request(:read_write, details) do
+    {:ok,
+     %{
+       details
+       | read_reserved_count: details.read_reserved_count + 1,
+         write_reserved?: true
+     }}
+  end
+
+  @spec handle_write(key(), value(), height(), __MODULE__.t()) ::
+          {:reply, :ok | {:error, atom()}, __MODULE__.t()}
+  defp handle_write(key, value, height, state) do
+    key_height_map = Map.get(state.kv, key, %{})
+
+    details = Map.get(key_height_map, height, @default_kv_entry_details)
+
+    cond do
+      !details.write_reserved? ->
+        {:reply, {:error, :write_reservation_required}, state}
+
+      true ->
+        # Valid write reservation
+        # Update value, clear write reservation, KEEP read reservation
+        updated_details = %{details | value: value, write_reserved?: false}
+        new_key_height_map = Map.put(key_height_map, height, updated_details)
+        new_kv = Map.put(state.kv, key, new_key_height_map)
+        new_state = %{state | kv: new_kv}
+
+        # Check pending reads *after* state update (write might allow resolution if watermark matches)
+        final_state = check_pending_reads(key, new_state)
+        {:reply, :ok, final_state}
+    end
+  end
+
+  @spec handle_read(key(), height(), GenServer.from(), __MODULE__.t()) ::
+          {:reply, {:ok, value()} | :absent | {:error, atom()},
+           __MODULE__.t()}
+          | {:noreply, __MODULE__.t()}
+  defp handle_read(key, height_req, from, state) do
+    # --- Validation ---
+    key_height_map = Map.get(state.kv, key, %{})
+
+    details_at_req =
+      Map.get(key_height_map, height_req, @default_kv_entry_details)
+
+    cond do
+      # 1. Check Read Reservation
+      details_at_req.read_reserved_count == 0 ->
+        {:reply, {:error, :read_not_reserved}, state}
+
+      # 2. Attempt Resolution
+      true ->
+        key_watermarks =
+          Map.get(state.watermarks, key, @initial_watermarks)
+
+        resolution_result =
+          resolve_read_value(height_req, key_height_map, key_watermarks)
+
+        case resolution_result do
+          # Includes {:ok, :absent} or {:ok, {:ok, val}}
+          {:ok, value_or_absent} ->
+            # Resolve succeeded, release reservation and reply
+            updated_details = %{
+              details_at_req
+              | read_reserved_count: details_at_req.read_reserved_count - 1
+            }
+
+            new_key_height_map =
+              Map.put(key_height_map, height_req, updated_details)
+
+            new_kv = Map.put(state.kv, key, new_key_height_map)
+            new_state = %{state | kv: new_kv}
+
+            # Map internal {:ok, :absent} to just :absent for the caller
+            {:reply, value_or_absent, new_state}
+
+          block_reason
+          when block_reason in [
+                 :blocked_by_watermark,
+                 :blocked_by_write_reservation
+               ] ->
+            # Queue the read
+            pending_for_key = Map.get(state.pending_reads, key, %{})
+            current_pending_list = Map.get(pending_for_key, height_req, [])
+            updated_pending_list = [from | current_pending_list]
+
+            updated_pending_for_key =
+              Map.put(pending_for_key, height_req, updated_pending_list)
+
+            new_pending_reads =
+              Map.put(state.pending_reads, key, updated_pending_for_key)
+
+            {:noreply, %{state | pending_reads: new_pending_reads}}
+        end
+    end
+  end
+
+  @spec handle_write_watermark_advanced(key(), height(), __MODULE__.t()) ::
+          {:noreply, __MODULE__.t()}
+  defp handle_write_watermark_advanced(key, h_write, state) do
+    current_key_watermarks =
+      Map.get(state.watermarks, key, @initial_watermarks)
+
+    # Write watermark should only advance
+    new_write_wm = max(h_write, current_key_watermarks.write)
+
+    if new_write_wm > current_key_watermarks.write do
+      updated_watermarks = %{current_key_watermarks | write: new_write_wm}
+      new_watermarks_map = Map.put(state.watermarks, key, updated_watermarks)
+      state_after_wm_update = %{state | watermarks: new_watermarks_map}
+
+      # Check pending reads based ONLY on the new write watermark
+      state_after_reads =
+        check_pending_reads(key, state_after_wm_update)
+
+      {:noreply, state_after_reads}
+    else
+      # Watermark did not advance for this key
+      {:noreply, state}
+    end
+  end
+
+  @spec handle_read_watermark_advanced(key(), height(), __MODULE__.t()) ::
+          {:noreply, __MODULE__.t()}
+  defp handle_read_watermark_advanced(key, h_read, state) do
+    current_key_watermarks =
+      Map.get(state.watermarks, key, @initial_watermarks)
+
+    # Read watermark should only advance
+    new_read_wm = max(h_read, current_key_watermarks.read)
+
+    if new_read_wm > current_key_watermarks.read do
+      updated_watermarks = %{current_key_watermarks | read: new_read_wm}
+      new_watermarks_map = Map.put(state.watermarks, key, updated_watermarks)
+      state_after_wm_update = %{state | watermarks: new_watermarks_map}
+
+      # Perform Garbage Collection based ONLY on the new read watermark
+      state_after_gc = gc_key(key, new_read_wm, state_after_wm_update)
+
+      {:noreply, state_after_gc}
+    else
+      # Watermark did not advance for this key
+      {:noreply, state}
+    end
+  end
+
+  @spec handle_unreserve(key(), height(), :read | :write, __MODULE__.t()) ::
+          {:noreply, __MODULE__.t()}
+  defp handle_unreserve(key, height, type, state) do
+    case Map.get(state.kv, key) do
+      nil ->
+        {:noreply, state}
+
+      key_height_map ->
+        case Map.get(key_height_map, height) do
+          nil ->
+            {:noreply, state}
+
+          details ->
+            original_details = details
+
+            updated_details =
+              case type do
+                :read ->
+                  if details.read_reserved_count > 0 do
+                    %{
+                      details
+                      | read_reserved_count: details.read_reserved_count - 1
+                    }
+                  else
+                    # Idempotent: no change if count already zero
+                    details
+                  end
+
+                :write ->
+                  %{details | write_reserved?: false}
+              end
+
+            if updated_details != original_details do
+              new_key_height_map =
+                Map.put(key_height_map, height, updated_details)
+
+              updated_kv = Map.put(state.kv, key, new_key_height_map)
+              state_after_kv_update = %{state | kv: updated_kv}
+
+              final_state =
+                if type == :write and original_details.write_reserved? and
+                     not updated_details.write_reserved? do
+                  check_pending_reads(key, state_after_kv_update)
+                else
+                  state_after_kv_update
+                end
+
+              {:noreply, final_state}
+            else
+              {:noreply, state}
+            end
+        end
+    end
+  end
+
+  @spec handle_backup_state(__MODULE__.t()) ::
+          {:reply, :ok | {:error, any()}, __MODULE__.t()}
+  defp handle_backup_state(
+         state = %__MODULE__{id: shard_id, node_id: node_id, kv: kv_map}
+       ) do
+    backup_table = Anoma.Node.Tables.table_shard_backups(node_id)
+
+    mnesia_tx = fn ->
+      # Overwrite for same height.
+      Enum.each(kv_map, fn {key, height_map} ->
+        Enum.each(height_map, fn {height, details} ->
+          # Only backup entries with a committed value
+          if not is_nil(details.value) do
+            record_key = {shard_id, key, height}
+            :mnesia.write({backup_table, record_key, details.value})
+          end
+        end)
+      end)
+    end
+
+    case :mnesia.transaction(mnesia_tx) do
+      {:atomic, :ok} ->
+        {:reply, :ok, state}
+
+      {:aborted, reason} ->
+        Logger.error(
+          "Shard #{inspect(shard_id)} backup failed: #{inspect(reason)}"
+        )
+
+        {:reply, {:error, reason}, state}
+    end
+  end
+
+  ############################################################
+  #                 Internal Helper Functions                #
+  ############################################################
+
+  # I am the helper function to check pending reads after a watermark update, write, or unreserve.
+
+  # I check all pending reads for a given key.
+  # If a read becomes resolvable, I calculate the result, reply directly to the waiting
+  # caller using `GenServer.reply/2`, release the corresponding read reservation, and
+  # remove the request from the pending map.
+  @spec check_pending_reads(key(), __MODULE__.t()) :: __MODULE__.t()
+  defp check_pending_reads(key, state) do
+    pending_for_key = Map.get(state.pending_reads, key, %{})
+    key_watermarks = Map.get(state.watermarks, key, @initial_watermarks)
+
+    # Iterate through pending heights {height_req => from_list}
+    {new_pending_for_key, final_state_after_key_reduction} =
+      Enum.reduce(pending_for_key, {%{}, state}, fn {height_req, from_list},
+                                                    {acc_pending_map,
+                                                     acc_state_outer} ->
+        # Re-fetch key_height_map for each height_req as it's modified by inner reduce
+        current_key_height_map_outer = Map.get(acc_state_outer.kv, key, %{})
+
+        resolution_result =
+          resolve_read_value(
+            height_req,
+            current_key_height_map_outer,
+            key_watermarks
+          )
+
+        case resolution_result do
+          {:ok, value_or_absent} ->
+            # Process each requester in the list, decrementing reservations one by one
+            final_acc_state_inner =
+              Enum.reduce(from_list, acc_state_outer, fn requester_from,
+                                                         acc_state_inner ->
+                # Get freshest details for THIS requester, as it might have been updated by previous one in list
+                current_key_height_map_inner =
+                  Map.get(acc_state_inner.kv, key, %{})
+
+                details_at_req_height =
+                  Map.get(
+                    current_key_height_map_inner,
+                    height_req,
+                    @default_kv_entry_details
+                  )
+
+                if details_at_req_height.read_reserved_count > 0 do
+                  GenServer.reply(requester_from, value_or_absent)
+
+                  updated_details = %{
+                    details_at_req_height
+                    | read_reserved_count:
+                        details_at_req_height.read_reserved_count - 1
+                  }
+
+                  new_key_height_map_inner =
+                    Map.put(
+                      current_key_height_map_inner,
+                      height_req,
+                      updated_details
+                    )
+
+                  new_kv_inner =
+                    Map.put(acc_state_inner.kv, key, new_key_height_map_inner)
+
+                  %{acc_state_inner | kv: new_kv_inner}
+                else
+                  # No reservation left, reply with error
+                  GenServer.reply(
+                    requester_from,
+                    {:error, :read_not_reserved}
+                  )
+
+                  # State (kv) doesn't change as no reservation was consumed
+                  acc_state_inner
+                end
+              end)
+
+            # All requesters for this height_req processed, remove from pending map
+            {acc_pending_map, final_acc_state_inner}
+
+          block_reason
+          when block_reason in [
+                 :blocked_by_watermark,
+                 :blocked_by_write_reservation
+               ] ->
+            # Still blocked, keep pending
+            {Map.put(acc_pending_map, height_req, from_list), acc_state_outer}
+        end
+      end)
+
+    new_pending_reads =
+      if map_size(new_pending_for_key) > 0 do
+        Map.put(
+          final_state_after_key_reduction.pending_reads,
+          key,
+          new_pending_for_key
+        )
+      else
+        Map.delete(final_state_after_key_reduction.pending_reads, key)
+      end
+
+    %{final_state_after_key_reduction | pending_reads: new_pending_reads}
+  end
+
+  # Finds essential heights to keep below a given target height.
+  # Returns a MapSet containing:
+  # - The height of the latest committed value strictly below target_height.
+  # - The heights of all write reservations between that value and target_height.
+  @spec find_essential_heights_below(height(), map()) :: MapSet.t(height())
+  defp find_essential_heights_below(target_height, key_height_map) do
+    # 1. Find the highest height h_val < target_height with a committed value
+    maybe_max_h_val =
+      key_height_map
+      |> Enum.filter(fn {h, details} ->
+        h < target_height and not is_nil(details.value)
+      end)
+      |> Enum.max_by(fn {h, _} -> h end, fn -> nil end)
+
+    case maybe_max_h_val do
+      nil ->
+        # No committed value below target_height. Find write reservations below target_height.
+        write_reservation_heights_below =
+          key_height_map
+          |> Enum.filter(fn {h, details} ->
+            h < target_height and details.write_reserved?
+          end)
+          # Keep only the heights
+          |> Enum.map(fn {h, _} -> h end)
+
+        MapSet.new(write_reservation_heights_below)
+
+      {h_val, _details} ->
+        # 2. Find all heights h_wr with write reservations between h_val and target_height
+        write_reservation_heights_between =
+          key_height_map
+          |> Enum.filter(fn {h, details} ->
+            h > h_val and h < target_height and details.write_reserved?
+          end)
+          # Keep only the heights
+          |> Enum.map(fn {h, _} -> h end)
+
+        # 3. Combine h_val and the intermediate write reservation heights
+        MapSet.new([h_val | write_reservation_heights_between])
+    end
+  end
+
+  # I am the garbage collection helper function.
+
+  # I perform garbage collection for a specific key based on the read watermark.
+  # I remove entries older than the watermark unless they are essential for resolving
+  # reads at or past the watermark height or at heights with active read reservations.
+  @spec gc_key(key(), height(), __MODULE__.t()) :: __MODULE__.t()
+  defp gc_key(key, read_watermark, state) do
+    case Map.get(state.kv, key) do
+      nil ->
+        # Key not present, nothing to GC
+        state
+
+      key_height_map ->
+        # 1. Identify heights with active read reservations
+        read_reservation_heights =
+          for {h, details} <- key_height_map,
+              details.read_reserved_count > 0,
+              do: h
+
+        read_reservation_heights_set = MapSet.new(read_reservation_heights)
+
+        # 2. Determine essential heights to keep below the read watermark
+        essential_below_watermark =
+          find_essential_heights_below(read_watermark, key_height_map)
+
+        # 3. Determine essential heights to keep below each active read reservation
+        essential_below_reservations =
+          read_reservation_heights
+          |> Enum.map(&find_essential_heights_below(&1, key_height_map))
+          |> Enum.reduce(MapSet.new(), &MapSet.union/2)
+
+        # 4. Combine all heights that MUST be kept:
+        #    - Heights holding read reservations themselves.
+        #    - Essential heights supporting the watermark.
+        #    - Essential heights supporting each reservation.
+        all_essential_heights_below_watermark =
+          read_reservation_heights_set
+          |> MapSet.union(essential_below_watermark)
+          |> MapSet.union(essential_below_reservations)
+
+        # 5. Filter the map: Keep entries >= watermark OR in the essential set below watermark
+        new_key_height_map =
+          Enum.filter(key_height_map, fn {h, _details} ->
+            # Keep if at or above watermark OR essential below
+            h >= read_watermark or
+              MapSet.member?(all_essential_heights_below_watermark, h)
+          end)
+          |> Map.new()
+
+        # 6. Update state
+        if map_size(new_key_height_map) > 0 do
+          new_kv = Map.put(state.kv, key, new_key_height_map)
+          %{state | kv: new_kv}
+        else
+          # If GC removed all entries for the key, remove the key itself
+          new_kv = Map.delete(state.kv, key)
+          %{state | kv: new_kv}
+        end
+    end
+  end
+
+  # I am the helper function to attempt resolving a read request.
+
+  # I check if a read for `key` at `height_req` can be resolved based on the
+  # current `key_height_map` and `key_watermarks`.
+  # I return:
+  # - `{:ok, :absent}` if resolvable and no value exists below `height_req`.
+  # - `{:ok, {:ok, value}}` if resolvable and a value exists.
+  # - `:blocked_by_watermark` if `height_req` is above the write watermark.
+  # - `:blocked_by_write_reservation` if the latest entry below `height_req` holds a write reservation.
+  @spec resolve_read_value(height(), map(), map()) ::
+          {:ok, :absent | {:ok, value()}}
+          | :blocked_by_watermark
+          | :blocked_by_write_reservation
+  defp resolve_read_value(height_req, key_height_map, key_watermarks) do
+    if height_req > key_watermarks.write + 1 do
+      :blocked_by_watermark
+    else
+      # 2. Find the latest entry below height_req that has EITHER a value OR a write reservation.
+      # This represents the most recent operation determining the state relevant to the read.
+      maybe_relevant_entry =
+        key_height_map
+        |> Enum.filter(fn {h, details} ->
+          h < height_req and
+            (not is_nil(details.value) or details.write_reserved?)
+        end)
+        |> Enum.max_by(fn {h, _details} -> h end, fn -> nil end)
+
+      case maybe_relevant_entry do
+        # 3. No relevant entry found below height_req (implies initial state or empty)
+        nil ->
+          # If no entry with a value or reservation exists below height_req, the result is absent.
+          {:ok, :absent}
+
+        # 4. Relevant entry found, check its state
+        {_h, details} ->
+          cond do
+            # If the latest relevant entry has a value (is committed), resolve the read.
+            not is_nil(details.value) ->
+              {:ok, {:ok, details.value}}
+
+            # If the latest relevant entry holds a write reservation, block the read.
+            details.write_reserved? ->
+              :blocked_by_write_reservation
+
+            # Should be unreachable.
+            true ->
+              Logger.error(
+                "Shard: Unreachable state in resolve_read_value for key height map: #{inspect(key_height_map)}, height_req: #{height_req}"
+              )
+
+              # Treat as absent if we somehow reach here
+              {:ok, :absent}
+          end
+      end
+    end
+  end
+end

--- a/apps/anoma_node/lib/node/transaction/shard_supervisor.ex
+++ b/apps/anoma_node/lib/node/transaction/shard_supervisor.ex
@@ -1,0 +1,383 @@
+defmodule Anoma.Node.Transaction.ShardSupervisor do
+  @moduledoc """
+  I am the dynamic supervisor for `Anoma.Node.Transaction.Shard` processes.
+
+  I start with no children. Children (shards) are started dynamically either
+  during initial node setup based on a provided schema or later via the
+  `start_shard/3` function. I maintain a Mnesia table
+  (`Anoma.Node.Tables.table_shard_key_map/1`) mapping keys to the registered name
+  (`{:via, Registry, {Anoma.Node, {Shard, key}}}`) of the `Shard` process
+  responsible for that key. The actual lookup of keys is handled by the
+  `Anoma.Node.Transaction.Ordering`.
+
+  ### Key Concepts
+
+  - **Supervisor Args:** Keyword list including `:node_id`, and optionally `:strategy` and `:schema` for *initial* setup.
+  - **Strategy:** Determines how initial shards are created (e.g., `:one_per_key`). Only used during initial setup.
+  - **Schema:** Defines the initial keys and their starting values. Only used during initial setup.
+  - **Mnesia Table:** `table_shard_key_map/1` for key -> shard name lookup (used by Anoma.Node.Transaction.Ordering).
+  - **Dynamic Starting:** Use `start_shard/3` to add new shards after initial setup.
+
+  ### Public API
+
+  - `start_link/1`: I start the supervisor.
+  - `start_shard/3`: I dynamically start a new shard for a given key and optionally value.
+  - `get_shard_key_map/1`: I return the name of the Mnesia table for the shard key map for the given node ID.
+  """
+
+  use DynamicSupervisor
+  use EventBroker.DefFilter
+  use TypedStruct
+
+  alias Anoma.Node.Registry
+  alias Anoma.Node.Transaction.Shard
+  alias Anoma.Node.Tables
+
+  require Logger
+
+  ############################################################
+  #                       Types                              #
+  ############################################################
+
+  @typedoc "I represent a key managed by a shard."
+  @type key_t :: binary()
+
+  @typedoc "I represent the initial value associated with a key in a shard."
+  @type initial_value_t :: any()
+
+  @typedoc """
+  I am the schema defining the keys and their initial values for shards.
+  For the `:one_per_key` strategy, I expect a list containing either `key` binaries
+  or `{key, initial_value}` tuples. If only a key is provided, there is no
+  initial value.
+  """
+  @type schema_t :: [key_t() | {key_t(), initial_value_t()}]
+
+  @typedoc """
+  I am the sharding strategy.
+  Currently, I only support `:one_per_key`.
+  """
+  @type strategy_t :: :one_per_key
+
+  @typedoc """
+  I am the type of the arguments that the ShardSupervisor expects at startup.
+  I require `:node_id` and optionally `:strategy` and `:schema` keys for initial setup.
+  """
+  @type supervisor_args_t :: [
+          node_id: String.t(),
+          strategy: strategy_t() | nil,
+          schema: schema_t() | nil
+        ]
+
+  @typedoc """
+  I am the type of the arguments that the Shard process expects.
+  I am not explicitly used, but this may be useful to know.
+  """
+  @type shard_args_t :: [
+          id: key_t(),
+          initial_kv: %{key_t() => initial_value_t()}
+        ]
+
+  ############################################################
+  #                 Supervisor Implementation                #
+  ############################################################
+
+  @doc """
+  I am the start_link function for the ShardSupervisor.
+
+  I start and link the dynamic supervisor process under the current supervision tree,
+  registering myself locally using a node-specific name.
+
+  If initial :strategy and :schema are provided, I perform Mnesia setup
+  synchronously *before* starting the supervisor. If Mnesia fails, I return
+  an error. After the supervisor starts, I start the initial children.
+  """
+  @spec start_link(args :: supervisor_args_t()) :: Supervisor.on_start()
+  def start_link(args) do
+    node_id = Keyword.fetch!(args, :node_id)
+    strategy = Keyword.get(args, :strategy)
+    schema = Keyword.get(args, :schema)
+    name = Registry.via(node_id, __MODULE__)
+
+    # Perform initial setup synchronously *before* starting the supervisor process
+    {initial_child_specs, mnesia_setup_result} =
+      if strategy != nil and is_list(schema) do
+        {specs, key_to_id_map} = process_schema(node_id, strategy, schema)
+        mnesia_result = populate_mnesia_table(key_to_id_map, node_id)
+        {specs, mnesia_result}
+      else
+        # No schema, Mnesia setup is considered successful
+        {[], :ok}
+      end
+
+    case mnesia_setup_result do
+      :ok ->
+        case DynamicSupervisor.start_link(__MODULE__, [node_id: node_id],
+               name: name
+             ) do
+          {:ok, pid} ->
+            Enum.reduce(initial_child_specs, {:ok, pid}, fn child_spec, acc ->
+              case acc do
+                {:ok, supervisor_pid} ->
+                  case DynamicSupervisor.start_child(
+                         supervisor_pid,
+                         child_spec
+                       ) do
+                    {:ok, _child_pid} ->
+                      {:ok, supervisor_pid}
+
+                    {:error, reason} ->
+                      error_info =
+                        {:failed_to_start_initial_child, child_spec[:id],
+                         reason}
+
+                      Logger.error(
+                        "#{__MODULE__} failed to start initial child #{inspect(child_spec[:id])} for node #{node_id}: #{inspect(reason)}. Supervisor startup will fail."
+                      )
+
+                      DynamicSupervisor.stop(supervisor_pid)
+
+                      {:error, error_info}
+                  end
+
+                error_acc ->
+                  error_acc
+              end
+            end)
+
+          {:error, _reason} = error ->
+            error
+        end
+
+      :no_shards ->
+        DynamicSupervisor.start_link(__MODULE__, [node_id: node_id],
+          name: name
+        )
+
+      {:error, reason} ->
+        {:error, {:mnesia_table_population_failed, reason}}
+    end
+  end
+
+  @impl true
+  @doc """
+  I am the DynamicSupervisor initialization callback.
+
+  I just set the process label and initialize the supervisor state.
+  Initial child starting is handled in `start_link/1` after this process starts.
+  """
+  @spec init(args :: [node_id: String.t()]) ::
+          {:ok, DynamicSupervisor.sup_flags()}
+  def init(args) do
+    node_id = Keyword.fetch!(args, :node_id)
+    Process.set_label({__MODULE__, node_id})
+
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  @doc """
+  I dynamically start a new shard process for the given key.
+
+  I register the shard with the registry and add its key mapping to the Mnesia table.
+  """
+  @spec start_shard(
+          node_id :: String.t(),
+          key :: key_t(),
+          initial_value :: initial_value_t() | nil
+        ) ::
+          DynamicSupervisor.on_start_child()
+          | {:error, :mnesia_update_failed, any()}
+  def start_shard(node_id, key, initial_value \\ nil) do
+    supervisor_name = Registry.via(node_id, __MODULE__)
+    shard_id = String.to_atom(key)
+
+    # Check if already registered before attempting start
+    case Registry.whereis(node_id, Shard, shard_id) do
+      existing_pid when is_pid(existing_pid) ->
+        {:error, {:already_started, existing_pid}}
+
+      nil ->
+        initial_kv =
+          if initial_value do
+            %{key => initial_value}
+          else
+            %{}
+          end
+
+        shard_args = [
+          node_id: node_id,
+          id: shard_id,
+          initial_kv: initial_kv
+        ]
+
+        child_spec = %{
+          id: shard_id,
+          start: {Shard, :start_link, [shard_args]}
+        }
+
+        result = DynamicSupervisor.start_child(supervisor_name, child_spec)
+
+        case result do
+          {:ok, new_pid} ->
+            case add_key_to_mnesia_map(node_id, key, shard_id) do
+              :ok ->
+                {:ok, new_pid}
+
+              {:error, reason} ->
+                # Attempt to terminate the child we just started if Mnesia fails
+                # to prevent inconsistent state (shard running but not in map)
+                DynamicSupervisor.terminate_child(supervisor_name, new_pid)
+                {:error, :mnesia_update_failed, reason}
+            end
+
+          other_result ->
+            other_result
+        end
+    end
+  end
+
+  ############################################################
+  #                    Private Helpers                       #
+  ############################################################
+
+  # Helper to create child spec and update accumulator map for a given key during initial setup.
+  # Returns the child spec itself and the {key, shard_id} tuple.
+  defp create_shard_spec_and_mapping(
+         node_id,
+         key,
+         initial_kv
+       ) do
+    shard_id = String.to_atom(key)
+
+    shard_args = [
+      node_id: node_id,
+      id: shard_id,
+      initial_kv: initial_kv
+    ]
+
+    child_spec = %{
+      id: shard_id,
+      start: {Shard, :start_link, [shard_args]}
+    }
+
+    {child_spec, {key, shard_id}}
+  end
+
+  # Processes the schema based on the strategy to generate shard child specs
+  # and a map of key -> shard_id. (Used only during initial async setup)
+  @spec process_schema(
+          node_id :: String.t(),
+          strategy :: strategy_t() | nil,
+          schema :: schema_t() | nil
+        ) ::
+          {
+            [Supervisor.child_spec()],
+            %{key_t() => atom()}
+          }
+  defp process_schema(node_id, :one_per_key, schema) when is_list(schema) do
+    Enum.reduce(schema, {[], %{}}, fn schema_entry, {specs_acc, map_acc} ->
+      # Determine key and initial_kv based on entry format
+      {key, initial_kv} =
+        case schema_entry do
+          {k, v} when is_binary(k) -> {k, %{k => v}}
+          k when is_binary(k) -> {k, %{}}
+          # Mark invalid entry
+          _ -> {nil, nil}
+        end
+
+      # If key is valid (not nil), create spec and get mapping
+      if key do
+        {child_spec, {map_key, map_value}} =
+          create_shard_spec_and_mapping(
+            node_id,
+            key,
+            initial_kv
+          )
+
+        {[child_spec | specs_acc], Map.put(map_acc, map_key, map_value)}
+      else
+        # Skip invalid entry
+        {specs_acc, map_acc}
+      end
+    end)
+  end
+
+  # Cases where strategy/schema are nil or invalid for initial setup
+  defp process_schema(_node_id, _strategy, _schema) do
+    {[], %{}}
+  end
+
+  @doc """
+  I return the Mnesia table name for the shard key map for the given node ID.
+  """
+  @spec get_shard_key_map(node_id :: String.t()) :: atom()
+  def get_shard_key_map(node_id) do
+    Tables.table_shard_key_map(node_id)
+  end
+
+  # Populates the Mnesia table with the key -> shard_id mapping.
+  # Called during initial synchronous setup within init/1.
+  # Returns :ok on success, :no_shards if the map is empty, or {:error, reason}.
+  @spec populate_mnesia_table(
+          map :: %{key_t() => atom()},
+          node_id :: String.t()
+        ) ::
+          :ok | :no_shards | {:error, any()}
+  defp populate_mnesia_table(key_to_id_map, node_id)
+       when map_size(key_to_id_map) > 0 do
+    table_name = Tables.table_shard_key_map(node_id)
+
+    # Clear existing entries first to handle potential restarts/schema changes
+    case :mnesia.clear_table(table_name) do
+      {:atomic, :ok} ->
+        mnesia_tx = fn ->
+          Enum.each(key_to_id_map, fn {key, shard_id} ->
+            :mnesia.write({table_name, key, shard_id})
+          end)
+        end
+
+        case :mnesia.transaction(mnesia_tx) do
+          {:atomic, :ok} ->
+            :ok
+
+          {:aborted, reason} ->
+            {:error, {:mnesia_transaction_failed, reason}}
+        end
+
+      {:aborted, reason} ->
+        {:error, {:clear_table_failed, reason}}
+    end
+  end
+
+  defp populate_mnesia_table(_empty_map, _node_id) do
+    :no_shards
+  end
+
+  # Adds a single key -> shard_id mapping to the Mnesia table transactionally.
+  # Called by start_shard/3. Does NOT clear the table.
+  @spec add_key_to_mnesia_map(
+          node_id :: String.t(),
+          key :: key_t(),
+          shard_id :: atom()
+        ) ::
+          :ok | {:error, any()}
+  defp add_key_to_mnesia_map(node_id, key, shard_id) do
+    table_name = Tables.table_shard_key_map(node_id)
+
+    mnesia_tx = fn ->
+      :mnesia.write({table_name, key, shard_id})
+    end
+
+    case :mnesia.transaction(mnesia_tx) do
+      {:atomic, :ok} ->
+        :ok
+
+      {:aborted, reason} ->
+        Logger.error(
+          "Failed to add key #{inspect(key)} -> #{inspect(shard_id)} to Mnesia table #{inspect(table_name)}: #{inspect(reason)}"
+        )
+
+        {:error, {:mnesia_transaction_failed, reason}}
+    end
+  end
+end

--- a/apps/anoma_node/lib/node/transaction/supervisor.ex
+++ b/apps/anoma_node/lib/node/transaction/supervisor.ex
@@ -8,6 +8,7 @@ defmodule Anoma.Node.Transaction.Supervisor do
   alias Anoma.Node.Registry
   alias Anoma.Node.Transaction.Mempool
   alias Anoma.Node.Transaction.Ordering
+  alias Anoma.Node.Transaction.ShardSupervisor
 
   ############################################################
   #                       Types                              #
@@ -19,7 +20,8 @@ defmodule Anoma.Node.Transaction.Supervisor do
   @type args_t :: [
           node_id: String.t(),
           mempool: Mempool.args_t(),
-          ordering: Ordering.args_t()
+          ordering: Ordering.args_t(),
+          shards: ShardSupervisor.supervisor_args_t() | nil
         ]
 
   ############################################################
@@ -36,6 +38,8 @@ defmodule Anoma.Node.Transaction.Supervisor do
     Process.set_label(__MODULE__)
 
     children = [
+      {ShardSupervisor,
+       [node_id: args[:node_id]] ++ Keyword.get(args, :shards, [])},
       {Anoma.Node.Transaction.Ordering,
        [node_id: args[:node_id]] ++ Keyword.get(args, :ordering, [])},
       {Anoma.Node.Transaction.Storage,

--- a/apps/anoma_node/test/shard_supervisor_test.exs
+++ b/apps/anoma_node/test/shard_supervisor_test.exs
@@ -1,0 +1,7 @@
+defmodule ShardSupervisorTest do
+  use ExUnit.Case, async: false
+  use TestHelper.TestMacro
+
+  use TestHelper.GenerateExampleTests,
+    for: Anoma.Node.Examples.EShardSupervisor
+end

--- a/apps/anoma_node/test/shard_test.exs
+++ b/apps/anoma_node/test/shard_test.exs
@@ -1,0 +1,5 @@
+defmodule ShardTest do
+  use ExUnit.Case, async: false
+  use TestHelper.TestMacro
+  use TestHelper.GenerateExampleTests, for: Anoma.Node.Examples.EShard
+end


### PR DESCRIPTION
Implements shards as a new backend. Core functionality is implemented in the transaction directory within anoma_node. The main files to look at are.
- shards.ex, which contains the core implementation of shards as a genserver.
- backend.ex, which was modified with a new shard_storage backend option that integrates with shards.
- ordering.ex, which was modified to perform the watermark tracking operations necessary for shards.

Still significant but less substantial are the files
- node/supervisor.ex
- transaction/supervisor.ex
- shard_supervisor.ex
- shard_router.ex
which add the ability to provide a simple schema at node startup which is used to spawn the initial shards and associate them with keys in the distributed KV store.

Additional examples were added. Specifically
- e_shard.ex, which tests the shards themselves
- e_shard_supervisor.ex, which tests shard spawning at node startup
- e_shard_backend.ex, which tests actually executing transactions using the shard_storage backend