### PR TITLE
docs: replace broken HexDocs links with GitHub sources for `compile_protoc` and `anoma_lib`

### DIFF
--- a/apps/anoma_lib/README.md
+++ b/apps/anoma_lib/README.md
@@ -20,4 +20,4 @@ end
 
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/anoma_lib>.
+be found at <https://github.com/anoma/anoma/tree/base/apps/anoma_lib>.

--- a/apps/compile_protoc/README.md
+++ b/apps/compile_protoc/README.md
@@ -17,4 +17,4 @@ end
 
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/compile_protoc>.
+be found at <https://github.com/anoma/anoma/tree/base/apps/compile_protoc>.


### PR DESCRIPTION
Hi, I’ve updated the documentation by swapping the outdated HexDocs URLs for `compile_protoc` and `anoma_lib` with direct links to their GitHub directories. This eliminates 404s and lets contributors reach the source code instantly—no functional changes, docs only.






