### PR TITLE
Separate Keyspaces Properly

### DIFF
--- a/apps/anoma_node/lib/examples/e_shielded_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_shielded_transaction.ex
@@ -28,7 +28,7 @@ defmodule Anoma.Node.Examples.EShieldedTransaction do
     input_nullifier = ESResource.a_resource_nullifier()
 
     assert {:ok, MapSet.new([input_nullifier])} ==
-             Storage.read(node_id, {1, ["anoma", "cairo_nullifiers"]})
+             Storage.read(node_id, {1, ["anoma", "cairo", "nullifiers"]})
 
     output_resource_cm =
       ESResource.a_fixed_output_resource()
@@ -46,12 +46,12 @@ defmodule Anoma.Node.Examples.EShieldedTransaction do
 
     assert {:ok,
             MapSet.new([Anoma.Constants.default_cairo_rm_root(), anchor])} ==
-             Storage.read(node_id, {1, ["anoma", "cairo_roots"]})
+             Storage.read(node_id, {1, ["anoma", "cairo", "roots"]})
 
-    assert {:ok, tree} == Storage.read(node_id, {1, ["anoma", "cairo_ct"]})
+    assert {:ok, tree} == Storage.read(node_id, {1, ["anoma", "cairo", "ct"]})
 
     assert {:ok, set_of_ciphertexts} ==
-             Storage.read(node_id, {1, ["anoma", "cairo_ciphertexts"]})
+             Storage.read(node_id, {1, ["anoma", "cairo", "ciphertexts"]})
 
     EventBroker.unsubscribe_me([])
 
@@ -84,10 +84,10 @@ defmodule Anoma.Node.Examples.EShieldedTransaction do
       |> Anoma.CairoResource.Resource.nullifier(<<1::256>>)
 
     assert {:ok, MapSet.new([input_nullifier_1, input_nullifier_2])} ==
-             Storage.read(node_id, {1, ["anoma", "cairo_nullifiers"]})
+             Storage.read(node_id, {1, ["anoma", "cairo", "nullifiers"]})
 
     assert {:ok, set_of_ciphertexts} ==
-             Storage.read(node_id, {1, ["anoma", "cairo_ciphertexts"]})
+             Storage.read(node_id, {1, ["anoma", "cairo", "ciphertexts"]})
 
     output_cm_1 =
       ESResource.a_fixed_output_resource()
@@ -105,9 +105,9 @@ defmodule Anoma.Node.Examples.EShieldedTransaction do
 
     assert {:ok,
             MapSet.new([Anoma.Constants.default_cairo_rm_root(), anchor])} ==
-             Storage.read(node_id, {1, ["anoma", "cairo_roots"]})
+             Storage.read(node_id, {1, ["anoma", "cairo", "roots"]})
 
-    assert {:ok, tree} == Storage.read(node_id, {1, ["anoma", "cairo_ct"]})
+    assert {:ok, tree} == Storage.read(node_id, {1, ["anoma", "cairo", "ct"]})
     EventBroker.unsubscribe_me([])
 
     node_id
@@ -150,7 +150,7 @@ defmodule Anoma.Node.Examples.EShieldedTransaction do
       |> Anoma.CairoResource.Resource.nullifier(<<1::256>>)
 
     assert {:ok, MapSet.new([input_nullifier_1, input_nullifier_2])} ==
-             Storage.read(node_id, {2, ["anoma", "cairo_nullifiers"]})
+             Storage.read(node_id, {2, ["anoma", "cairo", "nullifiers"]})
 
     output_cm_1 =
       ESResource.a_fixed_output_resource()
@@ -177,15 +177,15 @@ defmodule Anoma.Node.Examples.EShieldedTransaction do
               anchor_1,
               anchor_2
             ])} ==
-             Storage.read(node_id, {2, ["anoma", "cairo_roots"]})
+             Storage.read(node_id, {2, ["anoma", "cairo", "roots"]})
 
