### PR TITLE
BugFix: Cairo Transactions Not Assumed to Have Hash Fields

### DIFF
--- a/apps/anoma_node/lib/node/transaction/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends.ex
@@ -527,8 +527,8 @@ defmodule Anoma.Node.Transaction.Backends do
       # TODO: Store ciphertext
 
       cairo_rm_event(
-        MapSet.new(tx.commitments),
-        MapSet.new(tx.nullifiers),
+        MapSet.new(commitments),
+        nullifiers,
         node_id
       )
 


### PR DESCRIPTION
This assumption after field removal made transactions fail inappropriately.