### PR TITLE
Fix types for vm result

### DIFF
--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -26,7 +26,7 @@ defmodule Anoma.Node.Examples.ETransaction do
     field(:id, binary())
     field(:backend, Backends.backend())
     field(:noun, Noun.t())
-    field(:result, Mempool.vm_result())
+    field(:result, Mempool.tx_result())
   end
 
   ############################################################

--- a/apps/anoma_node/lib/examples/serializing/events/backends.ex
+++ b/apps/anoma_node/lib/examples/serializing/events/backends.ex
@@ -14,7 +14,7 @@ defmodule Anoma.Node.Examples.Serializing.Events.Backends do
   """
   @spec result_event_error :: Events.ResultEvent.t()
   def result_event_error do
-    result_event = %Events.ResultEvent{tx_id: "foo", vm_result: :error}
+    result_event = %Events.ResultEvent{tx_id: "foo", vm_result: :vm_error}
     _json = Jason.encode!(result_event)
     result_event
   end

--- a/apps/anoma_node/lib/node/transaction/backends/events.ex
+++ b/apps/anoma_node/lib/node/transaction/backends/events.ex
@@ -69,7 +69,7 @@ defmodule Anoma.Node.Transaction.Backends.Events do
                               {:ok, value} tuple.
     """
     field(:tx_id, binary())
-    field(:tx_result, Mempool.vm_result())
+    field(:tx_result, Mempool.tx_result())
   end
 
   defimpl Jason.Encoder, for: CompleteEvent do

--- a/apps/anoma_node/lib/node/transaction/mempool/mempool.ex
+++ b/apps/anoma_node/lib/node/transaction/mempool/mempool.ex
@@ -46,7 +46,7 @@ defmodule Anoma.Node.Transaction.Mempool do
   @typedoc """
   I am the type of the Nock VM result.
   """
-  @type vm_result :: {:ok, Noun.t()} | :error | :in_progress
+  @type vm_result :: {:ok, Noun.t()} | :vm_error | :in_progress
 
   @typedoc """
   I am the type of the transaction result.


### PR DESCRIPTION
There was an error in the types for the vm result, and I added some wrong code, too. This fixes that.