### PR TITLE
chore(scripts): add dev-check.sh for local compile+test sanity checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,4 @@ For more information on a smooth git experience check out the [git
 section in contributor's guide](./documentation/contributing/git.livemd)
 
 Happy hacking, and don't be afraid to submit patches.
+- See **[Windows/WSL Quickstart](documentation/windows-wsl-quickstart.md)**.

--- a/documentation/windows-wsl-quickstart.md
+++ b/documentation/windows-wsl-quickstart.md
@@ -1,13 +1,17 @@
 # Windows/WSL Quickstart (Elixir Umbrella)
 
-## Prereqs
+## Gerekler
 - Windows 10/11 + WSL2 (Ubuntu 22.04+)
 - Git, build-essential, Erlang, Elixir
 
-## Install on WSL Ubuntu
+## WSL Ubuntu Kurulum
 ```bash
 sudo apt update && sudo apt upgrade -y
 sudo apt install -y git curl build-essential erlang elixir
 elixir -v
 mix --version
+
+
+
+
 

--- a/documentation/windows-wsl-quickstart.md
+++ b/documentation/windows-wsl-quickstart.md
@@ -1,0 +1,13 @@
+# Windows/WSL Quickstart (Elixir Umbrella)
+
+## Prereqs
+- Windows 10/11 + WSL2 (Ubuntu 22.04+)
+- Git, build-essential, Erlang, Elixir
+
+## Install on WSL Ubuntu
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install -y git curl build-essential erlang elixir
+elixir -v
+mix --version
+

--- a/scripts/dev-check.sh
+++ b/scripts/dev-check.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[check] Erlang/Elixir:"
+which erl && erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().' -noshell
+which elixir && elixir -v
+
+echo "[check] protoc & plugins:"
+which protoc || { echo "missing protoc"; exit 1; }
+export PATH="$HOME/.mix/escripts:$PATH"
+which protoc-gen-elixir || { echo "missing protoc-gen-elixir (run: mix escript.install hex protobuf --force)"; exit 1; }
+
+echo "[deps] hex/rebar/deps:"
+mix local.hex --force
+mix local.rebar --force
+mix deps.get
+
+echo "[build] compile + test:"
+mix compile
+MIX_ENV=test mix test


### PR DESCRIPTION
Adds a one-shot script to sanity-check local environment and run compile+tests:
- Verifies Erlang/Elixir, protoc and protoc-gen-elixir, Rust (cargo)
- Runs mix deps/build/test with clear errors

Goal: reduce setup friction for new contributors on WSL/Linux.
