### PR TITLE
Fix bug where Cue fails

### DIFF
--- a/apps/anoma_lib/lib/nock/jets.ex
+++ b/apps/anoma_lib/lib/nock/jets.ex
@@ -448,7 +448,7 @@ defmodule Nock.Jets do
 
     case maybe_sample do
       {:ok, sample} when is_noun_atom(sample) ->
-        Noun.Jam.cue(sample)
+        Noun.Jam.cue(sample |> Noun.atom_integer_to_binary())
 
       _ ->
         :error


### PR DESCRIPTION
Introduced because the new Cue only takes binary

> Noun.Jam.cue(105128044753814370304047833304315174184869094258555698820435096100953339290075418152589504897156357)

{:error,
 %ArgumentError{
   message: "errors were found at the given arguments:\n\n  * 1st argument: not a binary\n"
 }}

This should instead work as intended without needing to manually call Noun.atom_integer_to_binary

iex(mariar@Gensokyo)14> Noun.Jam.cue(sample |> Noun.atom_integer_to_binary) {:ok,
 [
   [
     " " |
     <<159, 203, 102, 222, 31, 58, 246, 185, 90, 6, 43, 237, 124, 216, 196, 252,
       111, 92, 6, 5, 241, 177, 57, 28, 183, 188, 19, 181, 95, 210, 50, 134>>
   ] |
   "bob"
 ]}