### PR TITLE
Add EPMD to CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,12 +46,12 @@ jobs:
 
       - name: mix test
         shell: bash
-        run: MIX_ENV=${{inputs.mix-env}} mix test
+        run: epmd -d & MIX_ENV=${{inputs.mix-env}} mix test
 
       - name: mix test (juvix)
         shell: bash
-        run: MIX_ENV=${{inputs.mix-env}} mix test --only juvix
+        run: epmd -d & MIX_ENV=${{inputs.mix-env}} mix test --only juvix
 
       - name: mix test (zk)
         shell: bash
-        run: MIX_ENV=${{inputs.mix-env}} mix test --only zk
+        run: epmd -d & MIX_ENV=${{inputs.mix-env}} mix test --only zk


### PR DESCRIPTION
Some tests that involve distribution require EPMD to be running. This PR adds that.