### PR TITLE
fix: resolve hardcoded interface binding and enable security features

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -13,10 +13,10 @@ config :anoma_client, Anoma.Client.Web.Endpoint,
   server: true,
   adapter: Bandit.PhoenixAdapter,
   http: [
-    ip: {127, 0, 0, 1},
+    ip: {0, 0, 0, 0},
     port: String.to_integer(System.get_env("CLIENT_HTTP_PORT") || "4000")
   ],
-  check_origin: false,
+  check_origin: true,
   debug_errors: false,
   render_errors: [view: Anoma.Client.Web.ErrorJSON, accepts: ~w(json)]
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -13,7 +13,11 @@ config :anoma_client, Anoma.Client.Web.Endpoint,
   server: true,
   adapter: Bandit.PhoenixAdapter,
   http: [
-    ip: {0, 0, 0, 0},
+    ip:
+      System.get_env("CLIENT_HTTP_IP", "0.0.0.0")
+      |> String.to_charlist()
+      |> :inet.parse_address()
+      |> elem(1),
     port: String.to_integer(System.get_env("CLIENT_HTTP_PORT") || "4000")
   ],
   check_origin: true,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,3 +2,6 @@ import Config
 
 # refresh the open api spec during development
 config :open_api_spex, :cache_adapter, OpenApiSpex.Plug.NoneCache
+
+# Enable debug errors in development
+config :anoma_client, Anoma.Client.Web.Endpoint, debug_errors: true

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -6,7 +6,11 @@ import Config
 # Configures the endpoint
 config :anoma_client, Anoma.Client.Web.Endpoint,
   http: [
-    ip: {0, 0, 0, 0},
+    ip:
+      System.get_env("CLIENT_HTTP_IP", "0.0.0.0")
+      |> String.to_charlist()
+      |> :inet.parse_address()
+      |> elem(1),
     port: String.to_integer(System.get_env("CLIENT_HTTP_PORT") || "4000")
   ]
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -6,7 +6,7 @@ import Config
 # Configures the endpoint
 config :anoma_client, Anoma.Client.Web.Endpoint,
   http: [
-    ip: {127, 0, 0, 1},
+    ip: {0, 0, 0, 0},
     port: String.to_integer(System.get_env("CLIENT_HTTP_PORT") || "4000")
   ]
 


### PR DESCRIPTION
## Summary

Fixes configuration issues for proper application packaging as described in [#2092](https://github.com/anoma/anoma/issues/2092).

## Changes

- Change hardcoded IP from `127.0.0.1` to `0.0.0.0` with parametrized approach and sane default
- Enable `check_origin` as requested
- Enable `debug_errors` in dev mode

## Files Modified

- `config/config.exs`
- `config/runtime.exs` 
- `config/dev.exs`

Fixes #2092