### PR TITLE
BugFix: Incorrect from_json_noun Return

### DIFF
--- a/apps/anoma_lib/lib/noun/nounable.ex
+++ b/apps/anoma_lib/lib/noun/nounable.ex
@@ -269,7 +269,10 @@ defimpl Nounable, for: Jason.OrderedObject do
     do: {:ok, %Jason.OrderedObject{}}
 
   def from_noun(o) do
-    from_json_noun(o)
+    case from_json_noun(o) do
+      :error -> :error
+      jason -> {:ok, jason}
+    end
   end
 
   defp from_json_noun(["o" | list]) do


### PR DESCRIPTION
Previously returned `result` plain, now returns `{:ok, result}`