### PR TITLE
TRM Reads Refactor

### DIFF
--- a/apps/anoma_node/lib/examples/e_shielded_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_shielded_transaction.ex
@@ -28,7 +28,7 @@ defmodule Anoma.Node.Examples.EShieldedTransaction do
     input_nullifier = ESResource.a_resource_nullifier()
 
     assert {:ok, MapSet.new([input_nullifier])} ==
-             Storage.read(node_id, {1, ["anoma", "cairo_nullifiers"]})
+             Storage.read(node_id, {1, ["anoma", "cairo", "nullifiers"]})
 
     output_resource_cm =
       ESResource.a_fixed_output_resource()
@@ -46,12 +46,12 @@ defmodule Anoma.Node.Examples.EShieldedTransaction do
 
     assert {:ok,
             MapSet.new([Anoma.Constants.default_cairo_rm_root(), anchor])} ==
-             Storage.read(node_id, {1, ["anoma", "cairo_roots"]})
+             Storage.read(node_id, {1, ["anoma", "cairo", "roots"]})
 
-    assert {:ok, tree} == Storage.read(node_id, {1, ["anoma", "cairo_ct"]})
+    assert {:ok, tree} == Storage.read(node_id, {1, ["anoma", "cairo", "ct"]})
 
     assert {:ok, set_of_ciphertexts} ==
-             Storage.read(node_id, {1, ["anoma", "cairo_ciphertexts"]})
+             Storage.read(node_id, {1, ["anoma", "cairo", "ciphertexts"]})
 
     EventBroker.unsubscribe_me([])
 
@@ -84,10 +84,10 @@ defmodule Anoma.Node.Examples.EShieldedTransaction do
       |> Anoma.CairoResource.Resource.nullifier(<<1::256>>)
 
     assert {:ok, MapSet.new([input_nullifier_1, input_nullifier_2])} ==
-             Storage.read(node_id, {1, ["anoma", "cairo_nullifiers"]})
+             Storage.read(node_id, {1, ["anoma", "cairo", "nullifiers"]})
 
     assert {:ok, set_of_ciphertexts} ==
-             Storage.read(node_id, {1, ["anoma", "cairo_ciphertexts"]})
+             Storage.read(node_id, {1, ["anoma", "cairo", "ciphertexts"]})
 
     output_cm_1 =
       ESResource.a_fixed_output_resource()
@@ -105,9 +105,9 @@ defmodule Anoma.Node.Examples.EShieldedTransaction do
 
     assert {:ok,
             MapSet.new([Anoma.Constants.default_cairo_rm_root(), anchor])} ==
-             Storage.read(node_id, {1, ["anoma", "cairo_roots"]})
+             Storage.read(node_id, {1, ["anoma", "cairo", "roots"]})
 
-    assert {:ok, tree} == Storage.read(node_id, {1, ["anoma", "cairo_ct"]})
+    assert {:ok, tree} == Storage.read(node_id, {1, ["anoma", "cairo", "ct"]})
     EventBroker.unsubscribe_me([])
 
     node_id
@@ -150,7 +150,7 @@ defmodule Anoma.Node.Examples.EShieldedTransaction do
       |> Anoma.CairoResource.Resource.nullifier(<<1::256>>)
 
     assert {:ok, MapSet.new([input_nullifier_1, input_nullifier_2])} ==
-             Storage.read(node_id, {2, ["anoma", "cairo_nullifiers"]})
+             Storage.read(node_id, {2, ["anoma", "cairo", "nullifiers"]})
 
     output_cm_1 =
       ESResource.a_fixed_output_resource()
@@ -177,15 +177,15 @@ defmodule Anoma.Node.Examples.EShieldedTransaction do
               anchor_1,
               anchor_2
             ])} ==
-             Storage.read(node_id, {2, ["anoma", "cairo_roots"]})
+             Storage.read(node_id, {2, ["anoma", "cairo", "roots"]})
 
-    assert {:ok, tree} == Storage.read(node_id, {2, ["anoma", "cairo_ct"]})
+    assert {:ok, tree} == Storage.read(node_id, {2, ["anoma", "cairo", "ct"]})
 
     set_of_ciphertexts =
       MapSet.union(set_of_ciphertexts1, set_of_ciphertexts2)
 
     assert {:ok, set_of_ciphertexts} ==
