### PR TITLE
Murisi/release anoma client rebased

### DIFF
--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -33,8 +33,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 50
-      - uses: erlef/setup-beam@v1.18.2
-        if: startsWith(runner.os, 'Linux') || startsWith(runner.os, 'Windows')
+      - uses: erlef/setup-beam@6e1d5a5aa63e46e2579c0a01718a1376fb24354f
         with:
           otp-version: ${{ inputs.otp-version }}
           elixir-version: ${{ inputs.elixir-version }}
@@ -45,7 +44,7 @@ jobs:
       - name: Install system dependencies
         shell: bash
         if: startsWith(runner.os, 'macOS')
-        run: brew install elixir protobuf
+        run: brew install protobuf
       - name: Install system dependencies
         shell: pwsh
         if: startsWith(runner.os, 'Windows')

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -63,6 +63,10 @@ jobs:
         run: |
           export PATH="$PATH:$HOME/.mix/escripts"
           mix release
+      - name: Copy shared libraries
+        if: startsWith(runner.os, 'macOS')
+        shell: bash
+        run: ./scripts/copy-dylibs.zsh _build/dev/rel/anoma
       - name: Build Anoma release
         if: startsWith(runner.os, 'Windows')
         shell: pwsh

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -66,7 +66,9 @@ jobs:
       - name: Copy shared libraries
         if: startsWith(runner.os, 'macOS')
         shell: bash
-        run: ./scripts/copy-dylibs.zsh _build/dev/rel/anoma
+        run: |
+           ./scripts/copy-dylibs.zsh _build/dev/rel/anoma
+           cp ./scripts/anomac _build/dev/rel/anoma/bin/
       - name: Copy shared libraries and client
         if: startsWith(runner.os, 'Linux')
         shell: bash

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -89,14 +89,18 @@ jobs:
         shell: pwsh
         run: |
           cd _build/dev/rel/
-          tar czf anoma.tar.gz anoma
-          shasum -a 1 anoma.tar.gz > anoma.tar.gz.sha1sum
-          shasum -a 256 anoma.tar.gz > anoma.tar.gz.sha256sum
+          tar czf ($env:ARTIFACT_NAME + '.tar.gz') anoma
+          shasum -a 1 ($env:ARTIFACT_NAME + '.tar.gz') > ($env:ARTIFACT_NAME + '.tar.gz.sha1sum')
+          shasum -a 256 ($env:ARTIFACT_NAME + '.tar.gz') > ($env:ARTIFACT_NAME + '.tar.gz.sha256sum')
+        env:
+          ARTIFACT_NAME: anoma-${{ github.ref_name }}-${{ runner.os }}-${{ runner.arch }}
       - name: Create Anoma release artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: anoma-${{ github.ref_name }}-${{ runner.os }}-${{ runner.arch }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: |
-            _build/dev/rel/anoma.tar.gz
-            _build/dev/rel/anoma.tar.gz.sha1sum
-            _build/dev/rel/anoma.tar.gz.sha256sum
+            _build/dev/rel/${{ env.ARTIFACT_NAME }}.tar.gz
+            _build/dev/rel/${{ env.ARTIFACT_NAME }}.tar.gz.sha1sum
+            _build/dev/rel/${{ env.ARTIFACT_NAME }}.tar.gz.sha256sum
+        env:
+          ARTIFACT_NAME: anoma-${{ github.ref_name }}-${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -6,6 +6,7 @@
 # - mix-env: The environment to build the release for.
 # - elixir-version: The version of Elixir to use.
 # - otp-version: The version of OTP to use.
+# - os: The operating system to build for.
 name: Build Release
 on:
   workflow_call:
@@ -22,47 +23,70 @@ on:
       release_name:
         required: true
         type: string
+      os:
+        required: true
+        type: string
 jobs:
   build_release:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.os }}
     steps:
-      - name: checkout the repository
-        uses: actions/checkout@v4
-
-      - name: setup deps and _build cache
-        uses: actions/cache@v4
+      - uses: actions/checkout@v4
         with:
-          path: |
-            ${{ github.workspace }}/deps
-            ${{ github.workspace }}/_build
-          key: ${{ runner.os }}-build-${{ inputs.mix-env }}-${{ hashFiles('mix.lock') }}
-
-      - name: setup elixir
-        uses: ./.github/actions/elixir_setup
+          fetch-depth: 50
+      - uses: erlef/setup-beam@v1.18.2
+        if: startsWith(runner.os, 'Linux') || startsWith(runner.os, 'Windows')
         with:
-          elixir-version: ${{ inputs.elixir-version }}
           otp-version: ${{ inputs.otp-version }}
-
-      - name: install apt packages
-        uses: ./.github/actions/os_setup
-
-      #---------------------------------------------------------------------------
-      # Create binaries
-      #
-      # This part of the action generates all the binaries that are necessary
-      # for a release.
-      # If these need to be compiled for different elixir versions, the matrix
-      # should be put in the on_release.yml file.
-
-      - name: create the client binary
-        continue-on-error: false
+          elixir-version: ${{ inputs.elixir-version }}
+      - name: Install system dependencies
+        shell: bash
+        if: startsWith(runner.os, 'Linux')
+        run: sudo apt install -y libsodium-dev protobuf-compiler
+      - name: Install system dependencies
+        shell: bash
+        if: startsWith(runner.os, 'macOS')
+        run: brew install elixir protobuf
+      - name: Install system dependencies
+        shell: pwsh
+        if: startsWith(runner.os, 'Windows')
+        run: |
+          choco install protoc
+          vcpkg install libsodium
+      - name: Install Elixir dependencies
         shell: bash
         run: |
