### PR TITLE
Fix typos across documentation and code comments

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -109,7 +109,7 @@ To get started with Postman, look here: https://learning.postman.com/docs/sendin
 ## GRPCurl
 
 For those so inclined, `grpcurl` is a command-line tool to make GRPC requests.
-Instalation instructions can be found here: https://github.com/fullstorydev/grpcurl?tab=readme-ov-file#installation
+Installation instructions can be found here: https://github.com/fullstorydev/grpcurl?tab=readme-ov-file#installation
 
 ### Listing the root services
 

--- a/apps/anoma_node/lib/examples/eintent_pool.ex
+++ b/apps/anoma_node/lib/examples/eintent_pool.ex
@@ -82,7 +82,7 @@ defmodule Anoma.Node.Examples.EIntentPool do
   I use `add_intent_transaction_nullifier` and then execute the trivial
   swap.
 
-  The nullifier of the ephemeral resource used gets trasmitted to the
+  The nullifier of the ephemeral resource used gets transmitted to the
   intent pool, hence removing the specified intent from the pool.
   """
   @spec remove_intents_with_nulllified_resources(ENode.t()) :: ENode.t()

--- a/apps/anoma_node/lib/examples/serializing/events/mempool.ex
+++ b/apps/anoma_node/lib/examples/serializing/events/mempool.ex
@@ -33,7 +33,7 @@ defmodule Anoma.Node.Examples.Serializing.Events.Mempool do
   def tx_event_with_values do
     tx_event = tx_event()
 
-    # create a random transactoin
+    # create a random transaction
     transaction = ETransaction.simple_transaction()
     # create a tx event for this transaction
     tx_event =
@@ -50,7 +50,7 @@ defmodule Anoma.Node.Examples.Serializing.Events.Mempool do
     # encode the transaction into a json string
     json = Jason.encode!(tx_event)
 
-    # assert the result is what we exepct
+    # assert the result is what we expect
     expected_result =
       transaction.result |> elem(1) |> Noun.Jam.jam() |> Base.encode64()
 

--- a/apps/anoma_node/lib/node/logging.ex
+++ b/apps/anoma_node/lib/node/logging.ex
@@ -42,7 +42,7 @@ defmodule Anoma.Node.Logging do
   ############################################################
 
   @typedoc """
-  I am the loggging message type flag.
+  I am the logging message type flag.
 
   I specify what logging levels are currently supported by the Logging
   Engine.
@@ -331,7 +331,7 @@ defmodule Anoma.Node.Logging do
       :mnesia.write({table, :round, round + 1})
     end)
 
-    log_fun({:info, "Block succesfully committed. Round: #{inspect(round)}"})
+    log_fun({:info, "Block successfully committed. Round: #{inspect(round)}"})
     state
   end
 

--- a/apps/anoma_node/lib/node/transaction/backends/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends/backends.ex
@@ -44,7 +44,7 @@ defmodule Anoma.Node.Transaction.Backends do
 
   First, I execute the transaction code on the Anoma VM. Next, I apply processing
   logic to the resulting value, dependent on the selected backend.
-  - For read-only backend, the value is sent directly to specified recepient.
+  - For read-only backend, the value is sent directly to specified recipient.
   - For the key-value and blob store executions, the obtained value is stored
   and a Complete Event is issued.
   - For the transparent Resource Machine (RM) execution, I verify the

--- a/apps/anoma_node/lib/node/transaction/executor/executor.ex
+++ b/apps/anoma_node/lib/node/transaction/executor/executor.ex
@@ -42,7 +42,7 @@ defmodule Anoma.Node.Transaction.Executor do
 
     Currently I only keep information of the relevant node identitfication.
 
-    ### Fileds
+    ### Fields
 
     - `:node_id` - The ID of the node to which an Executor instantiation is
                    bound.
@@ -70,7 +70,7 @@ defmodule Anoma.Node.Transaction.Executor do
 
   @impl true
   @doc """
-  I am the intialization function for the Executor Engine.
+  I am the initialization function for the Executor Engine.
 
   Given the arguments containing a node ID, I subscribe to all messages
   which come from completed workers of that node and launch the Executor

--- a/apps/anoma_node/lib/node/transaction/storage/storage.ex
+++ b/apps/anoma_node/lib/node/transaction/storage/storage.ex
@@ -7,7 +7,7 @@ defmodule Anoma.Node.Transaction.Storage do
   last timestamp is.
 
   Any time before the next timestamp or at the timestamp itself is
-  considered the past. Anyting else is considered the future.
+  considered the past. Anything else is considered the future.
 
   The semantics for reads and writes are as follows:
 

--- a/apps/event_broker/lib/examples/e_subscribe.ex
+++ b/apps/event_broker/lib/examples/e_subscribe.ex
@@ -1,6 +1,6 @@
 defmodule Examples.EEventBroker.Subscribe do
   @moduledoc """
