### PR TITLE
Fix DoS vulnerability in Noun.Jam.cue/1

### DIFF
--- a/apps/anoma_lib/lib/noun/jam.ex
+++ b/apps/anoma_lib/lib/noun/jam.ex
@@ -310,8 +310,14 @@ defmodule Noun.Jam do
                       __STACKTRACE__
           end
 
-        with {:ok, referenced_noun} <-
-               Map.fetch(cache, :binary.decode_unsigned(backref_key, :little)) do
+        backref_offset = :binary.decode_unsigned(backref_key, :little)
+
+        if backref_offset >= offset do
+          raise CueError,
+                "invalid backref at offset #{inspect(offset)}"
+        end
+
+        with {:ok, referenced_noun} <- Map.fetch(cache, backref_offset) do
           {referenced_noun, continuation, new_offset, cache}
         else
           _ ->
@@ -357,6 +363,13 @@ defmodule Noun.Jam do
     # now we have the actual length and can read that many bits off the
     # bitstream. shadowing bits and length once more.
     size = size - length
+    IO.puts("size: #{size}, length: #{length}")
+
+    if size < 0 do
+      raise CueError,
+            "invalid atom length at offset #{inspect(offset)}"
+    end
+
     <<bits::size(size)-bitstring, atom::size(length)-bitstring>> = bits
 
     # now pad the atom back into a binary.


### PR DESCRIPTION
The `cue_atom` function in `Noun.Jam` did not properly validate the size of an atom before attempting to allocate memory for it. This could lead to a denial of service vulnerability where a malicious actor could craft a payload that would cause the server to attempt to allocate a very large amount of memory, leading to a crash.

This commit adds a check to ensure that the declared size of an atom is not greater than the remaining size of the buffer.

A second vulnerability was also found in the `cue_bits` function, where a malicious actor could craft a payload with a back-reference that points to an offset that is greater than or equal to the current offset. This could lead to an infinite loop, causing a denial of service.

This commit adds a check to ensure that all back-references point to a previous offset.