-          MIX_ENV=prod mix do --app anoma_client escript.build
-          mv "apps/anoma_client/anoma_client" "apps/anoma_client/anoma_client-elixir-${{ inputs.elixir-version }}-otp-${{ inputs.otp-version }}"
-
-      - name: create artifact of the client binary
+          mix deps.get --force
+          mix escript.install hex protobuf 0.11.0 --force
+      - name: Build Anoma release
+        if: startsWith(runner.os, 'Linux') || startsWith(runner.os, 'macOS')
+        shell: bash
+        run: |
+          export PATH="$PATH:$HOME/.mix/escripts"
+          mix release
+      - name: Build Anoma release
+        if: startsWith(runner.os, 'Windows')
+        shell: pwsh
+        run: |
+          & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1" -Arch amd64 -SkipAutomaticLocation
+          $env:PATH += $env:USERPROFILE + '\.mix\escripts;'
+          $env:INCLUDE += ';' + $env:VCPKG_INSTALLATION_ROOT + '\packages\libsodium_x64-windows\include'
+          $LIBSODIUM_LIB = $env:VCPKG_INSTALLATION_ROOT + '\packages\libsodium_x64-windows\lib'
+          $env:LIB += ';' + $LIBSODIUM_LIB
+          copy ($LIBSODIUM_LIB + '\libsodium.lib') ($LIBSODIUM_LIB + '\libsodium.dll.a')
+          $env:DEBUG = '1'
+          mix release
+      - name: Compute SHA hashes
+        shell: pwsh
+        run: |
+          cd _build/dev/rel/
+          tar czf anoma.tar.gz anoma
+          shasum -a 1 anoma.tar.gz > anoma.tar.gz.sha1sum
+          shasum -a 256 anoma.tar.gz > anoma.tar.gz.sha256sum
+      - name: Create Anoma release artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: anoma_client-elixir-${{ inputs.elixir-version }}-otp-${{ inputs.otp-version }}
-          path: "apps/anoma_client/anoma_client-elixir-${{ inputs.elixir-version }}-otp-${{ inputs.otp-version }}"
+          name: anoma-${{ github.ref_name }}-${{ runner.os }}-${{ runner.arch }}
+          path: |
+            _build/dev/rel/anoma.tar.gz
+            _build/dev/rel/anoma.tar.gz.sha1sum
+            _build/dev/rel/anoma.tar.gz.sha256sum

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -67,10 +67,12 @@ jobs:
         if: startsWith(runner.os, 'macOS')
         shell: bash
         run: ./scripts/copy-dylibs.zsh _build/dev/rel/anoma
-      - name: Copy shared libraries
+      - name: Copy shared libraries and client
         if: startsWith(runner.os, 'Linux')
         shell: bash
-        run: ./scripts/copy-sos.sh _build/dev/rel/anoma
+        run: |
+           ./scripts/copy-sos.sh _build/dev/rel/anoma
+           cp ./scripts/anomac _build/dev/rel/anoma/bin/
       - name: Build Anoma release
         if: startsWith(runner.os, 'Windows')
         shell: pwsh

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -67,6 +67,10 @@ jobs:
         if: startsWith(runner.os, 'macOS')
         shell: bash
         run: ./scripts/copy-dylibs.zsh _build/dev/rel/anoma
+      - name: Copy shared libraries
+        if: startsWith(runner.os, 'Linux')
+        shell: bash
+        run: ./scripts/copy-sos.sh _build/dev/rel/anoma
       - name: Build Anoma release
         if: startsWith(runner.os, 'Windows')
         shell: pwsh

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -63,7 +63,19 @@ jobs:
         run: |
           export PATH="$PATH:$HOME/.mix/escripts"
           mix release
-      - name: Copy shared libraries
+      - name: Build Anoma release
+        if: startsWith(runner.os, 'Windows')
+        shell: pwsh
+        run: |
+          & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1" -Arch amd64 -SkipAutomaticLocation
+          $env:PATH = $env:USERPROFILE + '\.mix\escripts;' + $env:VCPKG_INSTALLATION_ROOT + '\packages\libsodium_x64-windows\bin;' + $env:PATH
+          $env:INCLUDE = $env:VCPKG_INSTALLATION_ROOT + '\packages\libsodium_x64-windows\include;' + $env:INCLUDE
+          $LIBSODIUM_LIB = $env:VCPKG_INSTALLATION_ROOT + '\packages\libsodium_x64-windows\lib'
+          $env:LIB = $LIBSODIUM_LIB + ';' + $env:LIB
+          copy ($LIBSODIUM_LIB + '\libsodium.lib') ($LIBSODIUM_LIB + '\libsodium.dll.a')
+          $env:DEBUG = '1'
+          mix release
+      - name: Copy shared libraries and client
         if: startsWith(runner.os, 'macOS')
         shell: bash
         run: |
@@ -75,18 +87,15 @@ jobs:
         run: |
            ./scripts/copy-sos.sh _build/dev/rel/anoma
            cp ./scripts/anomac _build/dev/rel/anoma/bin/