-  I define examples on how to susbcribe to topics in the event broker.
+  I define examples on how to subscribe to topics in the event broker.
   """
 
   alias Examples.EEVentBroker.EFilter

--- a/documentation/contributing/git.livemd
+++ b/documentation/contributing/git.livemd
@@ -52,9 +52,9 @@ This document is best viewed from within liveview, as the charts do not render o
 * `next` - a branch that has a superset of features that will be
   included in the next release
 
-* `maint` - a maintnance branch that will be updated if bugs are found
+* `maint` - a maintenance branch that will be updated if bugs are found
 
-* `integreation branch` - a topic that merges a bunch of other topics
+* `integration branch` - a topic that merges a bunch of other topics
 
 ## Naming conventions
 
@@ -183,7 +183,7 @@ checkout base
 merge Topic-Y id: "52b44a6"
 ```
 
-and your code hapens to be base on 52b44a6, then the history will look something like:
+and your code happens to be base on 52b44a6, then the history will look something like:
 
 ```mermaid
 %%{init:
@@ -263,7 +263,7 @@ In a textual form this looks like:
 ```
 0438922 *   main Merge branch 'topic-y'
         |\
-546a8f9 | * topic-y Added a feature that conflcits with X!
+546a8f9 | * topic-y Added a feature that conflicts with X!
 90d91e7 * |   Merge branch 'topic-x'
         |\ \
         | |/

--- a/documentation/contributing/mnesia-vs-actor-state.livemd
+++ b/documentation/contributing/mnesia-vs-actor-state.livemd
@@ -42,7 +42,7 @@ The philosophy for what is stored in Mnesia should be: "Is this something the us
 
 ## Actor Storage
 
-Actor storage on the other hand are for things we don't wish the user to be able to query. Thus implementaiton details about the execution should be omitted from user visible storage, and would be better served stored on the Actor.
+Actor storage on the other hand are for things we don't wish the user to be able to query. Thus implementation details about the execution should be omitted from user visible storage, and would be better served stored on the Actor.
 
 A good example of this is the old ordering logic.
 

--- a/documentation/contributing/style-guide.livemd
+++ b/documentation/contributing/style-guide.livemd
@@ -119,7 +119,7 @@ Exceptions might exist but should be noted explicitly in PR and commit messages.
 If `foo` uses Router or GenServer functionality, it should be a `call` if and only if either
 
 1. The underlying state is unchanged by calling `foo`
-2. There are synchronizaton requirements that `foo` has to fullfill.
+2. There are synchronization requirements that `foo` has to fullfill.
 
 #### Rule 1.6
 

--- a/documentation/contributing/testing/running-tests.livemd
+++ b/documentation/contributing/testing/running-tests.livemd
@@ -78,7 +78,7 @@ The error text hints at a suggestion on how to solve the problem.
 MIX_ENV=iex iex --sname mariari --cookie mariari -S mix
 ```
 
-I recommend using the `iex` environment over the `test` environment that is shwon in the error, as in the `Anoma` project, we set the `test` environment to have `Config.config/2` to have the following settings:
+I recommend using the `iex` environment over the `test` environment that is shown in the error, as in the `Anoma` project, we set the `test` environment to have `Config.config/2` to have the following settings:
 
 <!-- livebook:{"force_markdown":true} -->
 


### PR DESCRIPTION

```markdown
## Summary
This PR fixes various spelling errors and typos found throughout the codebase, improving code readability and documentation quality.

## Changes Made

### Documentation Files
- **`USAGE.md`**: Fixed "Instalation" → "Installation"
- **`documentation/contributing/git.livemd`**: 
  - Fixed "maintnance" → "maintenance"
  - Fixed "integreation" → "integration" 
  - Fixed "hapens" → "happens"
  - Fixed "conflcits" → "conflicts"
- **`documentation/contributing/mnesia-vs-actor-state.livemd`**: Fixed "implementaiton" → "implementation"
- **`documentation/contributing/style-guide.livemd`**: Fixed "synchronizaton" → "synchronization"
- **`documentation/contributing/testing/running-tests.livemd`**: Fixed "shwon" → "shown"

### Code Files
- **`apps/anoma_node/lib/examples/eintent_pool.ex`**: Fixed "trasmitted" → "transmitted"
- **`apps/anoma_node/lib/examples/serializing/events/mempool.ex`**: 
  - Fixed "transactoin" → "transaction"
  - Fixed "exepct" → "expect"
- **`apps/anoma_node/lib/node/logging.ex`**: 
  - Fixed "loggging" → "logging"
  - Fixed "succesfully" → "successfully"
- **`apps/anoma_node/lib/node/transaction/backends/backends.ex`**: Fixed "recepient" → "recipient"
- **`apps/anoma_node/lib/node/transaction/executor/executor.ex`**: 
  - Fixed "Fileds" → "Fields"
  - Fixed "intialization" → "initialization"
- **`apps/anoma_node/lib/node/transaction/storage/storage.ex`**: Fixed "Anyting" → "Anything"
- **`apps/event_broker/lib/examples/e_subscribe.ex`**: Fixed "susbcribe" → "subscribe"


```