### PR TITLE
Removed duplicate imports

### DIFF
--- a/apps/anoma_lib/lib/test_helper/test_macro.ex
+++ b/apps/anoma_lib/lib/test_helper/test_macro.ex
@@ -15,7 +15,6 @@ defmodule TestHelper.TestMacro do
   defmacro __using__(opts) do
     quote do
       require ExUnit.Assertions
-      require ExUnit.Assertions
       require TestMacro
 
       import ExUnit.Assertions, only: [flunk: 1]

--- a/apps/anoma_node/lib/node/transport/grpc/endpoint/executor.ex
+++ b/apps/anoma_node/lib/node/transport/grpc/endpoint/executor.ex
@@ -1,7 +1,6 @@
 defmodule Anoma.Node.Transport.GRPC.Servers.Executor do
   alias Anoma.Node.Registry
   alias Anoma.Node.Transaction.Executor
-  alias Anoma.Node.Transaction.Executor
   alias Anoma.Proto.Executor.AddROTransaction
   alias Anoma.Proto.Nock.Error
   alias Anoma.Proto.Nock.Success


### PR DESCRIPTION
1. Duplicate Alias Import in TestMacro Module:
    File: apps/anoma_lib/lib/test_helper/test_macro.ex
    Issue: Line 17 has a duplicate require `ExUnit.Assertions`
    
2.  Duplicate Alias in GRPC Executor:
File: apps/anoma_node/lib/node/transport/grpc/endpoint/executor.ex
Issue: Line 4 has duplicate alias import `Anoma.Node.Transaction.Executor`

   
    
    
    