-      - name: Build Anoma release
+      - name: Copy shared libraries
         if: startsWith(runner.os, 'Windows')
         shell: pwsh
         run: |
-          & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1" -Arch amd64 -SkipAutomaticLocation
-          $env:PATH += $env:USERPROFILE + '\.mix\escripts;'
-          $env:INCLUDE += ';' + $env:VCPKG_INSTALLATION_ROOT + '\packages\libsodium_x64-windows\include'
-          $LIBSODIUM_LIB = $env:VCPKG_INSTALLATION_ROOT + '\packages\libsodium_x64-windows\lib'
-          $env:LIB += ';' + $LIBSODIUM_LIB
-          copy ($LIBSODIUM_LIB + '\libsodium.lib') ($LIBSODIUM_LIB + '\libsodium.dll.a')
-          $env:DEBUG = '1'
-          mix release
+          $env:PATH = $env:USERPROFILE + '\.mix\escripts;' + $env:VCPKG_INSTALLATION_ROOT + '\packages\libsodium_x64-windows\bin;' + $env:PATH
+          $bin_dirs = (ls -Path "_build\dev\rel\anoma\erts-*\bin")
+          foreach($bin_dir in $bin_dirs) {
+            .\scripts\copy-dlls.ps1 -LibPath _build\dev\rel\anoma\lib -DestinationPath $bin_dir.FullName
+          }
       - name: Compute SHA hashes
         shell: pwsh
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,6 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-      # 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -50,8 +49,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      
-      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)." 
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)."
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,60 @@
+#
+name: Create and publish a Docker image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  push:
+    tags:
+      - v*
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+      # 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)." 
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,11 +1,8 @@
 #
 name: Create and publish a Docker image
 
-# Configures this workflow to run every time a change is pushed to the branch called `release`.
-on:
-  push:
-    tags:
-      - v*
+# Indicates that the workflow can be called by another workflow
+on: workflow_call
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -64,11 +64,16 @@ jobs:
     needs: [compile, lint, test, docs]
     strategy:
       matrix:
-        beam_versions:
-          - otp: "27.1"
-            elixir: "1.17"
-          # - otp: "26.2.5.5"
-          #   elixir: "1.17"
+        include:
+          - otp_version: "27.1"
+            os: macos-latest
+            elixir_version: "1.17"
+          - otp_version: "27.1"
+            os: ubuntu-latest
+            elixir_version: "1.17"
+          - otp_version: "27.1"
+            os: windows-latest
+            elixir_version: "1.17"
     permissions:
       contents: write
       id-token: write
@@ -76,8 +81,9 @@ jobs:
     uses: ./.github/workflows/build_release.yaml
     with:
       mix-env: "prod"
-      elixir-version: "${{ matrix.beam_versions.elixir }}"
-      otp-version: "${{ matrix.beam_versions.otp }}"
+      elixir-version: "${{ matrix.elixir_version }}"
+      otp-version: "${{ matrix.otp_version }}"
+      os: "${{ matrix.os }}"
       release_name: ${{ github.ref_name }}
 
   publish_release:

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -93,3 +93,12 @@ jobs:
       id-token: write
       pages: write
     uses: ./.github/workflows/publish_release.yaml
+
+  create_publish_docker:
+    needs: [compile, lint, test, docs]
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    uses: ./.github/workflows/docker.yml

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -74,6 +74,9 @@ jobs:
           - otp_version: "27.1"
             os: windows-latest
             elixir_version: "1.17"
+          - otp_version: "27.1"
+            os: macos-13
+            elixir_version: "1.17"
     permissions:
       contents: write
       id-token: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ COPY global_deps.exs mix.exs mix.lock version.exs ./
 COPY apps apps
 COPY config config
 COPY documentation documentation
-COPY params params
 # The Hex package manager is required for Mix to fetch dependencies
 RUN mix local.hex --force
 # rebar3 is required to compile Anoma dependencies
@@ -37,7 +36,6 @@ RUN apt-get install -y openssl
 # Copy the Anoma release into the minimal image
 WORKDIR /app
 COPY --from=builder /app/_build/dev/rel/anoma .