-             Storage.read(node_id, {2, ["anoma", "cairo_ciphertexts"]})
+             Storage.read(node_id, {2, ["anoma", "cairo", "ciphertexts"]})
 
     EventBroker.unsubscribe_me([])
 

--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -415,7 +415,7 @@ defmodule Anoma.Node.Examples.ETransaction do
 
     assert {:ok,
             Anoma.RM.Transparent.Primitive.CommitmentAccumulator.value(cms)} ==
-             Storage.read(node_id, {1, ["anoma", "transparent", "anchor"]})
+             Storage.read(node_id, {1, ["anoma", "transparent", "roots"]})
 
     EventBroker.unsubscribe_me([])
 

--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -414,7 +414,7 @@ defmodule Anoma.Node.Examples.ETransaction do
              )
 
     assert {:ok,
-            Anoma.RM.Transparent.Primitive.CommitmentAccumulator.value(cms)} ==
+            [Anoma.RM.Transparent.Primitive.CommitmentAccumulator.value(cms)]} ==
              Storage.read(node_id, {1, ["anoma", "transparent", "roots"]})
 
     EventBroker.unsubscribe_me([])

--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -394,18 +394,28 @@ defmodule Anoma.Node.Examples.ETransaction do
     base_swap = ETransaction.swap_from_actions()
 
     assert {:ok, base_swap |> Transaction.nullifiers()} ==
-             Storage.read(node_id, {1, ["anoma", "nullifiers"]})
+             Storage.read(
+               node_id,
+               {1, ["anoma", "transparent", "nullifiers"]}
+             )
 
     assert {:ok, base_swap |> Transaction.commitments()} ==
-             Storage.read(node_id, {1, ["anoma", "commitments"]})
+             Storage.read(
+               node_id,
+               {1, ["anoma", "transparent", "commitments"]}
+             )
 
     cms = base_swap |> Transaction.commitments()
 
-    assert {:ok, cms} == Storage.read(node_id, {1, ["anoma", "commitments"]})
+    assert {:ok, cms} ==
+             Storage.read(
+               node_id,
+               {1, ["anoma", "transparent", "commitments"]}
+             )
 
     assert {:ok,
             Anoma.RM.Transparent.Primitive.CommitmentAccumulator.value(cms)} ==
-             Storage.read(node_id, {1, ["anoma", "anchor"]})
+             Storage.read(node_id, {1, ["anoma", "transparent", "anchor"]})
 
     EventBroker.unsubscribe_me([])
 

