### PR TITLE
Bugfix: Local writes provide wrap values in blob keyspace

### DIFF
--- a/apps/anoma_client/lib/client/nock/runner.ex
+++ b/apps/anoma_client/lib/client/nock/runner.ex
@@ -58,7 +58,7 @@ defmodule Anoma.Client.Runner do
         |> Transaction.app_data()
         |> Enum.filter(fn {_, bool} -> bool end)
         |> Enum.each(fn {bin, _} ->
-          Storage.write({:crypto.hash(:sha256, bin), bin})
+          Storage.write({["anoma", "blob", :crypto.hash(:sha256, bin)], bin})
         end)
 
         :ok

--- a/apps/anoma_client/lib/examples/e_client/nock/scry.ex
+++ b/apps/anoma_client/lib/examples/e_client/nock/scry.ex
@@ -53,7 +53,10 @@ defmodule Anoma.Client.Examples.EClient.Nock.Scry do
 
     # assert the storage value
     assert {:ok, string} ==
-             Storage.read({System.os_time(), :crypto.hash(:sha256, string)})
+             Storage.read(
+               {System.os_time(),
+                ["anoma", "blob", :crypto.hash(:sha256, string)]}
+             )
 
     client
   end


### PR DESCRIPTION
Previously the information in appdata was stored by hashing directly. Instead, we should provide the same keyspaces globally availiable for seemless scrying.