### PR TITLE
Add a `wrap` flag to the mempool to wrap transactions in a transaction candidate before submitting

### DIFF
--- a/apps/anoma_client/lib/client/node/grpc_proxy.ex
+++ b/apps/anoma_client/lib/client/node/grpc_proxy.ex
@@ -111,11 +111,11 @@ defmodule Anoma.Client.Node.GRPCProxy do
     GenServer.call(__MODULE__, {:add_intent, intent})
   end
 
-  @spec add_transaction(binary(), atom()) :: any()
-  def add_transaction(jammed_nock, transaction_type) do
+  @spec add_transaction(binary(), atom(), boolean()) :: any()
+  def add_transaction(jammed_nock, transaction_type, wrap? \\ false) do
     GenServer.call(
       __MODULE__,
-      {:add_transaction, jammed_nock, transaction_type}
+      {:add_transaction, jammed_nock, transaction_type, wrap?}
     )
   end
 
@@ -149,17 +149,14 @@ defmodule Anoma.Client.Node.GRPCProxy do
     {:reply, result, state}
   end
 
-  def handle_call(
-        {:add_transaction, transaction, transaction_type},
-        _from,
-        state
-      ) do
+  def handle_call({:add_transaction, transaction, type, wrap}, _from, state) do
     result =
       RPC.add_transaction(
         state.channel,
         state.node_id,
         transaction,
-        transaction_type
+        type,
+        wrap
       )
 
     {:reply, result, state}

--- a/apps/anoma_client/lib/client/node/rpc.ex
+++ b/apps/anoma_client/lib/client/node/rpc.ex
@@ -92,9 +92,9 @@ defmodule Anoma.Client.Node.RPC do
   I make a call to a GRPC endpoint to add a transaction to the mempool of the
   node.
   """
-  @spec add_transaction(any(), String.t(), binary(), atom()) ::
+  @spec add_transaction(any(), String.t(), binary(), atom(), boolean()) ::
           {:ok, :added} | {:error, :add_transaction_failed, String.t()}
-  def add_transaction(channel, node_id, transaction, transaction_type) do
+  def add_transaction(channel, node_id, transaction, transaction_type, wrap) do
     node = %Node{id: node_id}
 
     transaction = %Transaction{transaction: transaction}
@@ -102,7 +102,8 @@ defmodule Anoma.Client.Node.RPC do
     request = %Mempool.Add.Request{
       node: node,
       transaction: transaction,
-      transaction_type: transaction_type
+      transaction_type: transaction_type,
+      wrap: wrap
     }
 
     case MempoolService.Stub.add(channel, request) do

--- a/apps/anoma_client/lib/client/web/controllers/mempool/mempool.ex
+++ b/apps/anoma_client/lib/client/web/controllers/mempool/mempool.ex
@@ -40,10 +40,11 @@ defmodule Anoma.Client.Web.MempoolController do
   @spec add_transaction(any(), nil | maybe_improper_list() | map()) :: any()
   def add_transaction(conn, params) do
     with %{"transaction" => tx} <- params,
+         wrap? <- Map.get(params, "wrap", false),
          type <- String.to_existing_atom(params["transaction_type"]),
          {:ok, transaction} <- Base.decode64(tx),
          {:ok, :added} <-
-           GRPCProxy.add_transaction(transaction, type) do
+           GRPCProxy.add_transaction(transaction, type, wrap?) do
       render(conn, "add_transaction.json")
     end
   end

--- a/apps/anoma_client/lib/client/web/controllers/mempool/spec.ex
+++ b/apps/anoma_client/lib/client/web/controllers/mempool/spec.ex
@@ -20,6 +20,11 @@ defmodule Anoma.Client.Web.MempoolController.Spec do
           description:
             "Base64 encoded, jammed nock representing a transaction"
         },
+        wrap: %Schema{
+          type: :bool,
+          description:
+            "If this flag is set, it will wrap the transaction in a transaction candidate before submitting it to the mempool."
+        },
         transaction_type: %Schema{
           type: :string,
           description: "The type of the transaction",
@@ -30,7 +35,8 @@ defmodule Anoma.Client.Web.MempoolController.Spec do
       required: [:transaction],
       example: %{
         "transaction" => @example_intent,
-        "transaction_type" => "transparent_resource"
+        "transaction_type" => "transparent_resource",
+        "wrap" => false
       }
     })
   end

--- a/apps/anoma_node/lib/node/transport/grpc/endpoint/mempool.ex
+++ b/apps/anoma_node/lib/node/transport/grpc/endpoint/mempool.ex
@@ -24,6 +24,9 @@ defmodule Anoma.Node.Transport.GRPC.Servers.Mempool do
 
     # create the transaction from the noun
     noun = Jam.cue!(request.transaction.transaction)
+
+    noun = if request.wrap, do: wrap_transaction(noun), else: noun
+
     transaction = {request.transaction_type, noun}
 
     # submit the transaction to the mempool
@@ -34,5 +37,13 @@ defmodule Anoma.Node.Transport.GRPC.Servers.Mempool do
     %Add.Response{}
   rescue
     e -> raise_grpc_error!(e)
+  end
+
+  # @doc """
+  # I wrap a transaction into a noun that makes it into a transaction candidate.
+  # """
+  @spec wrap_transaction(Noun.t()) :: Noun.t()
+  defp wrap_transaction(transaction) do
+    [[1, 0, [1 | transaction], 0 | 909], 0 | 707]
   end
 end

--- a/apps/anoma_protobuf/priv/protobuf/mempool.proto
+++ b/apps/anoma_protobuf/priv/protobuf/mempool.proto
@@ -23,6 +23,7 @@ message Add {
     Node node = 1;
     Transaction transaction = 2;
     TransactionType transaction_type = 3;
+    bool wrap = 4;
   }
 
   message Response { string result = 1; }


### PR DESCRIPTION
Solvers in particular don't know how to create a transaction candidate from a transaction binary without having a full nock infrastructure available. 

I updated the mempool api to pass in a flag "wrap" that will wrap the transaction in a transaction candidate before submitting it. 
