### PR TITLE
chore: update GitHub actions in CI workflows

### DIFF
--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: setup deps and _build cache
         uses: actions/cache@v4

--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: setup deps and _build cache
         uses: actions/cache@v4

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: setup deps and _build cache
         uses: actions/cache@v4
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: setup deps and _build cache
         uses: actions/cache@v4

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
     steps:
       - name: checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: setup deps and _build cache
         uses: actions/cache@v4

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
         #---------------------------------------------------------------------------
         # Create a GitHub release

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: setup deps and _build cache
         uses: actions/cache@v4

--- a/.github/workflows/try_merge.yaml
+++ b/.github/workflows/try_merge.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # fetch all branches
 


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.

Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0