### PR TITLE
Murisi/remove tx candidates

### DIFF
--- a/apps/anoma_client/lib/client/nock/runner.ex
+++ b/apps/anoma_client/lib/client/nock/runner.ex
@@ -157,8 +157,8 @@ defmodule Anoma.Client.Runner do
   end
 
   @spec send_scry(Noun.t()) :: {:ok, Noun.t()} | :error
-  defp send_scry(space) do
-    case GRPCProxy.run_scry(space |> Noun.Jam.jam()) do
+  defp send_scry(key) do
+    case GRPCProxy.run_scry(key |> Noun.Jam.jam()) do
       {:ok, noun} ->
         {:ok, noun}
 

--- a/apps/anoma_client/lib/client/nock/runner.ex
+++ b/apps/anoma_client/lib/client/nock/runner.ex
@@ -141,7 +141,7 @@ defmodule Anoma.Client.Runner do
             {:ok, val}
 
           :absent ->
-            case send_candidate(space_list) do
+            case send_scry(space_list) do
               :error ->
                 :error
 
@@ -152,37 +152,13 @@ defmodule Anoma.Client.Runner do
         end
 
       _ ->
-        send_candidate(space_list)
+        send_scry(space_list)
     end
   end
 
-  @spec ro_tx_candidate(Noun.t()) :: Noun.t()
-  def ro_tx_candidate(ref) do
-    sample = 0
-    keyspace = 0
-
-    arm = [12, [1], [0 | 6] | [1, ref]]
-
-    [
-      arm,
-      0,
-      [
-        8,
-        [1 | sample],
-        [1 | keyspace],
-        [1 | arm],
-        0 |
-        1
-      ],
-      999
-    ]
-  end
-
-  @spec send_candidate(Noun.t()) :: {:ok, Noun.t()} | :error
-  defp send_candidate(space) do
-    tx_candidate = space |> ro_tx_candidate() |> Noun.Jam.jam()
-
-    case GRPCProxy.add_read_only_transaction(tx_candidate) do
+  @spec send_scry(Noun.t()) :: {:ok, Noun.t()} | :error
+  defp send_scry(space) do
+    case GRPCProxy.run_scry(space |> Noun.Jam.jam()) do
       {:ok, noun} ->
         {:ok, noun}
 

--- a/apps/anoma_client/lib/client/nock/runner.ex
+++ b/apps/anoma_client/lib/client/nock/runner.ex
@@ -163,7 +163,19 @@ defmodule Anoma.Client.Runner do
 
     arm = [12, [1], [0 | 6] | [1, ref]]
 
-    [[8, [1 | sample], [1 | keyspace], [1 | arm], 0 | 1] | 999]
+    [
+      arm,
+      0,
+      [
+        8,
+        [1 | sample],
+        [1 | keyspace],
+        [1 | arm],
+        0 |
+        1
+      ],
+      999
+    ]
   end
 
   @spec send_candidate(Noun.t()) :: {:ok, Noun.t()} | :error

--- a/apps/anoma_client/lib/client/node/grpc_proxy.ex
+++ b/apps/anoma_client/lib/client/node/grpc_proxy.ex
@@ -125,14 +125,6 @@ defmodule Anoma.Client.Node.GRPCProxy do
     GenServer.call(__MODULE__, {:subscribe, topic})
   end
 
-  @spec add_read_only_transaction(binary()) ::
-          {:ok, Noun.t()}
-          | {:error, :absent}
-          | {:error, :add_read_only_transaction_failed, String.t()}
-  def add_read_only_transaction(jammed_nock) do
-    GenServer.call(__MODULE__, {:add_ro_transaction, jammed_nock})
-  end
-
   @spec run_scry(binary()) ::
           {:ok, Noun.t()}
           | {:error, :absent}
@@ -173,13 +165,6 @@ defmodule Anoma.Client.Node.GRPCProxy do
   def handle_call({:subscribe, topic}, _from, state) do
     result =
       RPC.subscribe(state.channel, state.node_id, state.client_id, topic)
-
-    {:reply, result, state}
-  end
-
-  def handle_call({:add_ro_transaction, transaction}, _from, state) do
-    result =
-      RPC.add_read_only_transaction(state.channel, state.node_id, transaction)
 
     {:reply, result, state}
   end

--- a/apps/anoma_client/lib/client/node/grpc_proxy.ex
+++ b/apps/anoma_client/lib/client/node/grpc_proxy.ex
@@ -137,8 +137,8 @@ defmodule Anoma.Client.Node.GRPCProxy do
           {:ok, Noun.t()}
           | {:error, :absent}
           | {:error, :run_scry_failed, String.t()}
-  def run_scry(jammed_space) do
-    GenServer.call(__MODULE__, {:run_scry, jammed_space})
+  def run_scry(jammed_key) do
+    GenServer.call(__MODULE__, {:run_scry, jammed_key})
   end
 
   ############################################################
@@ -184,9 +184,9 @@ defmodule Anoma.Client.Node.GRPCProxy do
     {:reply, result, state}
   end
 
-def handle_call({:run_scry, space}, _from, state) do
+  def handle_call({:run_scry, key}, _from, state) do
     result =
-      RPC.run_scry(state.channel, state.node_id, space)
+      RPC.run_scry(state.channel, state.node_id, key)
 
     {:reply, result, state}
   end

--- a/apps/anoma_client/lib/client/node/grpc_proxy.ex
+++ b/apps/anoma_client/lib/client/node/grpc_proxy.ex
@@ -133,6 +133,14 @@ defmodule Anoma.Client.Node.GRPCProxy do
     GenServer.call(__MODULE__, {:add_ro_transaction, jammed_nock})
   end
 
+  @spec run_scry(binary()) ::
+          {:ok, Noun.t()}
+          | {:error, :absent}
+          | {:error, :run_scry_failed, String.t()}
+  def run_scry(jammed_space) do
+    GenServer.call(__MODULE__, {:run_scry, jammed_space})
+  end
+
   ############################################################
   #                    Genserver Behavior                    #
   ############################################################
@@ -172,6 +180,13 @@ defmodule Anoma.Client.Node.GRPCProxy do
   def handle_call({:add_ro_transaction, transaction}, _from, state) do
     result =
       RPC.add_read_only_transaction(state.channel, state.node_id, transaction)