-    assert {:ok, tree} == Storage.read(node_id, {2, ["anoma", "cairo_ct"]})
+    assert {:ok, tree} == Storage.read(node_id, {2, ["anoma", "cairo", "ct"]})
 
     set_of_ciphertexts =
       MapSet.union(set_of_ciphertexts1, set_of_ciphertexts2)
 
     assert {:ok, set_of_ciphertexts} ==
-             Storage.read(node_id, {2, ["anoma", "cairo_ciphertexts"]})
+             Storage.read(node_id, {2, ["anoma", "cairo", "ciphertexts"]})
 
     EventBroker.unsubscribe_me([])
 

--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -394,18 +394,28 @@ defmodule Anoma.Node.Examples.ETransaction do
     base_swap = ETransaction.swap_from_actions()
 
     assert {:ok, base_swap |> Transaction.nullifiers()} ==
-             Storage.read(node_id, {1, ["anoma", "nullifiers"]})
+             Storage.read(
+               node_id,
+               {1, ["anoma", "transparent", "nullifiers"]}
+             )
 
     assert {:ok, base_swap |> Transaction.commitments()} ==
-             Storage.read(node_id, {1, ["anoma", "commitments"]})
+             Storage.read(
+               node_id,
+               {1, ["anoma", "transparent", "commitments"]}
+             )
 
     cms = base_swap |> Transaction.commitments()
 
-    assert {:ok, cms} == Storage.read(node_id, {1, ["anoma", "commitments"]})
+    assert {:ok, cms} ==
+             Storage.read(
+               node_id,
+               {1, ["anoma", "transparent", "commitments"]}
+             )
 
     assert {:ok,
             Anoma.RM.Transparent.Primitive.CommitmentAccumulator.value(cms)} ==
-             Storage.read(node_id, {1, ["anoma", "anchor"]})
+             Storage.read(node_id, {1, ["anoma", "transparent", "anchor"]})
 
     EventBroker.unsubscribe_me([])
 

--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -282,13 +282,13 @@ defmodule Anoma.Node.Transaction.Backends do
         end
 
       old_cms =
