### PR TITLE
docs: fix typos across multiple documentation files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,17 +113,17 @@
   + [executor module](https://github.com/anoma/anoma/pull/622)
   + [worker module](https://github.com/anoma/anoma/pull/623)
 
-- Examplifying the codebase
-  + [Examplifying clock](https://github.com/anoma/anoma/pull/598)
-  + [Examplifying serialization](https://github.com/anoma/anoma/pull/587)
-  + [Examplifying blocks](https://github.com/anoma/anoma/pull/582)
-  + [Examplifying commitment trees](https://github.com/anoma/anoma/pull/583)
-  + [Examplifying nouns](https://github.com/anoma/anoma/pull/631)
-  + [Examplifying storage](https://github.com/anoma/anoma/pull/603)
-  + [Examplifying pinger](https://github.com/anoma/anoma/pull/611)
-  + [Examplifying intent](https://github.com/anoma/anoma/pull/605)
-  + [Examplifying the identity machine](https://github.com/anoma/anoma/pull/606)
-  + [Examplifying dumper](https://github.com/anoma/anoma/pull/613)
+- Exemplifying the codebase
+  + [Exemplifying clock](https://github.com/anoma/anoma/pull/598)
+  + [Exemplifying serialization](https://github.com/anoma/anoma/pull/587)
+  + [Exemplifying blocks](https://github.com/anoma/anoma/pull/582)
+  + [Exemplifying commitment trees](https://github.com/anoma/anoma/pull/583)
+  + [Exemplifying nouns](https://github.com/anoma/anoma/pull/631)
+  + [Exemplifying storage](https://github.com/anoma/anoma/pull/603)
+  + [Exemplifying pinger](https://github.com/anoma/anoma/pull/611)
+  + [Exemplifying intent](https://github.com/anoma/anoma/pull/605)
+  + [Exemplifying the identity machine](https://github.com/anoma/anoma/pull/606)
+  + [Exemplifying dumper](https://github.com/anoma/anoma/pull/613)
 
 
 

--- a/documentation/contributing/examples-over-testing.livemd
+++ b/documentation/contributing/examples-over-testing.livemd
@@ -90,7 +90,7 @@ The translation of tests in classification `2.` into examples can be split into 
 
 <!-- livebook:{"branch_parent_index":4} -->
 
-## Examplifying non Actors
+## Exemplifying non Actors
 
 A good example we can use, is a test in our `resource` test file.
 
@@ -238,7 +238,7 @@ Further, if we were to not do a 1 to 1 extraction, we could factor some of the d
 
 <!-- livebook:{"branch_parent_index":4} -->
 
-## Examplifying stateful code
+## Exemplifying stateful code
 
 ```elixir
 defmodule AnomaTest.Node.Executor.Worker do
@@ -384,7 +384,7 @@ defmodule Example.Transaction do
       nullifiers: [ERsource.nullifier_space_bucks_b()],
       proofs: [proved_spacebucks_a(), proved_spacebucks_b()]
     }
-    # This wans't in the original test!
+    # This wasn't in the original test!
     assert verify(trans)
     trans
   end

--- a/documentation/contributing/git.livemd
+++ b/documentation/contributing/git.livemd
@@ -52,9 +52,9 @@ This document is best viewed from within liveview, as the charts do not render o
 * `next` - a branch that has a superset of features that will be
   included in the next release
 
-* `maint` - a maintnance branch that will be updated if bugs are found
+* `maint` - a maintenance branch that will be updated if bugs are found
 
-* `integreation branch` - a topic that merges a bunch of other topics
+* `integration branch` - a topic that merges a bunch of other topics
 
 ## Naming conventions
 

--- a/documentation/contributing/mnesia-vs-actor-state.livemd
+++ b/documentation/contributing/mnesia-vs-actor-state.livemd
@@ -38,11 +38,11 @@ As discussed in the user data documentation, loading a `dump` file overwrites th
 
 ## Mnesia Storage
 
-The philosophy for what is stored in Mnesia should be: "Is this something the user should be able to query and write code over". Since Anoma is a distributed operating system project, many of the answers should be yes. The user should be able to make full fledged progrmas on Anoma and extend the system.
+The philosophy for what is stored in Mnesia should be: "Is this something the user should be able to query and write code over". Since Anoma is a distributed operating system project, many of the answers should be yes. The user should be able to make full fledged programs on Anoma and extend the system.
 
 ## Actor Storage
 
-Actor storage on the other hand are for things we don't wish the user to be able to query. Thus implementaiton details about the execution should be omitted from user visible storage, and would be better served stored on the Actor.
+Actor storage on the other hand are for things we don't wish the user to be able to query. Thus implementation details about the execution should be omitted from user visible storage, and would be better served stored on the Actor.
 
 A good example of this is the old ordering logic.
 

--- a/documentation/contributing/style-guide.livemd
+++ b/documentation/contributing/style-guide.livemd
@@ -119,7 +119,7 @@ Exceptions might exist but should be noted explicitly in PR and commit messages.
 If `foo` uses Router or GenServer functionality, it should be a `call` if and only if either
 
 1. The underlying state is unchanged by calling `foo`
-2. There are synchronizaton requirements that `foo` has to fullfill.
+2. There are synchronization  requirements that `foo` has to fulfill.
 
 #### Rule 1.6
 

--- a/documentation/contributing/testing/running-tests.livemd
+++ b/documentation/contributing/testing/running-tests.livemd
@@ -78,7 +78,7 @@ The error text hints at a suggestion on how to solve the problem.
 MIX_ENV=iex iex --sname mariari --cookie mariari -S mix
 ```
 
-I recommend using the `iex` environment over the `test` environment that is shwon in the error, as in the `Anoma` project, we set the `test` environment to have `Config.config/2` to have the following settings:
+I recommend using the `iex` environment over the `test` environment that is shown in the error, as in the `Anoma` project, we set the `test` environment to have `Config.config/2` to have the following settings:
 
 <!-- livebook:{"force_markdown":true} -->
 
@@ -203,7 +203,7 @@ Since most (if not all!) tests are composed from examples. One can simply run th
 
 <!-- livebook:{"break_markdown":true} -->
 
-If we take `AnomaTest.LiveBook.Example` as our exmaple, then we can run the individual tests like the following.
+If we take `AnomaTest.LiveBook.Example` as our example, then we can run the individual tests like the following.
 
 <!-- livebook:{"break_markdown":true} -->
 

--- a/documentation/contributing/understanding-any-module.livemd
+++ b/documentation/contributing/understanding-any-module.livemd
@@ -52,7 +52,7 @@ module. Thankfully, the codebase is setup in such a way that one can
 always interactively play with any given module.
 
 This is done by simply checking out the examples folder, and finding the
-module you wish to learn to learn about.
+module you wish to learn about.
 
 For example, let us learn about the nock. In the codebase currently
 this can be found here:

--- a/documentation/contributing/writing-documents.livemd
+++ b/documentation/contributing/writing-documents.livemd
@@ -39,7 +39,7 @@ To better do this, the codebase as a few levels of documentations:
 
 `1.` is what specifies what `Anoma` is abstractly.
 
-`2.` serves the purpose of general knowledge transfer. Some documents serve to provide newcomers with information about various parts of Anoma's development process, others provide visual presentations to various parts of the codebase, while even others provide indepth analys of the codebase.
+`2.` serves the purpose of general knowledge transfer. Some documents serve to provide newcomers with information about various parts of Anoma's development process, others provide visual presentations to various parts of the codebase, while even others provide in-depth analysis of the codebase.
 
 `3.` is documents regarding module and function specifics. This is often augmented by `2.` for better context and examples.
 

--- a/documentation/hoon.livemd
+++ b/documentation/hoon.livemd
@@ -30,10 +30,10 @@
 This guide hopefully serves you to be able to reason about the nock
 code in Anoma. It is written for a non Hoon audience, so if you are
 familiar with Hoon, you may find use in the Nock code as there is a
-big emphesis on nock itself, rather than just Hoon. If you are not
+big emphasis on nock itself, rather than just Hoon. If you are not
 familiar with Hoon, this merely shows you how to use the
 [Urbit](https://urbit.org/) environment to aid Nock code.
 
 A good general guide to Hoon can be found [At the Hoon School](https://developers.urbit.org/guides/core/hoon-school).
-Hopefully the documention here serves as a good companion piece for
+Hopefully the documentation here serves as a good companion piece for
 anyone interested in Nock, Hoon, or Anoma.

--- a/documentation/hoon/calling.livemd
+++ b/documentation/hoon/calling.livemd
@@ -181,7 +181,7 @@ In this case, it doesn't do much, but it makes sense if we look at a real exampl
 ]
 ```
 
-On this example I want to focus on the `dec` call `[8 [9 342 0 7] 9 2 10 ...]`. We know this is dec, as we already know it's offset inside layer 1 is `342`, but it's located at `7` as we've pushed `add` with its sample to the tree, making layer 1's index go to 7 (see the [section on how indicies change](./dumping.livemd#how-index-of-layers-change)) relative to `add`.
+On this example I want to focus on the `dec` call `[8 [9 342 0 7] 9 2 10 ...]`. We know this is dec, as we already know it's offset inside layer 1 is `342`, but it's located at `7` as we've pushed `add` with its sample to the tree, making layer 1's index go to 7 (see the [section on how indices  change](./dumping.livemd#how-index-of-layers-change)) relative to `add`.
 
 What is very interesting, is that since the [gate](https://developers.urbit.org/reference/glossary/gate) evaluates to the nock function we wish, we can follow it up with the simple `[9 2 10 [6 ...] 0 ...]` pattern we found before.
 
@@ -231,7 +231,7 @@ Which gives us the correct computation to run dec on Anoma.
 
 ## What a Hoon function call actually does
 
-So far this document has only outlined calling Hoon functions by hand, but what does the cannonical application form generate?
+So far this document has only outlined calling Hoon functions by hand, but what does the canonical application form generate?
 
 ```hoon
 > =>  anoma  (dec 3)
@@ -280,9 +280,9 @@ Let us break down this expression
 
 Thus as we can see, the calling convention of Hoon is not very complicated, and is mostly sensible about trying to preserve the environments things are called in.
 
-## Paramarterized Modules: Or How Gates are just Cores
+## Parameterized  Modules: Or How Gates are just Cores
 
-A common occurence in our standard library is the use of paramartized modules. However something interesting to note is that on the [gate](https://developers.urbit.org/reference/glossary/gate) documentation, it mentions
+A common occurrence  in our standard library is the use of parameterized  modules. However something interesting to note is that on the [gate](https://developers.urbit.org/reference/glossary/gate) documentation, it mentions
 
 > A [gate](https://developers.urbit.org/reference/glossary/gate) is [core](https://developers.urbit.org/reference/glossary/core) with one arm named $ (buc). They are often called Hoon functions because they have many of the same properties of functions from other programming languages.
 
@@ -310,9 +310,9 @@ We can see here that block is located at index `10` inside of the anoma environm
 
 next we check `lsh` which is located `90` within it, nothing out of the ordinary. We use `%7` to compose the indexing into the structure, which is reasonable.
 
-When we call `lsh` on `3` and `4` the result is exactly like we expect, we generate out the `%8` call that we disected above.
+When we call `lsh` on `3` and `4` the result is exactly like we expect, we generate out the `%8` call that we dissected above.
 
-So we can already call the `lsh` function as if no paramartized was had. This makes sense as we know that each [gate](https://developers.urbit.org/reference/glossary/gate) has a sample that it takes if no substitution is had.
+So we can already call the `lsh` function as if no parameterized was had. This makes sense as we know that each [gate](https://developers.urbit.org/reference/glossary/gate) has a sample that it takes if no substitution is had.
 
 Now let us replace the default block value with `999` (note you don't want to run this, it'll be too slow)
 
@@ -331,7 +331,7 @@ Now let us replace the default block value with `999` (note you don't want to ru
 
 The only difference that was had was in in  `[8 [9 10 0 1] 9 90 10 [6 7 [0 3] 1 999] 0 2]`. The rest of the formula stayed the same.
 
-However looking at this change, this should not be very shocking, as we have analyzed with the function above, we are simply pushing `block` to the front of the env with the `[8 [9 10 0 1] ...]`, leaing the environment being `[block anoma]`, then we simply wish to call `90` where `lsh` is located with the `6` index of the `block` environment being set to `999`.
+However looking at this change, this should not be very shocking, as we have analyzed with the function above, we are simply pushing `block` to the front of the env with the `[8 [9 10 0 1] ...]`, leaving the environment being `[block anoma]`, then we simply wish to call `90` where `lsh` is located with the `6` index of the `block` environment being set to `999`.
 
 Note the `6` index is a gate's argument which we can see with this call:
 

--- a/documentation/hoon/dumping.livemd
+++ b/documentation/hoon/dumping.livemd
@@ -49,7 +49,7 @@ We won't go into detail about calling functions in this section, however there i
 
 <!-- livebook:{"break_markdown":true} -->
 
-Speaking of functions, we should know just a few things about the layout of functions, and their important indicies.
+Speaking of functions, we should know just a few things about the layout of functions, and their important indices.
 
 Functions in Hoon are laid out as the following:
 
@@ -108,7 +108,7 @@ Note that Hoon uses `function:module` (`f:mn:...:m1`) form.
 [6 [5 [1 0] 0 6] [0 0] 8 [1 0] 8 [1 6 [5 [0 30] 4 0 6] [0 6] 9 2 10 [6 4 0 6] 0 1] 9 2 0 1]
 ```
 
-The logic here doesn't particularly matter, but here we have the nock definiton of decrement, which is wonderful!
+The logic here doesn't particularly matter, but here we have the nock definition of decrement, which is wonderful!
 
 <!-- livebook:{"break_markdown":true} -->
 
@@ -138,7 +138,7 @@ A good way to visualize the dump, is by casting the result to nock
 
 the `p`'s and `q`'s are arguments and the `%9` and `%0` are the nock instructions being ran.
 
-From here, the [instruction set can be consluted for the meaning of any particular instruction](https://developers.urbit.org/reference/nock/definition#instructions).
+From here, the [instruction set can be consulted for the meaning of any particular instruction](https://developers.urbit.org/reference/nock/definition#instructions).
 
 ```hoon
 > ;;  nock  .*  dec.anoma  [0 2]
@@ -255,7 +255,7 @@ Which just gives the default values. If the result is hard to read, then no prob
 [[[0 15] [0 0 0 0 0 0 0] [0 0 0 0 0 0 0] 0] 0 0 0 0 0 0 0]
 ```
 
-Here we simply jsut cast it to the any type, forgetting all information, and we can now see the format of the empty resource.
+Here we simply just cast it to the any type, forgetting all information, and we can now see the format of the empty resource.
 
 ## Dump Modules
 
@@ -405,7 +405,7 @@ Let us start off simple with [zaptis(!=)](https://developers.urbit.org/reference
 [0 46]
 ```
 
-Interesting, we can see that saying anoma, indexs into the current environment by `46`. The current environment in Hoon can be conjured with `.`.
+Interesting, we can see that saying anoma, indexes into the current environment by `46`. The current environment in Hoon can be conjured with `.`.
 
 ```hoon
 > !=(.)
@@ -474,7 +474,7 @@ all we have to pay attention to is the `342` and the `15`, some more examples sh
 [7 [0 46] 9 42 0 7]
 ```
 
-Here for any non nested module we can see the layers and indexs quite plainly!
+Here for any non nested module we can see the layers and indexes quite plainly!
 
 <!-- livebook:{"branch_parent_index":7} -->
 

--- a/documentation/hoon/setting-up.livemd
+++ b/documentation/hoon/setting-up.livemd
@@ -40,7 +40,7 @@ From here we can setup the environment quite nicely
 |mount %anoma
 ```
 
-From here we want to remove all the uneeded files, get it to the following state:
+From here we want to remove all the unneeded files, get it to the following state:
 
 <!-- livebook:{"break_markdown":true} -->
 

--- a/documentation/visualization/actors.livemd
+++ b/documentation/visualization/actors.livemd
@@ -56,7 +56,7 @@ classDef notstarted color:#777, fill:#d9d9d9, stroke:#777, stroke-width:1px;
 ## Mempool
 
 A good view of visualizing Anoma can be seen through running the
-mempool, as it orchastrates the other actors in Anoma to act
+mempool, as it orchestrates the other actors in Anoma to act
 
 <!-- livebook:{"break_markdown":true} -->
 


### PR DESCRIPTION
This PR fixes minor typos across 13 documentation files.

Typos that appeared in code examples or reference identifiers within the docs were intentionally left unchanged to avoid breaking consistency with the actual codebase or external usage.

No code logic or file content was altered. This is a documentation-only cleanup.