--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -288,7 +288,7 @@ defmodule Anoma.Node.Transaction.Backends do
         end
 
       writes = [
-        {transparent_keyspace("anchor"),
+        {transparent_keyspace("roots"),
          TAcc.value(
            MapSet.union(
              map.commitments,
@@ -413,7 +413,7 @@ defmodule Anoma.Node.Transaction.Backends do
              :mnesia.transaction(fn ->
                :mnesia.match_object(
                  {Storage.values_table(node_id),
-                  {:_, transparent_keyspace("anchor")}, root}
+                  {:_, transparent_keyspace("roots")}, root}
                )
              end) do
         {:cont, acc}

--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -250,7 +250,7 @@ defmodule Anoma.Node.Transaction.Backends do
          true <- TTransaction.verify(tx),
          # possibly also add check for CU roots
          true <- storage_check(node_id, id, tx),
-         true <- verify_tx_root(node_id, tx) do
+         true <- verify_tx_root(node_id, id, tx) do
       map =
         for action <- tx.actions,
             reduce: %{
@@ -287,14 +287,23 @@ defmodule Anoma.Node.Transaction.Backends do
           {:ok, res} -> res
         end
 
+      old_roots =
+        case Ordering.read(node_id, {id, transparent_keyspace("roots")}) do
+          :absent -> []
+          {:ok, res} -> res
+        end
+
       writes = [
         {transparent_keyspace("roots"),
-         TAcc.value(
-           MapSet.union(
-             map.commitments,
-             old_cms
+         [
+           TAcc.value(
+             MapSet.union(
+               map.commitments,
+               old_cms
+             )
            )
-         )}
+           | old_roots
+         ]}
         | map.blobs
       ]
 
@@ -326,10 +335,10 @@ defmodule Anoma.Node.Transaction.Backends do
     end
   end
 
-  @spec verify_tx_root(String.t(), TTransaction.t()) ::
+  @spec verify_tx_root(String.t(), binary(), TTransaction.t()) ::
           true | {:error, String.t()}
-  defp verify_tx_root(node_id, trans = %TTransaction{}) do
-    with true <- roots_exist?(node_id, trans) do
+  defp verify_tx_root(node_id, id, trans = %TTransaction{}) do
+    with true <- roots_exist?(node_id, id, trans) do
       true
     else
       {:error, msg} ->
@@ -392,10 +401,11 @@ defmodule Anoma.Node.Transaction.Backends do
     end
   end
 
-  @spec roots_exist?(String.t(), TTransaction.t()) ::
+  @spec roots_exist?(String.t(), binary(), TTransaction.t()) ::
           true | {:error, String.t()}
   defp roots_exist?(
          node_id,
+         id,
          trans = %TTransaction{}
        ) do
     roots =
@@ -408,17 +418,17 @@ defmodule Anoma.Node.Transaction.Backends do
           |> MapSet.union(acc)
       end
 
+    committed_roots =
+      case Ordering.read(node_id, {id, transparent_keyspace("roots")}) do
+        :absent -> []
+        {:ok, res} -> res
+      end
+
     Enum.reduce_while(roots, true, fn root, acc ->
-      with {:atomic, [{_, {_, _}, ^root}]} <-
-             :mnesia.transaction(fn ->
-               :mnesia.match_object(
-                 {Storage.values_table(node_id),
-                  {:_, transparent_keyspace("roots")}, root}
-               )
-             end) do
+      if Enum.any?(committed_roots, &Noun.equal?(&1, root)) do
         {:cont, acc}
       else
-        {:atomic, []} -> {:halt, {:error, "Root #{inspect(root)} is absent"}}
+        {:halt, {:error, "Root #{inspect(root)} is absent"}}
       end
     end)
   end

--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -282,13 +282,13 @@ defmodule Anoma.Node.Transaction.Backends do
         end
 
       old_cms =
-        case Ordering.read(node_id, {id, anoma_keyspace("commitments")}) do
+        case Ordering.read(node_id, {id, transparent_keyspace("commitments")}) do
           :absent -> MapSet.new()
           {:ok, res} -> res
         end
 
       writes = [
-        {anoma_keyspace("anchor"),
+        {transparent_keyspace("anchor"),
          TAcc.value(
            MapSet.union(
              map.commitments,
@@ -303,8 +303,8 @@ defmodule Anoma.Node.Transaction.Backends do
         {id,
          %{
            append: [
-             {anoma_keyspace("nullifiers"), map.nullifiers},
-             {anoma_keyspace("commitments"), map.commitments}
+             {transparent_keyspace("nullifiers"), map.nullifiers},
+             {transparent_keyspace("commitments"), map.commitments}
            ],
            write: writes
          }}
@@ -341,13 +341,13 @@ defmodule Anoma.Node.Transaction.Backends do
           true | {:error, String.t()}
   defp storage_check(node_id, id, trans) do
     stored_commitments =
-      case Ordering.read(node_id, {id, anoma_keyspace("commitments")}) do
+      case Ordering.read(node_id, {id, transparent_keyspace("commitments")}) do
         :absent -> MapSet.new()
         {:ok, res} -> res
       end
 
     stored_nullifiers =
-      case Ordering.read(node_id, {id, anoma_keyspace("nullifiers")}) do
+      case Ordering.read(node_id, {id, transparent_keyspace("nullifiers")}) do
         :absent -> MapSet.new()
         {:ok, res} -> res
       end
@@ -413,7 +413,7 @@ defmodule Anoma.Node.Transaction.Backends do
              :mnesia.transaction(fn ->
                :mnesia.match_object(
                  {Storage.values_table(node_id),
-                  {:_, anoma_keyspace("anchor")}, root}
+                  {:_, transparent_keyspace("anchor")}, root}
                )
              end) do
         {:cont, acc}
@@ -474,7 +474,7 @@ defmodule Anoma.Node.Transaction.Backends do
          # No need to check the commitment existence
          true <- nullifier_existence_check(tx, node_id, id) do
       {ct, append_roots} =
-        case Ordering.read(node_id, {id, anoma_keyspace("cairo_ct")}) do
+        case Ordering.read(node_id, {id, cairo_keyspace("ct")}) do
           :absent ->
             {CTransaction.cm_tree(),
              MapSet.new([Anoma.Constants.default_cairo_rm_root()])}
@@ -501,8 +501,7 @@ defmodule Anoma.Node.Transaction.Backends do
               Noun.equal?(deletion, <<1::256>>)
             end)
             |> Enum.map(fn {value, _} ->
-              {["anoma", "blob", "cairo", :crypto.hash(:sha256, value)],
-               value}
+              {["anoma", "blob", :crypto.hash(:sha256, value)], value}
             end)
           end)
         end)
@@ -512,12 +511,11 @@ defmodule Anoma.Node.Transaction.Backends do
         {id,
          %{
            append: [
-             {anoma_keyspace("cairo_nullifiers"), nullifiers},
-             {anoma_keyspace("cairo_roots"),
-              MapSet.put(append_roots, anchor)},
-             {anoma_keyspace("cairo_ciphertexts"), ciphertexts}
+             {cairo_keyspace("nullifiers"), nullifiers},
+             {cairo_keyspace("roots"), MapSet.put(append_roots, anchor)},
+             {cairo_keyspace("ciphertexts"), ciphertexts}
            ],
-           write: [{anoma_keyspace("cairo_ct"), ct_new} | write_app_data]
+           write: [{cairo_keyspace("ct"), ct_new} | write_app_data]
          }}
       )
 
@@ -544,7 +542,7 @@ defmodule Anoma.Node.Transaction.Backends do
           true | {:error, String.t()}
   def nullifier_existence_check(transaction, node_id, id) do
     with {:ok, stored_nullifiers} <-
-           Ordering.read(node_id, {id, anoma_keyspace("cairo_nullifiers")}) do
+           Ordering.read(node_id, {id, cairo_keyspace("nullifiers")}) do
       if Enum.any?(
            CTransaction.nullifiers(transaction),
            &MapSet.member?(stored_nullifiers, &1)
@@ -563,7 +561,7 @@ defmodule Anoma.Node.Transaction.Backends do
           true | {:error, String.t()}
   def root_existence_check(transaction, node_id, id) do
     stored_roots =
-      case Ordering.read(node_id, {id, anoma_keyspace("cairo_roots")}) do
+      case Ordering.read(node_id, {id, cairo_keyspace("roots")}) do
         :absent -> MapSet.new([Anoma.Constants.default_cairo_rm_root()])
         {:ok, val} -> val
       end
@@ -696,8 +694,18 @@ defmodule Anoma.Node.Transaction.Backends do
     val == value(w) and MapSet.member?(w, cm)
   end
 
-  @spec anoma_keyspace(String.t()) :: list(String.t())
+  @spec cairo_keyspace(String.t()) :: list(String.t())
+  defp cairo_keyspace(key) do
+    anoma_keyspace(["cairo", key])
+  end
+
+  @spec transparent_keyspace(String.t()) :: list(String.t())
+  defp transparent_keyspace(key) do
+    anoma_keyspace(["transparent", key])
+  end
+
+  @spec anoma_keyspace(list(String.t())) :: list(String.t())
   defp anoma_keyspace(key) do
-    ["anoma", key]
+    ["anoma" | key]
   end
 end

--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -248,9 +248,25 @@ defmodule Anoma.Node.Transaction.Backends do
   defp transparent_resource_tx(node_id, id, result) do
     with {:ok, tx} <- TTransaction.from_noun(result),
          true <- TTransaction.verify(tx),
+         cms <-
+           read_with_default(
+             node_id,
+             id,
+             transparent_keyspace("commitments"),
+             MapSet.new()
+           ),
+         nlfs <-
+           read_with_default(
+             node_id,
+             id,
+             transparent_keyspace("nullifiers"),
+             MapSet.new()
+           ),
          # possibly also add check for CU roots
-         true <- storage_check(node_id, id, tx),
-         true <- verify_tx_root(node_id, id, tx) do
+         true <- storage_check(tx, cms, nlfs),
+         roots <-
+           read_with_default(node_id, id, transparent_keyspace("roots"), []),
+         true <- verify_tx_root(tx, roots) do
       map =
         for action <- tx.actions,
             reduce: %{
@@ -281,28 +297,16 @@ defmodule Anoma.Node.Transaction.Backends do
             }
         end
 
-      old_cms =
-        case Ordering.read(node_id, {id, transparent_keyspace("commitments")}) do
-          :absent -> MapSet.new()
-          {:ok, res} -> res
-        end
-
-      old_roots =
-        case Ordering.read(node_id, {id, transparent_keyspace("roots")}) do
-          :absent -> []
-          {:ok, res} -> res
-        end
-
       writes = [
         {transparent_keyspace("roots"),
          [
            TAcc.value(
              MapSet.union(
                map.commitments,
-               old_cms
+               cms
              )
            )
-           | old_roots
+           | roots
          ]}
         | map.blobs
       ]
@@ -335,10 +339,10 @@ defmodule Anoma.Node.Transaction.Backends do
     end
   end
 
-  @spec verify_tx_root(String.t(), binary(), TTransaction.t()) ::
+  @spec verify_tx_root(TTransaction.t(), list(Noun.t())) ::
           true | {:error, String.t()}
-  defp verify_tx_root(node_id, id, trans = %TTransaction{}) do
-    with true <- roots_exist?(node_id, id, trans) do
+  defp verify_tx_root(trans = %TTransaction{}, roots) do
+    with true <- roots_exist?(trans, roots) do
       true
     else
       {:error, msg} ->
@@ -346,21 +350,9 @@ defmodule Anoma.Node.Transaction.Backends do
     end
   end
 
-  @spec storage_check(String.t(), binary(), TTransaction.t()) ::
+  @spec storage_check(TTransaction.t(), MapSet.t(), MapSet.t()) ::
           true | {:error, String.t()}
-  defp storage_check(node_id, id, trans) do
-    stored_commitments =
-      case Ordering.read(node_id, {id, transparent_keyspace("commitments")}) do
-        :absent -> MapSet.new()
-        {:ok, res} -> res
-      end
-
-    stored_nullifiers =
-      case Ordering.read(node_id, {id, transparent_keyspace("nullifiers")}) do
-        :absent -> MapSet.new()
-        {:ok, res} -> res
-      end
-
+  defp storage_check(trans, stored_commitments, stored_nullifiers) do
     {:ok, precis} = TTransaction.action_precis(trans)
 
     with true <-
@@ -401,12 +393,11 @@ defmodule Anoma.Node.Transaction.Backends do
     end
   end
 
-  @spec roots_exist?(String.t(), binary(), TTransaction.t()) ::
+  @spec roots_exist?(TTransaction.t(), list(Noun.t())) ::
           true | {:error, String.t()}
   defp roots_exist?(
-         node_id,
-         id,
-         trans = %TTransaction{}
+         trans = %TTransaction{},
+         committed_roots
        ) do
     roots =
       for action <- trans.actions, reduce: MapSet.new() do
@@ -416,12 +407,6 @@ defmodule Anoma.Node.Transaction.Backends do
             l_acc -> TCU.roots(compliance_unit) |> MapSet.union(l_acc)
           end
           |> MapSet.union(acc)
-      end
-
-    committed_roots =
-      case Ordering.read(node_id, {id, transparent_keyspace("roots")}) do
-        :absent -> []
-        {:ok, res} -> res
       end
 
     Enum.reduce_while(roots, true, fn root, acc ->
@@ -702,6 +687,14 @@ defmodule Anoma.Node.Transaction.Backends do
   @spec verify(binary(), MapSet.t(), binary()) :: bool()
   def verify(cm, w, val) do
     val == value(w) and MapSet.member?(w, cm)
+  end
+
+  @spec read_with_default(String.t(), binary(), list(), any()) :: any()
+  defp read_with_default(node_id, tx_id, key, default) do
+    case Ordering.read(node_id, {tx_id, key}) do
+      :absent -> default
+      {:ok, val} -> val
+    end
   end
 
   @spec cairo_keyspace(String.t()) :: list(String.t())


### PR DESCRIPTION
Now we read RM keyspaces only once during evaluation and put them
inside a `with` statement for succesful reading