### PR TITLE
Config files

### DIFF
--- a/apps/anoma_lib/lib/noun.ex
+++ b/apps/anoma_lib/lib/noun.ex
@@ -183,7 +183,7 @@ defmodule Noun do
       fal
     else
       haz = Murmur.hash_x86_32(key, seed)
-      ham = haz >>> 31 |> bxor(haz &&& (1 <<< 31) - 1)
+      ham = (haz >>> 31) |> bxor(haz &&& (1 <<< 31) - 1)
 
       unless ham == 0 do
         ham

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,12 +1,15 @@
 import Config
 
+# ----------------------------------------------------------------------------
+# Logger
+
 config :logger,
   level: :error,
   handle_otp_reports: false,
   handle_sasl_reports: false
 
 # ----------------------------------------------------------------------------
-# Endpoint
+# Anoma Client Web Endpoint
 
 # Configures the endpoint
 config :anoma_client, Anoma.Client.Web.Endpoint,
@@ -14,27 +17,26 @@ config :anoma_client, Anoma.Client.Web.Endpoint,
   adapter: Bandit.PhoenixAdapter,
   http: [
     ip: {127, 0, 0, 1},
-    port: String.to_integer(System.get_env("CLIENT_HTTP_PORT") || "4000")
+    port: 4000
   ],
   check_origin: false,
   debug_errors: false,
   render_errors: [view: Anoma.Client.Web.ErrorJSON, accepts: ~w(json)]
 
-config :anoma_client,
-  grpc_port: String.to_integer(System.get_env("CLIENT_GRPC_PORT") || "40051")
+# ----------------------------------------------------------------------------
+# Anoma Client
 
-config :anoma_lib, []
+config :anoma_client,
+  grpc_port: 40051
+
+# ----------------------------------------------------------------------------
+# Anoma Node
 
 config :anoma_node,
-  grpc_port: String.to_integer(System.get_env("NODE_GRPC_PORT") || "50051")
+  grpc_port: 50051
 
-config :anoma_protobuf, []
-config :compile_protoc, []
-config :event_broker, []
-
-############################################################
-#                       Mnesia                             #
-############################################################
+# ----------------------------------------------------------------------------
+# Mnesia
 
 # persist_to_disk: should the mnesia data be written to disk?
 #                  default: false
@@ -53,6 +55,4 @@ config :anoma_node, :mnesia,
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
-if File.exists?("config/#{config_env()}.exs") do
-  import_config "#{config_env()}.exs"
-end
+import_config "#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,4 @@
 import Config
 
-# refresh the open api spec during development
+# refresh the open api spec during development, don't keep it in ETS cache.
 config :open_api_spex, :cache_adapter, OpenApiSpex.Plug.NoneCache

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,14 +1,28 @@
 import Config
 
-# ----------------------------------------------------------------------------
-# Endpoint
+# This configuration file is always evaluated at runtime. The other config files
+# are evaluated at compile time.
 
-# Configures the endpoint
-config :anoma_client, Anoma.Client.Web.Endpoint,
-  http: [
-    ip: {127, 0, 0, 1},
-    port: String.to_integer(System.get_env("CLIENT_HTTP_PORT") || "4000")
-  ]
+if Mix.env() == :prod do
+  # ----------------------------------------------------------------------------
+  # Anoma Client Web Endpoint
 
-config :anoma_client,
-  grpc_port: String.to_integer(System.get_env("CLIENT_GRPC_PORT") || "40051")
+  config :anoma_client, Anoma.Client.Web.Endpoint,
+    http: [
+      ip: {127, 0, 0, 1},
+      port: String.to_integer(System.get_env("CLIENT_HTTP_PORT") || "4001")
+    ]
+
+  # ----------------------------------------------------------------------------
+  # Anoma Client
+
+  config :anoma_client,
+    grpc_port:
+      String.to_integer(System.get_env("CLIENT_GRPC_PORT") || "40051")
+
+  # ----------------------------------------------------------------------------
+  # Anoma Node
+
+  config :anoma_node,
+    grpc_port: String.to_integer(System.get_env("NODE_GRPC_PORT") || "50051")
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,7 +1,40 @@
 import Config
 
+# ----------------------------------------------------------------------------
+# Logger
+
 config :logger,
   level: :error
+
+# ----------------------------------------------------------------------------
+# Anoma Client Web Endpoint
+
+# Configures the endpoint
+config :anoma_client, Anoma.Client.Web.Endpoint,
+  server: true,
+  adapter: Bandit.PhoenixAdapter,
+  http: [
+    ip: {127, 0, 0, 1},
+    port: 5000
+  ],
+  check_origin: false,
+  debug_errors: false,
+  render_errors: [view: Anoma.Client.Web.ErrorJSON, accepts: ~w(json)]
+
+# ----------------------------------------------------------------------------
+# Anoma Client
+
+config :anoma_client,
+  grpc_port: 41051
+
+# ----------------------------------------------------------------------------
+# Anoma Node
+
+config :anoma_node,
+  grpc_port: 51051
+
+# ----------------------------------------------------------------------------
+# Mnesia
 
 # rocksdb is disabled for testing because it slows tests down too much
 config :anoma_node, :mnesia,


### PR DESCRIPTION
This PR adds config files for dev/test/prod. Jeremy noticed that the ports being used under test were the same as the ones in dev. I took the opportunity to create the proper config scaffolding now. 

The idea is that configs under dev/test are generated at compiletime, and not at runtime. This makes sense because you run the dev/test in the repo itself, which causes a compile cycle every time anyway.

