### PR TITLE
Fix stop_node/1 to safely lookup and stop node process by PID

### DIFF
--- a/apps/anoma_node/lib/supervisor.ex
+++ b/apps/anoma_node/lib/supervisor.ex
@@ -73,11 +73,15 @@ defmodule Anoma.Supervisor do
   @doc """
   Given a node id, I stop that node completely.
   """
-  @spec stop_node(String.t()) :: :ok
+  @spec stop_node(String.t()) :: :ok | {:error, :not_found}
   def stop_node(node_id) do
-    Anoma.Node.Registry.via(node_id, Anoma.Node.Supervisor)
+    case Anoma.Node.Registry.whereis(node_id, Anoma.Node.Supervisor) do
+      nil ->
+        {:error, :not_found}
 
-    Supervisor.stop(Anoma.Node.Registry.via(node_id, Anoma.Node.Supervisor))
+      pid when is_pid(pid) ->
+        Supervisor.stop(pid)
+    end
   end
 
   ############################################################


### PR DESCRIPTION
This patch corrects a critical bug in the Anoma.Supervisor.stop_node/1 function.

Previously, stop_node/1 incorrectly passed a :via tuple directly to Supervisor.stop/1, which expects a PID. This would cause runtime errors.
The fix involves first resolving the registered process PID via Anoma.Node.Registry.whereis/3.
If no process is found, it returns {:error, :not_found}.
Otherwise, it safely calls Supervisor.stop/1 with the PID to stop the node supervisor process.
This change ensures safe and reliable stopping of node supervisors.

cc @mariari @agureev 