-COPY --from=builder /app/params params
 ENV LANG=C.UTF-8
 # The entry point of the Anoma system
 ENTRYPOINT ["bin/anoma"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN mix local.hex --force
 # rebar3 is required to compile Anoma dependencies
 RUN mix local.rebar --force
 # Protocol Buffers compiler is also required
-RUN mix escript.install hex protobuf --force
+RUN mix escript.install hex protobuf 0.11.0 --force
 # Add the Protocol Buffers compiler to the path
 ENV PATH="/root/.mix/escripts:${PATH}"
 RUN mix clean --deps

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ Further see the Known issues section if you encounter an issue.
 ## Docker images
 To work with Docker images, do the following:
 1. Install [Docker](https://docs.docker.com/engine/install/), this is necessary for both building and running Docker images
-2. Build the Anoma image from the repository root: `docker build -t <IMAGE> .`
+2. If using the official Anoma image, download it using [the package instructions](https://github.com/anoma/anoma/pkgs/container/anoma)
+3. If building the Anoma image instead, then run from the repository root: `docker build -t <IMAGE> .`
     * `<IMAGE>` is your chosen image name
 4. Run the Anoma image: `docker run -it --network host <IMAGE> <SUBCOMMAND>`
     * `<IMAGE>` is the name of Anoma Docker image to be run

--- a/apps/anoma_client/lib/cli.ex
+++ b/apps/anoma_client/lib/cli.ex
@@ -50,6 +50,18 @@ defmodule Anoma.Client.CLI do
 
   require Logger
 
+  # Entry point to use if the Anoma client is being invoked by init. The plain
+  # arguments are obtained from :init analogously to :elixir.start_cli or
+  # :escript.start. Note that if running with `erl`, the CLI arguments have to
+  # be passed after the -extra flag to ensure that characters like hyphens are
+  # not interpreted by the runtime system or the emulator.
+  @spec start() :: any()
+  def start() do
+    main(Enum.map(:init.get_plain_arguments(), &List.to_string/1))
+  end
+
+  # Entry point called by escript. CLI arguments for the Anoma client are passed
+  # to this function as an array of strings.
   @spec main([String.t()]) :: any()
   def main(args) do
     case parse_args(args) do

--- a/apps/anoma_lib/lib/anoma/tables.ex
+++ b/apps/anoma_lib/lib/anoma/tables.ex
@@ -500,6 +500,10 @@ defmodule Anoma.Tables do
     mnesia_data_dir(:os.type())
   end
 
+  defp mnesia_data_dir({:win32, :nt}) do
+    Path.expand("~/AppData/Anoma")
+  end
+
   defp mnesia_data_dir({:unix, :darwin}) do
     Path.expand("~/Library/Application Support/Anoma")
   end

--- a/apps/anoma_lib/mix.exs
+++ b/apps/anoma_lib/mix.exs
@@ -25,7 +25,7 @@ defmodule AnomaLib.MixProject do
   #       mnesia should *not* be started automatically
   def application do
     [
-      included_applications: [:mnesia]
+      extra_applications: [{:mnesia, :optional}]
     ]
   end
 

--- a/apps/anoma_node/mix.exs
+++ b/apps/anoma_node/mix.exs
@@ -34,9 +34,9 @@ defmodule AnomaNode.MixProject do
         :logger,
         :runtime_tools,
         :tools,
-        :ex_unit
-      ],
-      included_applications: [:mnesia]
+        :ex_unit,
+        {:mnesia, :optional}
+      ]
     ]
   end
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -12,3 +12,6 @@ config :anoma_client, Anoma.Client.Web.Endpoint,
 
 config :anoma_client,
   grpc_port: String.to_integer(System.get_env("CLIENT_GRPC_PORT") || "40051")
+
+config :anoma_node,
+  grpc_port: String.to_integer(System.get_env("NODE_GRPC_PORT") || "50051")

--- a/mix.exs
+++ b/mix.exs
@@ -43,17 +43,12 @@ defmodule Anoma.MixProject do
 
   def releases do
     [
-      anoma_client: [
-        include_executables_for: [:unix],
-        applications: [
-          {:anoma_client, :permanent}
-        ]
-      ],
       anoma: [
         include_executables_for: [:unix, :windows],
         applications: [
           anoma_node: :permanent,
-          event_broker: :permanent
+          event_broker: :permanent,
+          anoma_client: :permanent
         ]
       ]
     ]
@@ -146,7 +141,7 @@ defmodule Anoma.MixProject do
 
   def escript do
     [
-      main_module: Anoma.Cli,
+      main_module: Anoma.Client.CLI,
       name: "anoma",
       app: nil
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -133,9 +133,9 @@ defmodule Anoma.MixProject do
     [
       extra_applications: [
         :observer,
-        :wx
-      ],
-      included_applications: [:mnesia]
+        :wx,
+        {:mnesia, :optional}
+      ]
     ]
   end
 

--- a/scripts/anomac
+++ b/scripts/anomac
@@ -8,6 +8,6 @@ anoma() { . "$(dirname "$SELF")/anoma"; }
 # Source the anoma functions but suppress output
 anoma version
 # Make erl's init call the Anoma client entry point
-export ELIXIR_ERL_OPTIONS="-run Elixir.Anoma.Client.CLI start"
+export ELIXIR_ERL_OPTIONS="$ELIXIR_ERL_OPTIONS -run Elixir.Anoma.Client.CLI start"
 # Start the Anoma client
 start "elixir" "$@"

--- a/scripts/anomac
+++ b/scripts/anomac
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+# Get the path to this script
+SELF=$(readlink "$0" || true)
+if [ -z "$SELF" ]; then SELF="$0"; fi
+# Source anoma in a function so we can control the CLI arguments it receives
+anoma() { . "$(dirname "$SELF")/anoma"; }
+# Source the anoma functions but suppress output
+anoma version
+# Make erl's init call the Anoma client entry point
+export ELIXIR_ERL_OPTIONS="-run Elixir.Anoma.Client.CLI start"
+# Start the Anoma client
+start "elixir" "$@"

