### PR TITLE
Remove lost and found `IO.puts`

### DIFF
--- a/apps/anoma_client/lib/client/grpc/pubsub.ex
+++ b/apps/anoma_client/lib/client/grpc/pubsub.ex
@@ -17,7 +17,6 @@ defmodule Anoma.Client.GRPC.PubSub do
   @spec publish(Event.Request.t(), Stream.t()) :: Event.Response.t()
   def publish(request, _stream) do
     Logger.debug("GRPC #{inspect(__ENV__.function)}: #{inspect(request)}")
-    IO.puts("got an event: #{inspect(request)}")
     topic = request.topic.topic
     event = :erlang.binary_to_term(request.message.message)
 


### PR DESCRIPTION
I added an `IO.puts` that was already on base, and this PR removes it.

Black mark of shame for me.