+
+    {:reply, result, state}
+  end
+
+def handle_call({:run_scry, space}, _from, state) do
+    result =
+      RPC.run_scry(state.channel, state.node_id, space)
 
     {:reply, result, state}
   end

--- a/apps/anoma_client/lib/client/node/rpc.ex
+++ b/apps/anoma_client/lib/client/node/rpc.ex
@@ -160,12 +160,12 @@ defmodule Anoma.Client.Node.RPC do
           {:ok, Noun.t()}
           | {:error, :run_scry_failed, String.t()}
           | {:error, :absent}
-  def run_scry(channel, node_id, space) do
+  def run_scry(channel, node_id, key) do
     node = %Node{id: node_id}
 
     request = %RunScry.Request{
       node: node,
-      space: space
+      key: key
     }
 
     case ExecutorService.Stub.run_scry(channel, request) do

--- a/apps/anoma_client/lib/client/node/rpc.ex
+++ b/apps/anoma_client/lib/client/node/rpc.ex
@@ -6,7 +6,6 @@ defmodule Anoma.Client.Node.RPC do
   alias Anoma.Proto.Advertisement.Advertise
   alias Anoma.Proto.Advertisement.GRPCAddress
   alias Anoma.Proto.AdvertisementService
-  alias Anoma.Proto.Executor.AddROTransaction
   alias Anoma.Proto.Executor.RunScry
   alias Anoma.Proto.ExecutorService
   alias Anoma.Proto.Intentpool
@@ -113,41 +112,6 @@ defmodule Anoma.Client.Node.RPC do
 
       {:error, %{status: _, message: err}} ->
         {:error, :add_transaction_failed, err}
-    end
-  end
-
-  @doc """
-  I make a call to a GRPC endpoint to add a read-only transaction to the mempool of the
-  node.
-
-  The result of this call is either an error, or a jammed noun.
-  """
-  @spec add_read_only_transaction(any(), String.t(), binary()) ::
-          {:ok, Noun.t()}
-          | {:error, :add_read_only_transaction_failed, String.t()}
-          | {:error, :absent}
-  def add_read_only_transaction(channel, node_id, transaction) do
-    node = %Node{id: node_id}
-
-    transaction = %Transaction{transaction: transaction}
-
-    request = %AddROTransaction.Request{
-      node: node,
-      transaction: transaction
-    }
-
-    case ExecutorService.Stub.add(channel, request) do
-      {:ok, %AddROTransaction.Response{result: result}} ->
-        case result do
-          {:success, %{result: jammed_nock}} ->
-            {:ok, Noun.Jam.cue!(jammed_nock)}
-
-          {:error, %{error: "absent"}} ->
-            {:error, :absent}
-        end
-
-      {:error, %{status: _, message: err}} ->
-        {:error, :add_read_only_transaction_failed, err}
     end
   end
 

--- a/apps/anoma_client/lib/client/node/rpc.ex
+++ b/apps/anoma_client/lib/client/node/rpc.ex
@@ -7,6 +7,7 @@ defmodule Anoma.Client.Node.RPC do
   alias Anoma.Proto.Advertisement.GRPCAddress
   alias Anoma.Proto.AdvertisementService
   alias Anoma.Proto.Executor.AddROTransaction
+  alias Anoma.Proto.Executor.RunScry
   alias Anoma.Proto.ExecutorService
   alias Anoma.Proto.Intentpool
   alias Anoma.Proto.Intentpool.Intent
@@ -147,6 +148,38 @@ defmodule Anoma.Client.Node.RPC do
 
       {:error, %{status: _, message: err}} ->
         {:error, :add_read_only_transaction_failed, err}
+    end
+  end
+
+  @doc """
+  I make a call to a GRPC endpoint to run a scry.
+
+  The result of this call is either an error, or a jammed noun.
+  """
+  @spec run_scry(any(), String.t(), binary()) ::
+          {:ok, Noun.t()}
+          | {:error, :run_scry_failed, String.t()}
+          | {:error, :absent}
+  def run_scry(channel, node_id, space) do
+    node = %Node{id: node_id}
+
+    request = %RunScry.Request{
+      node: node,
+      space: space
+    }
+
+    case ExecutorService.Stub.run_scry(channel, request) do
+      {:ok, %RunScry.Response{result: result}} ->
+        case result do
+          {:success, %{result: jammed_nock}} ->
+            {:ok, Noun.Jam.cue!(jammed_nock)}
+
+          {:error, %{error: "absent"}} ->
+            {:error, :absent}
+        end
+
+      {:error, %{status: _, message: err}} ->
+        {:error, :run_scry_failed, err}
     end
   end
 

--- a/apps/anoma_client/lib/client/web/controllers/executor/executor.ex
+++ b/apps/anoma_client/lib/client/web/controllers/executor/executor.ex
@@ -13,12 +13,10 @@ defmodule Anoma.Client.Web.ExecutorController do
 
   tags(["Executor"])
 