--- a/scripts/copy-dlls.ps1
+++ b/scripts/copy-dlls.ps1
@@ -1,0 +1,37 @@
+param (
+    [string] $LibPath,
+    [string] $DestinationPath
+)
+
+function Copy-Dependencies {
+    param (
+        [string] $RootPath,
+        [string] $DestinationPath
+    )
+    $excludelist = "C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Program Files\Amazon\cfn-bootstrap\;C:\Users\runneradmin\AppData\Local\Microsoft\WindowsApps;" -split ";"
+    $paths = $env:path -split ";"
+    $shared_libs = (dumpbin /dependents $RootPath)
+    $libs_start = $shared_libs | select-string -Pattern "^  Image has the following dependencies:$"
+    $libs_end = $shared_libs | select-string -Pattern "^  Summary$"
+    $shared_libs = $shared_libs | Select-Object -Index (($libs_start.LineNumber+1)..($libs_end.LineNumber-3))
+    foreach($shared_lib in $shared_libs) {
+        foreach($path in $paths) {
+            if($shared_lib -and $path -and !$excludelist.contains($path)){
+                $shared_lib_path = (Join-Path -Path $path -ChildPath $shared_lib.Trim())
+                $target_lib_path = (Join-Path -Path $DestinationPath -ChildPath $shared_lib.Trim())
+                if ((Test-Path $shared_lib_path) -and !(Test-Path $target_lib_path)) {
+                    echo "Copying $shared_lib_path for $RootPath"
+                    Copy-Item $shared_lib_path -Destination $DestinationPath
+                    Copy-Dependencies -RootPath $shared_lib_path -DestinationPath $DestinationPath
+                }
+            }
+        }
+    }
+}
+
+echo $env:path
+& "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1" -Arch amd64 -SkipAutomaticLocation
+$shared_libs = Get-ChildItem -Path $LibPath -Filter *.dll -Recurse
+foreach($shared_lib in $shared_libs) {
+    Copy-Dependencies -RootPath $shared_lib.FullName -DestinationPath $DestinationPath
+}

--- a/scripts/copy-dylibs.zsh
+++ b/scripts/copy-dylibs.zsh
@@ -1,0 +1,38 @@
+#!/usr/bin/env zsh
+# Copy the shared libraries depended upon by all the files in the given directory.
+
+# Copy the dynamic libraries depended upon by the object file given in the first argument.
+# The second argument is the path to the original object file; this is required to prevent
+# an infinite recurse stemming from a self-referential shared library.
+function cp_dylibs {
+    object_file="$1"
+    source_object_file="$2"
+    echo "Patching $object_file";
+    # Find all the shared library dependencies of the given object file
+    otool -L "$object_file" |
+    # Select only those shared libraries that are added to the base system
+    grep -o "/opt/.*dylib" |
+    # For each shared library that has been added to the base system
+    while read -r shared_library; do
+        # Only do something if we have not encountered this shared library yet
+        if ! [[ $shared_library -ef $source_object_file ]]; then
+            # Copy the shared library found into the release
+            cp -v "$shared_library" "${object_file%/*}/";
+            # Patch the given object file to point the shared library copy
+            install_name_tool -change "$shared_library" "@loader_path/$(basename $shared_library)" "$object_file";
+            # The above patching invalidates any existing signatures, so force ad-hoc signing of the object file
+            codesign -s - -f "$object_file";
+            # Recurse to handle the dependencies of the current shared library
+            cp_dylibs "${object_file%/*}/$(basename $shared_library)" "$shared_library"
+        fi
+    done
+}
+
+# Move to the directory with the binaries
+cd $1
+# Copy the shared libraries required by each file in the release
+find . -type f |
+while read object_file; do
+    # Recursively copy the shared libraries used by this object file and patch it
+    cp_dylibs "$object_file" "$object_file";
+done

