### PR TITLE
chore(mix): add `mix anoma.doctor` to check local toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,4 @@ For more information on a smooth git experience check out the [git
 section in contributor's guide](./documentation/contributing/git.livemd)
 
 Happy hacking, and don't be afraid to submit patches.
+- See **[Windows/WSL Quickstart](documentation/windows-wsl-quickstart.md)**.

--- a/apps/anoma_client/lib/mix/tasks/anoma.doctor.ex
+++ b/apps/anoma_client/lib/mix/tasks/anoma.doctor.ex
@@ -1,0 +1,43 @@
+defmodule Mix.Tasks.Anoma.Doctor do
+  use Mix.Task
+  @shortdoc "Checks local toolchain: OTP/Elixir, protoc, plugins, Rust"
+
+  @impl true
+  def run(_args) do
+    Mix.shell().info("==> Checking Erlang/Elixir")
+    otp = :erlang.system_info(:otp_release) |> to_string()
+    Mix.shell().info("OTP: #{otp}")
+    Mix.shell().info(System.cmd("elixir", ["-v"]) |> elem(0))
+
+    Mix.shell().info("==> Checking protoc & plugins")
+    check!("protoc", "sudo apt install -y protobuf-compiler")
+    escripts = System.user_home!() <> "/.mix/escripts"
+    path = System.get_env("PATH", "")
+    unless String.contains?(path, escripts), do:
+      Mix.shell().info("Hint: export PATH=\"#{escripts}:\$PATH\"")
+
+    check!("protoc-gen-elixir", "mix escript.install hex protobuf --force")
+
+    Mix.shell().info("==> Checking Rust (cargo)")
+    check!("cargo", "curl -sSf https://rustup.rs | sh -s -- -y && source ~/.cargo/env")
+
+    Mix.shell().info("==> Mix deps/build/test (dry run)")
+    run!("mix", ["local.hex", "--force"])
+    run!("mix", ["local.rebar", "--force"])
+    run!("mix", ["deps.get"])
+    Mix.shell().info("OK. You can now run: mix compile && MIX_ENV=test mix test")
+  end
+
+  defp check!(exe, fix) do
+    case System.find_executable(exe) do
+      nil -> Mix.shell().error("[missing] #{exe}  →  fix: #{fix}")
+      _ -> Mix.shell().info("[found]   #{exe}")
+    end
+  end
+
+  defp run!(cmd, args) do
+    {out, code} = System.cmd(cmd, args, stderr_to_stdout: true)
+    Mix.shell().info(out)
+    if code != 0, do: Mix.raise("#{cmd} #{Enum.join(args, " ")} failed")
+  end
+end

--- a/documentation/windows-wsl-quickstart.md
+++ b/documentation/windows-wsl-quickstart.md
@@ -1,13 +1,17 @@
 # Windows/WSL Quickstart (Elixir Umbrella)
 
-## Prereqs
+## Gerekler
 - Windows 10/11 + WSL2 (Ubuntu 22.04+)
 - Git, build-essential, Erlang, Elixir
 
-## Install on WSL Ubuntu
+## WSL Ubuntu Kurulum
 ```bash
 sudo apt update && sudo apt upgrade -y
 sudo apt install -y git curl build-essential erlang elixir
 elixir -v
 mix --version
+
+
+
+
 

--- a/documentation/windows-wsl-quickstart.md
+++ b/documentation/windows-wsl-quickstart.md
@@ -1,0 +1,13 @@
+# Windows/WSL Quickstart (Elixir Umbrella)
+
+## Prereqs
+- Windows 10/11 + WSL2 (Ubuntu 22.04+)
+- Git, build-essential, Erlang, Elixir
+
+## Install on WSL Ubuntu
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install -y git curl build-essential erlang elixir
+elixir -v
+mix --version
+


### PR DESCRIPTION
Adds a Mix task to verify OTP/Elixir, protoc & protoc-gen-elixir, and Rust (cargo).
Reduces setup friction for new contributors; shows fix hints when tools are missing.