-        case Ordering.read(node_id, {id, anoma_keyspace("commitments")}) do
+        case Ordering.read(node_id, {id, transparent_keyspace("commitments")}) do
           :absent -> MapSet.new()
           {:ok, res} -> res
         end
 
       writes = [
-        {anoma_keyspace("anchor"),
+        {transparent_keyspace("anchor"),
          TAcc.value(
            MapSet.union(
              map.commitments,
@@ -303,8 +303,8 @@ defmodule Anoma.Node.Transaction.Backends do
         {id,
          %{
            append: [
-             {anoma_keyspace("nullifiers"), map.nullifiers},
-             {anoma_keyspace("commitments"), map.commitments}
+             {transparent_keyspace("nullifiers"), map.nullifiers},
+             {transparent_keyspace("commitments"), map.commitments}
            ],
            write: writes
          }}
@@ -341,13 +341,13 @@ defmodule Anoma.Node.Transaction.Backends do
           true | {:error, String.t()}
   defp storage_check(node_id, id, trans) do
     stored_commitments =
-      case Ordering.read(node_id, {id, anoma_keyspace("commitments")}) do
+      case Ordering.read(node_id, {id, transparent_keyspace("commitments")}) do
         :absent -> MapSet.new()
         {:ok, res} -> res
       end
 
     stored_nullifiers =
-      case Ordering.read(node_id, {id, anoma_keyspace("nullifiers")}) do
+      case Ordering.read(node_id, {id, transparent_keyspace("nullifiers")}) do
         :absent -> MapSet.new()
         {:ok, res} -> res
       end
@@ -413,7 +413,7 @@ defmodule Anoma.Node.Transaction.Backends do
              :mnesia.transaction(fn ->
                :mnesia.match_object(
                  {Storage.values_table(node_id),
-                  {:_, anoma_keyspace("anchor")}, root}
+                  {:_, transparent_keyspace("anchor")}, root}
                )
              end) do
         {:cont, acc}
@@ -474,7 +474,7 @@ defmodule Anoma.Node.Transaction.Backends do
          # No need to check the commitment existence
          true <- nullifier_existence_check(tx, node_id, id) do
       {ct, append_roots} =
-        case Ordering.read(node_id, {id, anoma_keyspace("cairo_ct")}) do
+        case Ordering.read(node_id, {id, cairo_keyspace("ct")}) do
           :absent ->
             {CTransaction.cm_tree(),
              MapSet.new([Anoma.Constants.default_cairo_rm_root()])}
@@ -501,8 +501,7 @@ defmodule Anoma.Node.Transaction.Backends do
               Noun.equal?(deletion, <<1::256>>)
             end)
             |> Enum.map(fn {value, _} ->
-              {["anoma", "blob", "cairo", :crypto.hash(:sha256, value)],
-               value}
+              {["anoma", "blob", :crypto.hash(:sha256, value)], value}
             end)
           end)
         end)
@@ -512,12 +511,11 @@ defmodule Anoma.Node.Transaction.Backends do
         {id,
          %{
            append: [
-             {anoma_keyspace("cairo_nullifiers"), nullifiers},
-             {anoma_keyspace("cairo_roots"),
-              MapSet.put(append_roots, anchor)},
-             {anoma_keyspace("cairo_ciphertexts"), ciphertexts}
+             {cairo_keyspace("nullifiers"), nullifiers},
+             {cairo_keyspace("roots"), MapSet.put(append_roots, anchor)},
+             {cairo_keyspace("ciphertexts"), ciphertexts}
            ],
-           write: [{anoma_keyspace("cairo_ct"), ct_new} | write_app_data]
+           write: [{cairo_keyspace("ct"), ct_new} | write_app_data]
          }}
       )
 
@@ -544,7 +542,7 @@ defmodule Anoma.Node.Transaction.Backends do
           true | {:error, String.t()}
   def nullifier_existence_check(transaction, node_id, id) do
     with {:ok, stored_nullifiers} <-
-           Ordering.read(node_id, {id, anoma_keyspace("cairo_nullifiers")}) do
+           Ordering.read(node_id, {id, cairo_keyspace("nullifiers")}) do
       if Enum.any?(
            CTransaction.nullifiers(transaction),
            &MapSet.member?(stored_nullifiers, &1)
@@ -563,7 +561,7 @@ defmodule Anoma.Node.Transaction.Backends do
           true | {:error, String.t()}
   def root_existence_check(transaction, node_id, id) do
     stored_roots =
-      case Ordering.read(node_id, {id, anoma_keyspace("cairo_roots")}) do
+      case Ordering.read(node_id, {id, cairo_keyspace("roots")}) do
         :absent -> MapSet.new([Anoma.Constants.default_cairo_rm_root()])
         {:ok, val} -> val
       end
@@ -696,8 +694,18 @@ defmodule Anoma.Node.Transaction.Backends do
     val == value(w) and MapSet.member?(w, cm)
   end
 
-  @spec anoma_keyspace(String.t()) :: list(String.t())
+  @spec cairo_keyspace(String.t()) :: list(String.t())
+  defp cairo_keyspace(key) do
+    anoma_keyspace(["cairo", key])
+  end
+
+  @spec transparent_keyspace(String.t()) :: list(String.t())
+  defp transparent_keyspace(key) do
+    anoma_keyspace(["transparent", key])
+  end
+
+  @spec anoma_keyspace(list(String.t())) :: list(String.t())
   defp anoma_keyspace(key) do
-    ["anoma", key]
+    ["anoma" | key]
   end
 end


### PR DESCRIPTION
Now transparent and Cairo RMs have properly different keyspace paths.