--- a/scripts/copy-dylibs.zsh
+++ b/scripts/copy-dylibs.zsh
@@ -10,7 +10,7 @@ function cp_dylibs {
     # Find all the shared library dependencies of the given object file
     otool -L "$object_file" |
     # Select only those shared libraries that are added to the base system
-    grep -o "/opt/.*dylib" |
+    grep -o -e "/usr/local/opt/.*dylib" -e "/opt/.*dylib" |
     # For each shared library that has been added to the base system
     while read -r shared_library; do
         shared_lib_basename="$(basename $shared_library)"

--- a/scripts/copy-sos.sh
+++ b/scripts/copy-sos.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copy the shared libraries depended upon by all the files in the given directory.
+
+excludelist=$(cat scripts/excludelist | grep -o '^[^#]*')
+
+# Copy the dynamic libraries depended upon by the object file given in the first argument.
+# The second argument is the path to the original object file; this is required to prevent
+# an infinite recurse stemming from a self-referential shared library.
+function cp_sos {
+    object_file="$1"
+    echo "Patching $object_file";
+    # Find all the shared library dependencies of the given object file
+    ldd "$object_file" |
+    # For each shared library depended upon by this object file
+    while read -r shared_lib sep shared_lib_path mem_loc; do
+        target_object_file="${object_file%/*}/$shared_lib"
+        # Only process libraries that are not in the base system. Only do something if we
+        # have not encountered this shared library yet
+        if [[ "$sep" == "=>" ]] && [ ! -e $target_object_file ] &&
+               { ! echo $excludelist | grep -w -q $shared_lib; }; then
+            # Copy the shared library found into the release
+            cp -v "$shared_lib_path" "$target_object_file";
+            # Patch the given object file to point the shared library copy
+            patchelf --add-rpath '$ORIGIN' "$object_file";
+            # Recurse to handle the dependencies of the current shared library
+            cp_sos $target_object_file;
+        fi
+    done
+}
+
+# Move to the directory with the binaries
+cd $1
+# Copy the shared libraries required by each file in the release
+find . -type f -executable |
+while read object_file; do
+    # Recursively copy the shared libraries used by this object file and patch it
+    cp_sos "$object_file";
+done

--- a/scripts/excludelist
+++ b/scripts/excludelist
@@ -1,0 +1,246 @@
+# This file lists libraries that we will assume to be present on the host system and hence
+# should NOT be bundled inside AppImages. This is a working document; expect it to change
+# over time. File format: one filename per line. Each entry should have a justification comment.
+
+# See the useful tool at https://abi-laboratory.pro/index.php?view=navigator&symbol=hb_buffer_set_cluster_level#result
+# to investigate issues with missing symbols.
+
+ld-linux.so.2
+ld-linux-x86-64.so.2
+libanl.so.1
+libBrokenLocale.so.1
+libcidn.so.1
+# libcrypt.so.1 # Not part of glibc anymore as of Fedora 30. See https://github.com/slic3r/Slic3r/issues/4798 and https://pagure.io/fedora-docs/release-notes/c/01d74b33564faa42959c035e1eee286940e9170e?branch=f28
+libc.so.6
+libdl.so.2
+libm.so.6
+libmvec.so.1
+# libnsl.so.1 # Not part of glibc anymore as of Fedora 28. See https://github.com/RPCS3/rpcs3/issues/5224#issuecomment-434930594
+libnss_compat.so.2
+# libnss_db.so.2 # Not part of neon-useredition-20190321-0530-amd64.iso
+libnss_dns.so.2
+libnss_files.so.2
+libnss_hesiod.so.2
+libnss_nisplus.so.2
+libnss_nis.so.2
+libpthread.so.0
+libresolv.so.2
+librt.so.1
+libthread_db.so.1
+libutil.so.1
+# These files are all part of the GNU C Library which should never be bundled.
+# List was generated from a fresh build of glibc 2.25.
+
+libstdc++.so.6
+# Workaround for:
+# usr/lib/libstdc++.so.6: version `GLIBCXX_3.4.21' not found
+
+libGL.so.1
+# The above may be missing on Chrome OS, https://www.reddit.com/r/Crostini/comments/d1lp67/ultimaker_cura_no_longer_running_as_an_appimage/
+libEGL.so.1
+# Part of the video driver (OpenGL); present on any regular
+# desktop system, may also be provided by proprietary drivers.
+# Known to cause issues if it's bundled.
+
+libGLdispatch.so.0
+libGLX.so.0
+# reported to be superfluent and conflicting system libraries (graphics driver)
+# see https://github.com/linuxdeploy/linuxdeploy/issues/89
+
+libOpenGL.so.0
+# Qt installed via install-qt.sh apparently links to this library
+# part of OpenGL like libGL/libEGL, so excluding it should not cause any problems
+# https://github.com/linuxdeploy/linuxdeploy/issues/152
+
+libdrm.so.2
+# Workaround for:
+# Antergos Linux release 2015.11 (ISO-Rolling)
+# /usr/lib/libdrm_amdgpu.so.1: error: symbol lookup error: undefined symbol: drmGetNodeTypeFromFd (fatal)
+# libGL error: unable to load driver: swrast_dri.so
+# libGL error: failed to load driver: swrast
+# Unrecognized OpenGL version
+
+libglapi.so.0
+# Part of mesa
+# known to cause problems with graphics, see https://github.com/RPCS3/rpcs3/issues/4427#issuecomment-381674910
+
+libgbm.so.1
+# Part of mesa
+# https://github.com/probonopd/linuxdeployqt/issues/390#issuecomment-529036305
+
+libxcb.so.1
+# Workaround for:
+# Fedora 23
+# symbol lookup error: /lib64/libxcb-dri3.so.0: undefined symbol: xcb_send_fd
+# Uncertain if this is required to be bundled for some distributions - if so we need to write a version check script and use LD_PRELOAD to load the system version if it is newer
+# Fedora 25:
+# undefined symbol: xcb_send_request_with_fds
+# https://github.com/AppImage/AppImages/issues/128
+
+libX11.so.6
+# Workaround for:
+# Fedora 23
+# symbol lookup error: ./lib/libX11.so.6: undefined symbol: xcb_wait_for_reply64
+# Uncertain if this is required to be bundled for some distributions - if so we need to write a version check script and use LD_PRELOAD to load the system version if it is newer
+
+libX11-xcb.so.1
+# https://github.com/probonopd/linuxdeployqt/issues/582
+# Uncertain if this is required to be bundled for some distributions - if so, please let us know
+
+libwayland-client.so.0
+# https://github.com/AppImageCommunity/pkg2appimage/pull/559
+# https://gitlab.freedesktop.org/mesa/mesa/-/issues/11316
+# New version of Mesa has some dependency issues with libwayland-client if it is bundled
+
+# --- Bundling GLib and its consequences ---
+# The following libraries need to be privately bundled, otherwise this error can happen:
+# - <AppDir>/usr/lib/x86_64-linux-gnu/libgnutls.so.30: version `GNUTLS_3_6_9' not found (required by /lib64/libglib-2.0.so.0)
+# See https://github.com/probonopd/Emacs.AppImage/issues/16
+# - /lib/x86_64-linux-gnu/libgio-2.0.so.0: undefined symbol: g_module_open_full
+# See https://github.com/AppImage/pkg2appimage/pull/500#issuecomment-997183221
+# libgio-2.0.so.0
+# libglib-2.0.so.0
+# libgmodule-2.0.so.0
+# libgobject-2.0.so.0
+# libgthread-2.0.so.0
+# NOTE: Privately bundling libglib-2.0.so.0 and libgobject-2.0.so.0 may break https://wiki.gnome.org/Projects/Libsecret,
+# see https://github.com/probonopd/linuxdeployqt/issues/544 for details
+# NOTE: Privately bundling libgio-2.0.so.0 can lead to this error on Ubuntu:
+# symbol lookup error: /usr/lib/x86_64-linux-gnu/gtk-2.0/modules/liboverlay-scrollbar.so: undefined symbol: g_settings_new
+
+# Since we bundle GLib (again), we have to bundle libpango to avoid undefined symbol: g_memdup2 etc.
+# see, e.g., https://github.com/TheAssassin/AppImageLauncher/issues/508
+# libpangoft2-1.0.so.0
+# libpangocairo-1.0.so.0
+# libpango-1.0.so.0
+# NOTE: Pango requires libharfbuzz >= 2.6.0 which isn't available on some older systems, so this error can happen:
+# libpango-1.0.so.0: undefined symbol: hb_ot_layout_get_horizontal_baseline_tag_for_script
+# See https://github.com/AppImageCommunity/pkg2appimage/issues/528
+
+# Commented as we currently bundle libpango
+# If libthai is bundled but libpango is not, this error can happen:
+# audacity: /tmp/.mount_AudaciUsFbON/usr/lib/libthai.so.0: version `LIBTHAI_0.1.25' not found (required by /usr/lib64/libpango-1.0.so.0)
+# on openSUSE Tumbleweed
+# libthai.so.0
+# If libcairo is bundled but libpango is not, this error can happen:
+# Can get symbol lookup error: /lib64/libpango-1.0.so.0: undefined symbol: g_log_structured_standard
+# --- Bundling GLib and its consequences ---
+
+# libgdk-x11-2.0.so.0 # Missing on openSUSE-Tumbleweed-KDE-Live-x86_64-Snapshot20170601-Media.iso
+# libgtk-x11-2.0.so.0 # Missing on openSUSE-Tumbleweed-KDE-Live-x86_64-Snapshot20170601-Media.iso
+
+libasound.so.2
+# Workaround for:
+# No sound, e.g., in VLC.AppImage (does not find sound cards)
+
+# https://github.com/AppImage/pkg2appimage/issues/475
+# libgdk_pixbuf-2.0.so.0
+# Was: Workaround for:
+# On Ubuntu, get (inkscape:25621): GdkPixbuf-WARNING **: Error loading XPM image loader: Image type 'xpm' is not supported
+
+libfontconfig.so.1
+# Workaround for:
+# Application stalls when loading fonts during application launch; e.g., KiCad on ubuntu-mate
+
+# other "low-level" font rendering libraries
+# should fix https://github.com/probonopd/linuxdeployqt/issues/261#issuecomment-377522251
+# and https://github.com/probonopd/linuxdeployqt/issues/157#issuecomment-320755694
+libfreetype.so.6
+libharfbuzz.so.0
+
+# Note, after discussion we do not exclude this, but we can use a dummy library that just does nothing
+# libselinux.so.1
+# Workaround for:
+# sed: error while loading shared libraries: libpcre.so.3: cannot open shared object file: No such file or directory
+# Some distributions, such as Arch Linux, do not come with libselinux.so.1 by default.
+# The solution is to bundle a dummy mock library:
+# echo "extern int is_selinux_enabled(void){return 0;}" >> selinux-mock.c
+# gcc -s -shared -o libselinux.so.1 -Wl,-soname,libselinux.so.1 selinux-mock.c
+# strip libselinux.so.1
+# More information: https://github.com/AppImage/AppImages/issues/83
+# and https://github.com/AppImage/AppImageKit/issues/775#issuecomment-614954821
+# https://gitlab.com/sulinos/devel/libselinux-dummy
+
+# The following are assumed to be part of the base system
+# Removing these has worked e.g., for Krita. Feel free to report if
+# you think that some of these should go into AppImages and why.
+libcom_err.so.2
+libexpat.so.1
+libgcc_s.so.1
+libgpg-error.so.0
+# libgssapi_krb5.so.2 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there
+# libgssapi.so.3 # Seemingly needed when running Ubuntu 14.04 binaries on Fedora 23
+# libhcrypto.so.4 # Missing on openSUSE LEAP 42.0
+# libheimbase.so.1 # Seemingly needed when running Ubuntu 14.04 binaries on Fedora 23
+# libheimntlm.so.0 # Seemingly needed when running Ubuntu 14.04 binaries on Fedora 23
+# libhx509.so.5 # Missing on openSUSE LEAP 42.0
+libICE.so.6
+# libidn.so.11 # Does not come with Solus by default
+# libk5crypto.so.3 # Running AppImage built on Debian 9 or Ubuntu 16.04 on an Archlinux fails otherwise; https://github.com/AppImage/AppImages/issues/301
+# libkeyutils.so.1 # Does not come with Void Linux by default; https://github.com/Subsurface-divelog/subsurface/issues/1971#issuecomment-466606834
+# libkrb5.so.26 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there. Missing on openSUSE LEAP 42.0
+# libkrb5.so.3 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there
+# libkrb5support.so.0 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there
+# libp11-kit.so.0 # https://github.com/AppImageCommunity/pkg2appimage/issues/547
+# libpcre.so.3 # Missing on Fedora 24, SLED 12 SP1, and openSUSE Leap 42.2
+# libroken.so.18 # Mission on openSUSE LEAP 42.0
+# libsasl2.so.2 # Seemingly needed when running Ubuntu 14.04 binaries on Fedora 23
+libSM.so.6
+libusb-1.0.so.0
+libuuid.so.1
+# libwind.so.0 # Missing on openSUSE LEAP 42.0
+libz.so.1
+
+# Workaround for:
+# e.g., Spotify
+# relocation error: /lib/x86_64-linux-gnu/libgcrypt.so.20:
+# symbol gpgrt_lock_lock, version GPG_ERROR_1.0 not defined
+# in file libgpg-error.so.0 with link time reference
+libgpg-error.so.0
+
+libjack.so.0
+# it must match the ABI of the JACK server which is installed in the base system
+# rncbc confirmed this
+# However, this library is missing on Fedora-WS-Live-31-1-9
+# which means that we should avoid using JACK altogether if possible
+
+libpipewire-0.3.so.0
+# like libjack, it must match the ABI of the JACK server which is installed in the base system
+# https://github.com/linuxdeploy/linuxdeploy/issues/292
+
+# Unsolved issue:
+# https://github.com/probonopd/linuxdeployqt/issues/35
+# Error initializing NSS with a persistent database (sql:/home/me/.pki/nssdb): libsoftokn3.so: cannot open shared object file: No such file or directory
+# Error initializing NSS without a persistent database: NSS error code: -5925
+# nss_error=-5925, os_error=0
+# libnss3.so should not be removed from the bundles, as this causes other issues, e.g.,
+# https://github.com/probonopd/linuxdeployqt/issues/35#issuecomment-256213517
+# and https://github.com/AppImage/AppImages/pull/114
+# libnss3.so
+
+# The following cannot be excluded, see
+# https://github.com/AppImage/AppImages/commit/6c7473d8cdaaa2572248dcc53d7f617a577ade6b
+# http://stackoverflow.com/questions/32644157/forcing-a-binary-to-use-a-specific-newer-version-of-a-shared-library-so
+# libssl.so.1
+# libssl.so.1.0.0
+# libcrypto.so.1
+# libcrypto.so.1.0.0
+
+# According to https://github.com/RicardoEPRodrigues/3Engine/issues/4#issuecomment-511598362
+# libGLEW is not tied to a specific GPU. It's linked against libGL.so.1
+# and that one is different depending on the installed driver.
+# In fact libGLEW is changing its soversion very often, so you should always bundle libGLEW.so.2.0
+
+# libglut.so.3 # to be confirmed
+
+libxcb-dri3.so.0 # https://github.com/AppImage/AppImages/issues/348
+libxcb-dri2.so.0 # https://github.com/probonopd/linuxdeployqt/issues/331#issuecomment-442276277
+
+# If the next line turns out to cause issues, we will have to remove it again and find another solution
+libfribidi.so.0 # https://github.com/olive-editor/olive/issues/221 and https://github.com/knapsu/plex-media-player-appimage/issues/14
+
+# Workaround for:
+# symbol lookup error: /lib/x86_64-linux-gnu/libgnutls.so.30: undefined symbol: __gmpz_limbs_write
+# https://github.com/ONLYOFFICE/appimage-desktopeditors/issues/3
+# Apparently coreutils depends on it, so it should be safe to assume that it comes with every target system
+libgmp.so.10


### PR DESCRIPTION
An attempt to address #1511 . Added an Anoma client executable script to the release archive that works by using the Erlang emulator to directly execute BEAM files in the release. From the release directory root, this script can be executed with `./bin/anomac --listen-port 4001 --node-host localhost --node-port 8181` for instance. This approach to releasing the Anoma client was chosen for the following reasons:
* The BEAM files for each Elixir module are not duplicated. If the binary produced `mix do --app anoma_client escript.build` was used instead, then BEAM files would be duplicated since the output of `escript.build` is essentially an archive of BEAM files headed by a shebang line.
* The source for the Anoma client does not have to be copied into the release archive. Doing this would be undesirable because (1) the logic that is in the BEAM files is still indirectly duplicated, and (2) it is probably more efficient to run the Anoma client from compiled artifacts than the source code directly.
* The `anomac` command invokes `erl` through the `anoma` executable script produced by `mix release` in order to avoid hardcoding the path to the `erl` binary (which might change between `mix` releases) and to ensure that the Anoma client is run with the same settings/configuration and the Anoma node.
* The `anomac` command boots into `releases/0.25.0/start` instead of `releases/0.25.0/start_clean` in order to ensure that `Anoma.Client.Application` starts the supervisor `Anoma.Client.ConnectionSupervisor` before the client CLI script starts. This is necessary because the client CLI script depends upon `Anoma.Client.ConnectionSupervisor`.