### PR TITLE
Fix Typos in Documentation Files

### DIFF
--- a/documentation/contributing/testing/running-tests.livemd
+++ b/documentation/contributing/testing/running-tests.livemd
@@ -203,7 +203,7 @@ Since most (if not all!) tests are composed from examples. One can simply run th
 
 <!-- livebook:{"break_markdown":true} -->
 
-If we take `AnomaTest.LiveBook.Example` as our exmaple, then we can run the individual tests like the following.
+If we take `AnomaTest.LiveBook.Example` as our example, then we can run the individual tests like the following.
 
 <!-- livebook:{"break_markdown":true} -->
 

--- a/documentation/hoon.livemd
+++ b/documentation/hoon.livemd
@@ -35,5 +35,5 @@ familiar with Hoon, this merely shows you how to use the
 [Urbit](https://urbit.org/) environment to aid Nock code.
 
 A good general guide to Hoon can be found [At the Hoon School](https://developers.urbit.org/guides/core/hoon-school).
-Hopefully the documention here serves as a good companion piece for
+Hopefully the documentation here serves as a good companion piece for
 anyone interested in Nock, Hoon, or Anoma.

--- a/documentation/hoon/dumping.livemd
+++ b/documentation/hoon/dumping.livemd
@@ -108,7 +108,7 @@ Note that Hoon uses `function:module` (`f:mn:...:m1`) form.
 [6 [5 [1 0] 0 6] [0 0] 8 [1 0] 8 [1 6 [5 [0 30] 4 0 6] [0 6] 9 2 10 [6 4 0 6] 0 1] 9 2 0 1]
 ```
 
-The logic here doesn't particularly matter, but here we have the nock definiton of decrement, which is wonderful!
+The logic here doesn't particularly matter, but here we have the nock definition of decrement, which is wonderful!
 
 <!-- livebook:{"break_markdown":true} -->
 


### PR DESCRIPTION


**Description:** 
This pull request addresses minor typographical errors in the documentation files. The changes include:

- Corrected spelling of "documentation" in `hoon.livemd`.
- Fixed a typo in `dumping.livemd`.
- Adjusted wording for clarity in `running-tests.livemd`.

These updates improve the readability and professionalism of the documentation.
