### PR TITLE
BugFix: cairo_prove_delta Nounifies Result

### DIFF
--- a/apps/anoma_lib/lib/nock/jets.ex
+++ b/apps/anoma_lib/lib/nock/jets.ex
@@ -991,7 +991,12 @@ defmodule Nock.Jets do
   def cairo_prove_delta(core) do
     with {:ok, sample} <- sample(core),
          {:ok, cairo_tx} <- CairoResource.Transaction.from_noun(sample) do
-      {:ok, CairoResource.Transaction.prove_delta(cairo_tx)}
+      tx =
+        cairo_tx
+        |> CairoResource.Transaction.prove_delta()
+        |> Noun.Nounable.to_noun()
+
+      {:ok, tx}
     else
       _ -> :error
     end


### PR DESCRIPTION
Before the output of cairo_prove_delta was not a noun.