### PR TITLE
fix: secure binary deserialization and handle malformed input

### DIFF
--- a/apps/anoma_client/lib/client/grpc/pubsub.ex
+++ b/apps/anoma_client/lib/client/grpc/pubsub.ex
@@ -12,19 +12,29 @@ defmodule Anoma.Client.GRPC.PubSub do
   require Logger
 
   @doc """
-  I handle incoming events sent t`o me by a node.
+  I handle incoming events sent to me by a node.
   """
   @spec publish(Event.Request.t(), Stream.t()) :: Event.Response.t()
   def publish(request, _stream) do
     Logger.debug("GRPC #{inspect(__ENV__.function)}: #{inspect(request)}")
     topic = request.topic.topic
-    event = :erlang.binary_to_term(request.message.message)
 
-    PubSub.broadcast(
-      :client_pubsub,
-      "node_events",
-      {:event, {topic, event}}
-    )
+    event =
+      try do
+        :erlang.binary_to_term(request.message.message, [:safe])
+      rescue
+        ArgumentError ->
+          Logger.warning("Invalid pubsub message received, dropping it")
+          nil
+      end
+
+    if event do
+      PubSub.broadcast(
+        :client_pubsub,
+        "node_events",
+        {:event, {topic, event}}
+      )
+    end
 
     %Event.Response{}
   end

--- a/apps/anoma_node/lib/node/transport/grpc/endpoint/intranode.ex
+++ b/apps/anoma_node/lib/node/transport/grpc/endpoint/intranode.ex
@@ -25,7 +25,14 @@ defmodule Anoma.Node.Transport.GRPC.Servers.IntraNode do
 
     engine = String.to_atom(request.engine)
     name = Registry.via(request.node.id, engine)
-    message = :erlang.binary_to_term(request.message)
+
+    message =
+      try do
+        :erlang.binary_to_term(request.message, [:safe])
+      rescue
+        ArgumentError ->
+          raise_grpc_error!(:invalid_message)
+      end
 
     result = GenServer.call(name, message)
     %Call.Response{message: :erlang.term_to_binary(result)}
@@ -45,7 +52,14 @@ defmodule Anoma.Node.Transport.GRPC.Servers.IntraNode do
 
     engine = String.to_atom(request.engine)
     name = Registry.via(request.node.id, engine)
-    message = :erlang.binary_to_term(request.message)
+
+    message =
+      try do
+        :erlang.binary_to_term(request.message, [:safe])
+      rescue
+        ArgumentError ->
+          raise_grpc_error!(:invalid_message)
+      end
 
     GenServer.cast(name, message)
     %Cast.Response{}


### PR DESCRIPTION
This PR makes `:binary_to_term` usage in PubSub and IntraNode safe by enabling `[:safe]` and adding error handling for invalid binaries. This prevents crashes and security risks from malformed inputs without changing functionality.