-  operation(:add_read_only_transaction,
-    summary: "Execute a read-only transaction.",
+  operation(:run_scry,
+    summary: "Run a scry.",
     parameters: [],
-    request_body:
-      {"Transaction candidate to submit", "application/json",
-       Spec.ReadOnlyTransaction},
+    request_body: {"Key to scry", "application/json", Spec.ScryKey},
     responses: [
       ok: {"Evaluation result", "application/json", Spec.Result}
     ]
@@ -29,16 +27,16 @@ defmodule Anoma.Client.Web.ExecutorController do
   ############################################################
 
   @doc """
-  I add a read-only transaction to the remote executor.
+  I a scry on the remote executor.
 
   I expect a jammed noun as paramter, base64 encoded.
 
   If anything goes wrong, I will return an error and this will be handled by the fallback controller.
   """
-  def add_read_only_transaction(conn, params = %{"transaction" => _}) do
-    with {:ok, intent} <- Base.decode64(params["transaction"]),
-         {:ok, result} <- GRPCProxy.add_read_only_transaction(intent) do
-      render(conn, "add_read_only_transaction.json", result: result)
+  def run_scry(conn, params = %{"key" => _}) do
+    with {:ok, key} <- Base.decode64(params["key"]),
+         {:ok, result} <- GRPCProxy.run_scry(key) do
+      render(conn, "run_scry.json", result: result)
     end
   end
 end

--- a/apps/anoma_client/lib/client/web/controllers/executor/spec.ex
+++ b/apps/anoma_client/lib/client/web/controllers/executor/spec.ex
@@ -3,26 +3,25 @@ defmodule Anoma.Client.Web.ExecutorController.Spec do
 
   require OpenApiSpex
 
-  defmodule ReadOnlyTransaction do
-    @example_tx Anoma.Node.Examples.EExecutor.read_only_transaction()
-                |> Noun.Jam.jam()
-                |> Base.encode64()
+  defmodule ScryKey do
+    @example_key ["anoma", "blob", "key"]
+                 |> Noun.Jam.jam()
+                 |> Base.encode64()
 
     OpenApiSpex.schema(%{
       # The title is optional. It defaults to the last section of the module name.
       # So the derived title for MyApp.User is "User".
-      description:
-        "A Base64 encoded representation of a read-only transaction",
+      description: "A Base64 encoded representation of a scry key",
       type: :object,
       properties: %{
-        transaction: %Schema{
+        key: %Schema{
           type: :string,
-          description: "Base64 encoded, jammed transaction candidate"
+          description: "Base64 encoded, jammed scry key"
         }
       },
       required: [:program],
       example: %{
-        "transaction" => @example_tx
+        "key" => @example_key
       }
     })
   end
@@ -31,18 +30,17 @@ defmodule Anoma.Client.Web.ExecutorController.Spec do
     OpenApiSpex.schema(%{
       # The title is optional. It defaults to the last section of the module name.
       # So the derived title for MyApp.User is "User".
-      description: "Result of submitting the transaction",
+      description: "Result of running a scry",
       type: :object,
       properties: %{
-        transaction: %Schema{
+        value: %Schema{
           type: :string,
-          description:
-            "Base64 encoded, jammed result of read-only transaction"
+          description: "Base64 encoded, jammed result of running a scry"
         }
       },
       required: [:program],
       example: %{
-        "result" => "FfDWyvIq"
+        "result" => "AXzSQMLaQMJA5sroKQ=="
       }
     })
   end

--- a/apps/anoma_client/lib/client/web/controllers/executor/view.ex
+++ b/apps/anoma_client/lib/client/web/controllers/executor/view.ex
@@ -1,5 +1,5 @@
 defmodule Anoma.Client.Web.ExecutorJSON do
-  def render("add_read_only_transaction.json", %{result: result}) do
+  def render("run_scry.json", %{result: result}) do
     result = result |> Noun.Jam.jam() |> Base.encode64()
     %{result: result}
   end

--- a/apps/anoma_client/lib/client/web/router.ex
+++ b/apps/anoma_client/lib/client/web/router.ex
@@ -26,7 +26,7 @@ defmodule Anoma.Client.Web.Router do
 
   scope "/executor", Anoma.Client.Web do
     pipe_through(:api)
-    post("/", ExecutorController, :add_read_only_transaction)
+    post("/", ExecutorController, :run_scry)
   end
 
   scope "/nock", Anoma.Client.Web do

--- a/apps/anoma_client/lib/examples/e_client/executor.ex
+++ b/apps/anoma_client/lib/examples/e_client/executor.ex
@@ -8,24 +8,32 @@ defmodule Anoma.Client.Examples.EClient.Executor do
   use TypedStruct
 
   alias Anoma.Client.Examples.EClient
-  alias Anoma.Node.Examples.EExecutor
+  alias Anoma.Node.Transaction.Storage, as: NodeStorage
 
   import ExUnit.Assertions
   import Anoma.Client.Examples.EClient
 
   @doc """
-  I add a read-only transaction using the client.
+  I run a scry using the client.
   """
-  @spec add_read_only_transaction(EClient.t()) :: {EClient.t(), String.t()}
-  def add_read_only_transaction(client \\ setup()) do
+  @spec run_scry(EClient.t()) :: {EClient.t(), String.t()}
+  def run_scry(client \\ setup()) do
+    val = MapSet.new(["i am a set"])
+    key = ["anoma", "blob", "key"]
+
+    NodeStorage.write(
+      client.node.node_id,
+      {1, [{key, val}]}
+    )
+
     # create an arbitrary read-only transaction and jam it
     transaction =
-      EExecutor.read_only_transaction()
+      ["anoma", "blob", "key"]
       |> Noun.Jam.jam()
       |> Base.encode64()
 
     # the json payload the endpoint expects
-    payload = %{"transaction" => transaction}
+    payload = %{"key" => transaction}
 
     data =
       client.conn
@@ -34,7 +42,7 @@ defmodule Anoma.Client.Examples.EClient.Executor do
 
     # this result is arbitrary and depends on the read only transaction submitted.
     # this could be fixed perhaps.
-    assert data == %{"result" => "FfDWyvIq"}
+    assert data == %{"result" => "AXzSQMLaQMJA5sroKQ=="}
 
     {client, transaction}
   end

--- a/apps/anoma_client/lib/examples/e_proxy/executor.ex
+++ b/apps/anoma_client/lib/examples/e_proxy/executor.ex
@@ -5,7 +5,6 @@ defmodule Anoma.Client.Examples.EProxy.Executor do
 
   alias Anoma.Client.Examples.EClient
   alias Anoma.Client.Node.GRPCProxy
-  alias Anoma.Node.Examples.EExecutor
 
   require ExUnit.Assertions
 
@@ -16,45 +15,44 @@ defmodule Anoma.Client.Examples.EProxy.Executor do
   @doc """
   I add a read-only transaction to the executor.
   """
-  @spec add_read_only_transaction(EClient.t()) :: {EClient.t(), any()}
-  def add_read_only_transaction(client \\ setup()) do
+  @spec run_scry(EClient.t()) :: {EClient.t(), any()}
+  def run_scry(client \\ setup()) do
     # create an arbitrary read-only transaction and jam it
-    transaction =
-      EExecutor.read_only_transaction()
+    key =
+      "valid"
       |> Noun.Jam.jam()
 
     # call the proxy
-    result = GRPCProxy.add_read_only_transaction(transaction)
+    result = GRPCProxy.run_scry(key)
 
     # this result is arbitrary and depends on the read only transaction submitted.
     # this could be fixed perhaps.
-    assert result == {:ok, [[["key" | ""] | ""] | ""]}
-    {client, transaction}
+    assert result == {:error, :absent}
+    {client, key}
   end
 
   @doc """
   I ask the node to return its list of intents via the proxy.
   """
-  @spec add_invalid_read_only_transaction(EClient.t()) ::
+  @spec run_invalid_scry(EClient.t()) ::
           {EClient.t(), binary()}
-  def add_invalid_read_only_transaction(client \\ setup()) do
+  def run_invalid_scry(client \\ setup()) do
     # invalid jammed nock
-    transaction = "invalid"
+    key = "invalid"
 
     assert capture_log(fn ->
              # call the proxy
-             result = GRPCProxy.add_read_only_transaction(transaction)
+             result = GRPCProxy.run_scry(key)
 
              assert result ==
-                      {:error, :add_read_only_transaction_failed,
-                       "invalid nock code"}
+                      {:error, :run_scry_failed, "invalid nock code"}
 
              # this sleep ensures that the log is captured before the
              # capture_log wrapper terminates.
              Process.sleep(100)
            end) =~
-             "Exception raised while handling /Anoma.Proto.ExecutorService/Add"
+             "Exception raised while handling /Anoma.Proto.ExecutorService/RunScry"
 
-    {client, transaction}
+    {client, key}
   end
 end

--- a/apps/anoma_lib/lib/examples/enock.ex
+++ b/apps/anoma_lib/lib/examples/enock.ex
@@ -63,7 +63,7 @@ defmodule Examples.ENock do
     arm = [10, [2 | zero_counter_arm], 1, 0 | 0]
     sample = 0
     keyspace = 0
-    [[8, [1 | sample], [1 | keyspace], [1 | arm], 0 | 1] | 999]
+    [arm, 0, [8, [1 | sample], [1 | keyspace], [1 | arm], 0 | 1] | 999]
   end
 
   @spec inc(Noun.t()) :: Noun.t()
@@ -73,7 +73,7 @@ defmodule Examples.ENock do
     arm = [10, [2 | increment_value_arm], 1, 0 | 0]
     sample = 0
     keyspace = 0
-    [[8, [1 | sample], [1 | keyspace], [1 | arm], 0 | 1] | 999]
+    [arm, 0, [8, [1 | sample], [1 | keyspace], [1 | arm], 0 | 1] | 999]
   end
 
   ####################################################################
@@ -172,8 +172,7 @@ defmodule Examples.ENock do
         |> Noun.Nounable.to_noun()
       ) do
     trivial_swap_arm = [1 | tx_noun]
-    keyspace = 0
-    swap = [[1, keyspace, trivial_swap_arm, 0 | 909], 0 | 707]
+    swap = [trivial_swap_arm, 0 | 909]
     swap
   end
 

--- a/apps/anoma_lib/lib/examples/enock.ex
+++ b/apps/anoma_lib/lib/examples/enock.ex
@@ -63,17 +63,17 @@ defmodule Examples.ENock do
     arm = [10, [2 | zero_counter_arm], 1, 0 | 0]
     sample = 0
     keyspace = 0
-    [arm, 0, [8, [1 | sample], [1 | keyspace], [1 | arm], 0 | 1] | 999]
+    [[[key] | 0] | 0]
   end
 
   @spec inc(Noun.t()) :: Noun.t()
-  def inc(key \\ "key") do
+  def inc(key \\ "key", value \\ 0) do
     increment_value_arm = [[1 | [key]], 4, 12, [1 | 0], [0 | 6], 1, [key] | 0]
     # Place the result in a list
     arm = [10, [2 | increment_value_arm], 1, 0 | 0]
     sample = 0
     keyspace = 0
-    [arm, 0, [8, [1 | sample], [1 | keyspace], [1 | arm], 0 | 1] | 999]
+    [[[key] | (value + 1)] | 0]
   end
 
   ####################################################################
@@ -171,8 +171,8 @@ defmodule Examples.ENock do
         tx_noun \\ Examples.ETransparent.ETransaction.swap_from_actions()
         |> Noun.Nounable.to_noun()
       ) do
-    trivial_swap_arm = [1 | tx_noun]
-    swap = [trivial_swap_arm, 0 | 909]
+    trivial_swap_arm = tx_noun
+    swap = trivial_swap_arm
     swap
   end
 

--- a/apps/anoma_lib/lib/examples/enock.ex
+++ b/apps/anoma_lib/lib/examples/enock.ex
@@ -59,21 +59,12 @@ defmodule Examples.ENock do
 
   @spec zero(Noun.t()) :: Noun.t()
   def zero(key \\ "key") do
-    zero_counter_arm = [1, [key] | 0]
-    arm = [10, [2 | zero_counter_arm], 1, 0 | 0]
-    sample = 0
-    keyspace = 0
     [[[key] | 0] | 0]
   end
 
   @spec inc(Noun.t()) :: Noun.t()
   def inc(key \\ "key", value \\ 0) do
-    increment_value_arm = [[1 | [key]], 4, 12, [1 | 0], [0 | 6], 1, [key] | 0]
-    # Place the result in a list
-    arm = [10, [2 | increment_value_arm], 1, 0 | 0]
-    sample = 0
-    keyspace = 0
-    [[[key] | (value + 1)] | 0]
+    [[[key] | value + 1] | 0]
   end
 
   ####################################################################

--- a/apps/anoma_lib/lib/noun.ex
+++ b/apps/anoma_lib/lib/noun.ex
@@ -183,7 +183,7 @@ defmodule Noun do
       fal
     else
       haz = Murmur.hash_x86_32(key, seed)
-      ham = haz >>> 31 |> bxor(haz &&& (1 <<< 31) - 1)
+      ham = (haz >>> 31) |> bxor(haz &&& (1 <<< 31) - 1)
 
       unless ham == 0 do
         ham

--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -322,8 +322,8 @@ defmodule Anoma.Node.Examples.ETransaction do
   end
 
   @spec inc(String.t()) :: {Backends.backend(), Noun.t()}
-  def inc(key \\ "key") do
-    {:debug_term_storage, Examples.ENock.inc(key)}
+  def inc(key \\ "key", value \\ 0) do
+    {:debug_term_storage, Examples.ENock.inc(key, value)}
   end
 
   @spec trivial_transparent_transaction() :: {Backends.backend(), Noun.t()}
@@ -623,7 +623,7 @@ defmodule Anoma.Node.Examples.ETransaction do
       %Mempool.Tx{
         code: [0 | 0],
         backend: :debug_term_storage,
-        vm_result: :vm_error,
+        vm_result: ["ok", 0 | 0],
         tx_result: :error
       }
       |> Noun.Nounable.to_noun()
@@ -671,7 +671,7 @@ defmodule Anoma.Node.Examples.ETransaction do
     read_txs_write_nothing(node_id)
     key = "key"
 
-    {_backend, code} = inc(key)
+    {_backend, code} = inc(key, 1)
 
     inc_counter_submit_with_zero(node_id)
 
@@ -708,7 +708,7 @@ defmodule Anoma.Node.Examples.ETransaction do
       %Mempool.Tx{
         code: [0 | 0],
         backend: :debug_term_storage,
-        vm_result: :vm_error,
+        vm_result: ["ok", 0 | 0],
         tx_result: :error
       }
       |> Noun.Nounable.to_noun()

--- a/apps/anoma_node/lib/examples/esolver.ex
+++ b/apps/anoma_node/lib/examples/esolver.ex
@@ -117,8 +117,7 @@ defmodule Anoma.Node.Examples.ESolver do
     IntentPool.new_intent(node_id, tx)
 
     tx_candidate = [
-      [1, 0, [1 | tx |> Noun.Nounable.to_noun()], 0 | 909],
-      0 | 707
+      [1 | tx |> Noun.Nounable.to_noun()], 0 | 909
     ]
 
     tx_filter = [

--- a/apps/anoma_node/lib/examples/esolver.ex
+++ b/apps/anoma_node/lib/examples/esolver.ex
@@ -116,9 +116,7 @@ defmodule Anoma.Node.Examples.ESolver do
 
     IntentPool.new_intent(node_id, tx)
 
-    tx_candidate = [
-      [1 | tx |> Noun.Nounable.to_noun()], 0 | 909
-    ]
+    tx_candidate = tx |> Noun.Nounable.to_noun()
 
     tx_filter = [
       Anoma.Node.Event.node_filter(node_id),

--- a/apps/anoma_node/lib/node/intents/solver.ex
+++ b/apps/anoma_node/lib/node/intents/solver.ex
@@ -284,7 +284,7 @@ defmodule Anoma.Node.Intents.Solver do
   @spec submit(Intent.t(), String.t()) :: :ok
   def submit(tx = %Anoma.RM.Transparent.Transaction{}, node_id) do
     tx_noun = tx |> Noun.Nounable.to_noun()
-    tx_candidate = [[1 | tx_noun], 0 | 909]
+    tx_candidate = tx_noun
     tx_filter = [Node.Event.node_filter(node_id), %Mempool.Events.TxFilter{}]
 
     with_subscription [tx_filter] do

--- a/apps/anoma_node/lib/node/intents/solver.ex
+++ b/apps/anoma_node/lib/node/intents/solver.ex
@@ -284,7 +284,7 @@ defmodule Anoma.Node.Intents.Solver do
   @spec submit(Intent.t(), String.t()) :: :ok
   def submit(tx = %Anoma.RM.Transparent.Transaction{}, node_id) do
     tx_noun = tx |> Noun.Nounable.to_noun()
-    tx_candidate = [[1, 0, [1 | tx_noun], 0 | 909], 0 | 707]
+    tx_candidate = [[1 | tx_noun], 0 | 909]
     tx_filter = [Node.Event.node_filter(node_id), %Mempool.Events.TxFilter{}]
 
     with_subscription [tx_filter] do

--- a/apps/anoma_node/lib/node/transaction/backends/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends/backends.ex
@@ -112,9 +112,7 @@ defmodule Anoma.Node.Transaction.Backends do
   @spec vm_execute(Noun.t(), Nock.t(), binary()) ::
           {:ok, Noun.t()} | :vm_error
   defp vm_execute(maybe_jammed_tx, env, id) do
-    with {:ok, tx} <- cue_when_atom(maybe_jammed_tx),
-         {:ok, ordered_tx} <- nock(tx, [10, [6, 1 | id], 0 | 1], env),
-         {:ok, result} <- nock(ordered_tx, [9, 2, 0 | 1], env) do
+    with {:ok, result} <- cue_when_atom(maybe_jammed_tx) do
       {:ok, result}
     else
       _e -> :vm_error

--- a/apps/anoma_node/lib/node/transaction/backends/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends/backends.ex
@@ -25,8 +25,6 @@ defmodule Anoma.Node.Transaction.Backends do
   require Node.Event
   require Noun
 
-  import Nock
-
   use TypedStruct
 
   @type backend() ::
@@ -56,38 +54,9 @@ defmodule Anoma.Node.Transaction.Backends do
         when id: binary(),
              node_id: String.t(),
              back: backend()
-  def execute(node_id, {backend, tx_code}, id) do
+  def execute(node_id, {backend, tx}, id) do
     time = Storage.current_time(node_id)
-
-    scry =
-      fn list ->
-        if list do
-          with [id, key] <- list |> Noun.list_nock_to_erlang(),
-               {:ok, value} <-
-                 (case backend do
-                    {:read_only, _pid} ->
-                      Storage.read(
-                        node_id,
-                        {time, key |> Noun.list_nock_to_erlang()}
-                      )
-
-                    _ ->
-                      Ordering.read(
-                        node_id,
-                        {id, key |> Noun.list_nock_to_erlang()}
-                      )
-                  end) do
-            {:ok, value |> Noun.Nounable.to_noun()}
-          else
-            _ -> :error
-          end
-        else
-          :error
-        end
-      end
-
-    env = %Nock{scry_function: scry}
-    vm_result = vm_execute(tx_code, env, id)
+    vm_result = cue_when_atom(tx)
     result_event(id, vm_result, node_id, backend)
 
     res =
@@ -109,23 +78,17 @@ defmodule Anoma.Node.Transaction.Backends do
   #                       VM Execution                       #
   ############################################################
 
-  @spec vm_execute(Noun.t(), Nock.t(), binary()) ::
-          {:ok, Noun.t()} | :vm_error
-  defp vm_execute(maybe_jammed_tx, env, id) do
-    with {:ok, result} <- cue_when_atom(maybe_jammed_tx) do
+  @spec cue_when_atom(Noun.t()) :: {:ok, Noun.t()} | :vm_error
+  defp cue_when_atom(tx) when Noun.is_noun_atom(tx) do
+    with {:ok, result} <- Noun.Jam.cue(tx) do
       {:ok, result}
     else
       _e -> :vm_error
     end
   end
 
-  @spec cue_when_atom(Noun.t()) :: :error | {:ok, Noun.t()}
-  defp cue_when_atom(tx_code) when Noun.is_noun_atom(tx_code) do
-    Noun.Jam.cue(tx_code)
-  end
-
-  defp cue_when_atom(tx_code) do
-    {:ok, tx_code}
+  defp cue_when_atom(tx) do
+    {:ok, tx}
   end
 
   ############################################################

--- a/apps/anoma_node/lib/node/transaction/backends/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends/backends.ex
@@ -111,10 +111,9 @@ defmodule Anoma.Node.Transaction.Backends do
 
   @spec vm_execute(Noun.t(), Nock.t(), binary()) ::
           {:ok, Noun.t()} | :vm_error
-  defp vm_execute(tx_code, env, id) do
-    with {:ok, code} <- cue_when_atom(tx_code),
-         {:ok, [_ | stage_2_tx]} <- nock(code, [9, 2, 0 | 1], env),
-         {:ok, ordered_tx} <- nock(stage_2_tx, [10, [6, 1 | id], 0 | 1], env),
+  defp vm_execute(maybe_jammed_tx, env, id) do
+    with {:ok, tx} <- cue_when_atom(maybe_jammed_tx),
+         {:ok, ordered_tx} <- nock(tx, [10, [6, 1 | id], 0 | 1], env),
          {:ok, result} <- nock(ordered_tx, [9, 2, 0 | 1], env) do
       {:ok, result}
     else

--- a/apps/anoma_node/lib/node/transaction/executor/executor.ex
+++ b/apps/anoma_node/lib/node/transaction/executor/executor.ex
@@ -161,34 +161,35 @@ defmodule Anoma.Node.Transaction.Executor do
   #                 Genserver Implementation                 #
   ############################################################
 
-  defp handle_scry(backend, id, list, state = %Executor{}) do
+  defp handle_scry(backend, id, list, state = %Executor{})
+       when is_list(list) do
     node_id = state.node_id
 
-    if list do
-      with key <- list |> Noun.list_nock_to_erlang(),
-           {:ok, value} <-
-             (case backend do
-                :read_only ->
-                  time = Storage.current_time(node_id)
+    with key <- list |> Noun.list_nock_to_erlang(),
+         {:ok, value} <-
+           (case backend do
+              :read_only ->
+                time = Storage.current_time(node_id)
 
-                  Storage.read(
-                    node_id,
-                    {time, key |> Noun.list_nock_to_erlang()}
-                  )
+                Storage.read(
+                  node_id,
+                  {time, key |> Noun.list_nock_to_erlang()}
+                )
 
-                _ ->
-                  Ordering.read(
-                    node_id,
-                    {id, key |> Noun.list_nock_to_erlang()}
-                  )
-              end) do
-        {:ok, value |> Noun.Nounable.to_noun()}
-      else
-        _ -> :error
-      end
+              _ ->
+                Ordering.read(
+                  node_id,
+                  {id, key |> Noun.list_nock_to_erlang()}
+                )
+            end) do
+      {:ok, value |> Noun.Nounable.to_noun()}
     else
-      :error
+      _ -> :error
     end
+  end
+
+  defp handle_scry(_backend, _id, _obj, _state = %Executor{}) do
+    :error
   end
 
   # @doc """

--- a/apps/anoma_node/lib/node/transaction/executor/executor.ex
+++ b/apps/anoma_node/lib/node/transaction/executor/executor.ex
@@ -130,7 +130,10 @@ defmodule Anoma.Node.Transaction.Executor do
   end
 
   def scry(node_id, backend, list, id \\ :crypto.strong_rand_bytes(16)) do
-    GenServer.call(Registry.via(node_id, __MODULE__), {:scry, backend, id, list})
+    GenServer.call(
+      Registry.via(node_id, __MODULE__),
+      {:scry, backend, id, list}
+    )
   end
 
   ############################################################
@@ -148,6 +151,7 @@ defmodule Anoma.Node.Transaction.Executor do
     {:noreply, state}
   end
 
+  @impl true
   def handle_call({:scry, backend, id, list}, _from, state) do
     reply = handle_scry(backend, id, list, state)
     {:reply, reply, state}
@@ -159,32 +163,34 @@ defmodule Anoma.Node.Transaction.Executor do
 
   defp handle_scry(backend, id, list, state = %Executor{}) do
     node_id = state.node_id
-    if list do
-          with key <- list |> Noun.list_nock_to_erlang(),
-               {:ok, value} <-
-                 (case backend do
-                    :read_only ->
-		      time = Storage.current_time(node_id)
-                      Storage.read(
-                        node_id,
-                        {time, key |> Noun.list_nock_to_erlang()}
-                      )
 
-                    _ ->
-                      Ordering.read(
-                        node_id,
-                        {id, key |> Noun.list_nock_to_erlang()}
-                      )
-                  end) do
-            {:ok, value |> Noun.Nounable.to_noun()}
-          else
-            _ -> :error
-          end
-        else
-          :error
-        end
+    if list do
+      with key <- list |> Noun.list_nock_to_erlang(),
+           {:ok, value} <-
+             (case backend do
+                :read_only ->
+                  time = Storage.current_time(node_id)
+
+                  Storage.read(
+                    node_id,
+                    {time, key |> Noun.list_nock_to_erlang()}
+                  )
+
+                _ ->
+                  Ordering.read(
+                    node_id,
+                    {id, key |> Noun.list_nock_to_erlang()}
+                  )
+              end) do
+        {:ok, value |> Noun.Nounable.to_noun()}
+      else
+        _ -> :error
+      end
+    else
+      :error
+    end
   end
-  
+
   # @doc """
   # I launch a transaction in its own Task to execute.
   # """

--- a/apps/anoma_node/lib/node/transaction/executor/executor.ex
+++ b/apps/anoma_node/lib/node/transaction/executor/executor.ex
@@ -24,6 +24,7 @@ defmodule Anoma.Node.Transaction.Executor do
   alias Anoma.Node.Transaction.Mempool
   alias Anoma.Node.Transaction.Ordering
   alias Anoma.Node.Transaction.Executor.Events
+  alias Anoma.Node.Transaction.Storage
 
   require Node.Event
 
@@ -128,6 +129,10 @@ defmodule Anoma.Node.Transaction.Executor do
     GenServer.cast(Registry.via(node_id, __MODULE__), {:execute, consensus})
   end
 
+  def scry(node_id, backend, list, id \\ :crypto.strong_rand_bytes(16)) do
+    GenServer.call(Registry.via(node_id, __MODULE__), {:scry, backend, id, list})
+  end
+
   ############################################################
   #                    Genserver Behavior                    #
   ############################################################
@@ -143,10 +148,43 @@ defmodule Anoma.Node.Transaction.Executor do
     {:noreply, state}
   end
 
+  def handle_call({:scry, backend, id, list}, _from, state) do
+    reply = handle_scry(backend, id, list, state)
+    {:reply, reply, state}
+  end
+
   ############################################################
   #                 Genserver Implementation                 #
   ############################################################
 
+  defp handle_scry(backend, id, list, state = %Executor{}) do
+    node_id = state.node_id
+    if list do
+          with key <- list |> Noun.list_nock_to_erlang(),
+               {:ok, value} <-
+                 (case backend do
+                    :read_only ->
+		      time = Storage.current_time(node_id)
+                      Storage.read(
+                        node_id,
+                        {time, key |> Noun.list_nock_to_erlang()}
+                      )
+
+                    _ ->
+                      Ordering.read(
+                        node_id,
+                        {id, key |> Noun.list_nock_to_erlang()}
+                      )
+                  end) do
+            {:ok, value |> Noun.Nounable.to_noun()}
+          else
+            _ -> :error
+          end
+        else
+          :error
+        end
+  end
+  
   # @doc """
   # I launch a transaction in its own Task to execute.
   # """

--- a/apps/anoma_node/lib/node/transport/grpc/endpoint/executor.ex
+++ b/apps/anoma_node/lib/node/transport/grpc/endpoint/executor.ex
@@ -3,6 +3,7 @@ defmodule Anoma.Node.Transport.GRPC.Servers.Executor do
   alias Anoma.Node.Transaction.Executor
   alias Anoma.Node.Transaction.Executor
   alias Anoma.Proto.Executor.AddROTransaction
+  alias Anoma.Proto.Executor.RunScry
   alias Anoma.Proto.Nock.Error
   alias Anoma.Proto.Nock.Success
   alias GRPC.Server.Stream
@@ -42,6 +43,38 @@ defmodule Anoma.Node.Transport.GRPC.Servers.Executor do
 
       {_time, result} ->
         %AddROTransaction.Response{
+          result: {:success, %Success{result: result |> Noun.Jam.jam()}}
+        }
+    end
+  end
+
+  @spec run_scry(RunScry.Request.t(), Stream.t()) ::
+          RunScry.Response.t()
+  def run_scry(request, _stream) do
+    Logger.debug("GRPC #{inspect(__ENV__.function)}: #{inspect(request)}")
+
+    # validate the request. will raise if not valid.
+    validate_request!(request)
+
+    # ensure the node id exists
+    if Registry.whereis(request.node.id, Executor) == nil do
+      raise_grpc_error!(:invalid_node_id)
+    end
+
+    space_noun = request.space |> Noun.Jam.cue!()
+
+    value = Executor.scry(
+      request.node.id,
+      :read_only,
+      space_noun
+    )
+
+    case value do
+      :error ->
+        %RunScry.Response{result: {:error, %Error{error: "absent"}}}
+	
+      {:ok, result} ->
+        %RunScry.Response{
           result: {:success, %Success{result: result |> Noun.Jam.jam()}}
         }
     end

--- a/apps/anoma_node/lib/node/transport/grpc/endpoint/executor.ex
+++ b/apps/anoma_node/lib/node/transport/grpc/endpoint/executor.ex
@@ -61,18 +61,19 @@ defmodule Anoma.Node.Transport.GRPC.Servers.Executor do
       raise_grpc_error!(:invalid_node_id)
     end
 
-    space_noun = request.space |> Noun.Jam.cue!()
+    key_noun = request.key |> Noun.Jam.cue!()
 
-    value = Executor.scry(
-      request.node.id,
-      :read_only,
-      space_noun
-    )
+    value =
+      Executor.scry(
+        request.node.id,
+        :read_only,
+        key_noun
+      )
 
     case value do
       :error ->
         %RunScry.Response{result: {:error, %Error{error: "absent"}}}
-	
+
       {:ok, result} ->
         %RunScry.Response{
           result: {:success, %Success{result: result |> Noun.Jam.jam()}}

--- a/apps/anoma_node/lib/node/transport/grpc/endpoint/executor.ex
+++ b/apps/anoma_node/lib/node/transport/grpc/endpoint/executor.ex
@@ -2,7 +2,6 @@ defmodule Anoma.Node.Transport.GRPC.Servers.Executor do
   alias Anoma.Node.Registry
   alias Anoma.Node.Transaction.Executor
   alias Anoma.Node.Transaction.Executor
-  alias Anoma.Proto.Executor.AddROTransaction
   alias Anoma.Proto.Executor.RunScry
   alias Anoma.Proto.Nock.Error
   alias Anoma.Proto.Nock.Success
@@ -13,40 +12,6 @@ defmodule Anoma.Node.Transport.GRPC.Servers.Executor do
   import Anoma.Protobuf.ErrorHandler
 
   require Logger
-
-  @spec add(AddROTransaction.Request.t(), Stream.t()) ::
-          AddROTransaction.Response.t()
-  def add(request, _stream) do
-    Logger.debug("GRPC #{inspect(__ENV__.function)}: #{inspect(request)}")
-
-    # validate the request. will raise if not valid.
-    validate_request!(request)
-
-    # ensure the node id exists
-    if Registry.whereis(request.node.id, Executor) == nil do
-      raise_grpc_error!(:invalid_node_id)
-    end
-
-    tx_noun = request.transaction.transaction |> Noun.Jam.cue!()
-
-    Executor.launch(
-      request.node.id,
-      {{:read_only, self()}, tx_noun}
-    )
-
-    # todo: GRPC/HTTP requests should not be long-lived. They should be as short
-    #       as possible. In the future this would return the tx id, and the
-    #       result of the transaction will be sent to the client via an event.
-    receive do
-      {_time, :error} ->
-        %AddROTransaction.Response{result: {:error, %Error{error: "absent"}}}
-
-      {_time, result} ->
-        %AddROTransaction.Response{
-          result: {:success, %Success{result: result |> Noun.Jam.jam()}}
-        }
-    end
-  end
 
   @spec run_scry(RunScry.Request.t(), Stream.t()) ::
           RunScry.Response.t()

--- a/apps/anoma_node/lib/node/transport/grpc/endpoint/mempool.ex
+++ b/apps/anoma_node/lib/node/transport/grpc/endpoint/mempool.ex
@@ -44,6 +44,6 @@ defmodule Anoma.Node.Transport.GRPC.Servers.Mempool do
   # """
   @spec wrap_transaction(Noun.t()) :: Noun.t()
   defp wrap_transaction(transaction) do
-    [[1 | transaction], 0 | 909]
+    transaction
   end
 end

--- a/apps/anoma_node/lib/node/transport/grpc/endpoint/mempool.ex
+++ b/apps/anoma_node/lib/node/transport/grpc/endpoint/mempool.ex
@@ -44,6 +44,6 @@ defmodule Anoma.Node.Transport.GRPC.Servers.Mempool do
   # """
   @spec wrap_transaction(Noun.t()) :: Noun.t()
   defp wrap_transaction(transaction) do
-    [[1, 0, [1 | transaction], 0 | 909], 0 | 707]
+    [[1 | transaction], 0 | 909]
   end
 end

--- a/apps/anoma_protobuf/lib/validate.ex
+++ b/apps/anoma_protobuf/lib/validate.ex
@@ -182,11 +182,11 @@ defimpl Validate, for: Anoma.Proto.Mempool.Transaction do
 end
 
 ############################################################
-#                       Read-Only Transaction              #
+#                       Scry                               #
 ############################################################
 
-defimpl Validate, for: [Anoma.Proto.Executor.AddROTransaction] do
-  @not_nil [:node, :transaction]
+defimpl Validate, for: [Anoma.Proto.Executor.RunScry] do
+  @not_nil [:node, :key]
 
   def valid?(request) do
     Validate.Helpers.validate(request, non_nil: @not_nil)

--- a/apps/anoma_protobuf/priv/protobuf/anoma.proto
+++ b/apps/anoma_protobuf/priv/protobuf/anoma.proto
@@ -87,9 +87,6 @@ service PubSubService {
  * Add a read-only transaction to or run a scry on the executor.
  */
 service ExecutorService {
-  rpc Add(Anoma.Proto.Executor.AddROTransaction.Request)
-      returns (Anoma.Proto.Executor.AddROTransaction.Response) {}
-
   rpc RunScry(Anoma.Proto.Executor.RunScry.Request)
       returns (Anoma.Proto.Executor.RunScry.Response) {}
 }

--- a/apps/anoma_protobuf/priv/protobuf/anoma.proto
+++ b/apps/anoma_protobuf/priv/protobuf/anoma.proto
@@ -84,9 +84,12 @@ service PubSubService {
 }
 
 /*
- * Add a read-only transaction to the executor.
+ * Add a read-only transaction to or run a scry on the executor.
  */
 service ExecutorService {
   rpc Add(Anoma.Proto.Executor.AddROTransaction.Request)
       returns (Anoma.Proto.Executor.AddROTransaction.Response) {}
+
+  rpc RunScry(Anoma.Proto.Executor.RunScry.Request)
+      returns (Anoma.Proto.Executor.RunScry.Response) {}
 }

--- a/apps/anoma_protobuf/priv/protobuf/executor.proto
+++ b/apps/anoma_protobuf/priv/protobuf/executor.proto
@@ -7,23 +7,6 @@ import "nock.proto";
 import "mempool.proto";
 
 /*
- * Add a read-only transaction to the executor.
-*/
-message AddROTransaction {
-  message Request {
-    Node node = 1;
-    Mempool.Transaction transaction = 2;
-  }
-
-  message Response {
-    oneof result {
-      Nock.Success success = 1;
-      Nock.Error error = 2;
-    }
-  }
-}
-
-/*
  * Run a scry on the executor.
 */
 message RunScry {

--- a/apps/anoma_protobuf/priv/protobuf/executor.proto
+++ b/apps/anoma_protobuf/priv/protobuf/executor.proto
@@ -29,7 +29,7 @@ message AddROTransaction {
 message RunScry {
   message Request {
     Node node = 1;
-    bytes space = 2;
+    bytes key = 2;
   }
 
   message Response {

--- a/apps/anoma_protobuf/priv/protobuf/executor.proto
+++ b/apps/anoma_protobuf/priv/protobuf/executor.proto
@@ -22,3 +22,20 @@ message AddROTransaction {
     }
   }
 }
+
+/*
+ * Run a scry on the executor.
+*/
+message RunScry {
+  message Request {
+    Node node = 1;
+    bytes space = 2;
+  }
+
+  message Response {
+    oneof result {
+      Nock.Success success = 1;
+      Nock.Error error = 2;
+    }
+  }
+}


### PR DESCRIPTION
This PR is an attempt to remove transaction candidates so that Anoma transactions no longer need to be preprocessed (i.e. being run through the Nock VM three times over) before being executed. Specifically, the following changes have been made:
* Removed the threefold Nock evaluation of transaction code by nodes so that the transaction bytes are now sent directly to the backend
* Removed the Nock wrapping/bytes placed around transactions during submission since the RPC now expects the transaction itself rather than something that eventually evaluates to the transaction
* Added an RPC function that allows clients to query the blobs at specified keyspaces since this can no longer be done through read only transactions (which require Nock evaluation)
* Modified scry function for proving so that it directly queries the blob at a given keyspace instead of sending a read only transaction (that contains a scry).
* Replaced constants/byte sequences around the codebase with the result that would have been obtained by executing the Nock VM on them. This reflects the fact that nodes no longer do this execution.