### PR TITLE
Fix typo in handle_info return reason (:disonnect → :disconnect)

### DIFF
--- a/apps/anoma_client/lib/client/node/grpc_proxy.ex
+++ b/apps/anoma_client/lib/client/node/grpc_proxy.ex
@@ -179,6 +179,6 @@ defmodule Anoma.Client.Node.GRPCProxy do
   @impl true
   # the connection to the remote node was closed.
   def handle_info({:gun_down, _pid, :http2, :closed, []}, state) do
-    {:stop, :disonnect, state}
+    {:stop, :disconnect, state}
   end
 end


### PR DESCRIPTION
This PR fixes a typo in the handle_info/2 callback of Anoma.Client.Node.GRPCProxy.
The atom :disonnect was not a meaningful or intentional value, and should be :disconnect.

cc @mariari @agureev 