### PR TITLE
feat(intent-lab): minimal intent matcher (two-party & three-cycle) with domain constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,3 +183,5 @@ section in contributor's guide](./documentation/contributing/git.livemd)
 
 Happy hacking, and don't be afraid to submit patches.
 - See **[Windows/WSL Quickstart](documentation/windows-wsl-quickstart.md)**.
+
+- Regenerate protobuf stubs: `scripts/proto-gen.sh` (requires protoc & protoc-gen-elixir).

--- a/README.md
+++ b/README.md
@@ -182,3 +182,4 @@ For more information on a smooth git experience check out the [git
 section in contributor's guide](./documentation/contributing/git.livemd)
 
 Happy hacking, and don't be afraid to submit patches.
+- See **[Windows/WSL Quickstart](documentation/windows-wsl-quickstart.md)**.

--- a/apps/anoma_client/lib/mix/tasks/anoma.doctor.ex
+++ b/apps/anoma_client/lib/mix/tasks/anoma.doctor.ex
@@ -1,0 +1,43 @@
+defmodule Mix.Tasks.Anoma.Doctor do
+  use Mix.Task
+  @shortdoc "Checks local toolchain: OTP/Elixir, protoc, plugins, Rust"
+
+  @impl true
+  def run(_args) do
+    Mix.shell().info("==> Checking Erlang/Elixir")
+    otp = :erlang.system_info(:otp_release) |> to_string()
+    Mix.shell().info("OTP: #{otp}")
+    Mix.shell().info(System.cmd("elixir", ["-v"]) |> elem(0))
+
+    Mix.shell().info("==> Checking protoc & plugins")
+    check!("protoc", "sudo apt install -y protobuf-compiler")
+    escripts = System.user_home!() <> "/.mix/escripts"
+    path = System.get_env("PATH", "")
+    unless String.contains?(path, escripts), do:
+      Mix.shell().info("Hint: export PATH=\"#{escripts}:\$PATH\"")
+
+    check!("protoc-gen-elixir", "mix escript.install hex protobuf --force")
+
+    Mix.shell().info("==> Checking Rust (cargo)")
+    check!("cargo", "curl -sSf https://rustup.rs | sh -s -- -y && source ~/.cargo/env")
+
+    Mix.shell().info("==> Mix deps/build/test (dry run)")
+    run!("mix", ["local.hex", "--force"])
+    run!("mix", ["local.rebar", "--force"])
+    run!("mix", ["deps.get"])
+    Mix.shell().info("OK. You can now run: mix compile && MIX_ENV=test mix test")
+  end
+
+  defp check!(exe, fix) do
+    case System.find_executable(exe) do
+      nil -> Mix.shell().error("[missing] #{exe}  →  fix: #{fix}")
+      _ -> Mix.shell().info("[found]   #{exe}")
+    end
+  end
+
+  defp run!(cmd, args) do
+    {out, code} = System.cmd(cmd, args, stderr_to_stdout: true)
+    Mix.shell().info(out)
+    if code != 0, do: Mix.raise("#{cmd} #{Enum.join(args, " ")} failed")
+  end
+end

--- a/apps/anoma_intent_lab/.formatter.exs
+++ b/apps/anoma_intent_lab/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/apps/anoma_intent_lab/.gitignore
+++ b/apps/anoma_intent_lab/.gitignore
@@ -1,0 +1,26 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+anoma_intent_lab-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/apps/anoma_intent_lab/README.md
+++ b/apps/anoma_intent_lab/README.md
@@ -1,0 +1,21 @@
+# AnomaIntentLab
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+by adding `anoma_intent_lab` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:anoma_intent_lab, "~> 0.1.0"}
+  ]
+end
+```
+
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
+and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+be found at <https://hexdocs.pm/anoma_intent_lab>.
+

--- a/apps/anoma_intent_lab/lib/anoma_intent_lab.ex
+++ b/apps/anoma_intent_lab/lib/anoma_intent_lab.ex
@@ -1,0 +1,18 @@
+defmodule AnomaIntentLab do
+  @moduledoc """
+  Documentation for `AnomaIntentLab`.
+  """
+
+  @doc """
+  Hello world.
+
+  ## Examples
+
+      iex> AnomaIntentLab.hello()
+      :world
+
+  """
+  def hello do
+    :world
+  end
+end

--- a/apps/anoma_intent_lab/lib/anoma_intent_lab/intent.ex
+++ b/apps/anoma_intent_lab/lib/anoma_intent_lab/intent.ex
@@ -1,0 +1,21 @@
+defmodule AnomaIntentLab.Intent do
+  @moduledoc """
+  Minimal intent modeli:
+    * `owner`: atom veya string
+    * `give`: %{asset => miktar}
+    * `want`: %{asset => miktar}
+    * `constraints`: %{domain: "local:..."} gibi basit kısıtlar
+  """
+  @enforce_keys [:owner, :want, :give]
+  defstruct [:owner, :want, :give, constraints: %{}, metadata: %{}]
+
+  @type t :: %__MODULE__{
+          owner: term(),
+          want: map(),
+          give: map(),
+          constraints: map(),
+          metadata: map()
+        }
+
+  def domain(%__MODULE__{constraints: c}), do: Map.get(c, :domain)
+end

--- a/apps/anoma_intent_lab/lib/anoma_intent_lab/matcher.ex
+++ b/apps/anoma_intent_lab/lib/anoma_intent_lab/matcher.ex
@@ -68,7 +68,6 @@ defmodule AnomaIntentLab.Matcher do
     is_nil(da) or is_nil(db) or da == db
   end
 
-  # basit kombinasyon üretici
   defp combinations(list, 0), do: [[ ] |> Enum.reverse()]
   defp combinations([], _k), do: []
   defp combinations([h | t], k) when k > 0 do

--- a/apps/anoma_intent_lab/lib/anoma_intent_lab/matcher.ex
+++ b/apps/anoma_intent_lab/lib/anoma_intent_lab/matcher.ex
@@ -1,0 +1,79 @@
+defmodule AnomaIntentLab.Matcher do
+  @moduledoc """
+  Basit eşleştirici:
+    - two_party/2: iki intent arasında karşılıklı kapsama varsa eşleşme
+    - three_cycle/1: 3'lü döngü (A->B, B->C, C->A) varsa eşleşme
+    - Domain kısıtı: domain belirtilmişse tüm taraflarda aynı olmalı
+  """
+  alias AnomaIntentLab.Intent
+
+  @spec complement?(Intent.t(), Intent.t()) :: boolean()
+  def complement?(%Intent{} = a, %Intent{} = b) do
+    same_domain?(a, b) and covers?(a.give, b.want) and covers?(b.give, a.want)
+  end
+
+  def two_party(a, b) do
+    if complement?(a, b) do
+      {:ok, %{type: :two_party, actors: [a.owner, b.owner], transfer: settlement(a, b)}}
+    else
+      :nomatch
+    end
+  end
+
+  defp settlement(a, b) do
+    ab =
+      for {asset, qty} <- a.want, qty > 0 do
+        %{from: b.owner, to: a.owner, asset: asset, qty: qty}
+      end
+
+    ba =
+      for {asset, qty} <- b.want, qty > 0 do
+        %{from: a.owner, to: b.owner, asset: asset, qty: qty}
+      end
+
+    ab ++ ba
+  end
+
+  def three_cycle(intents) when is_list(intents) do
+    intents
+    |> combinations(3)
+    |> Enum.find_value(:nomatch, fn [a, b, c] ->
+      if same_domain?(a, b) and same_domain?(b, c) and same_domain?(a, c) and
+           covers?(a.give, c.want) and covers?(b.give, a.want) and covers?(c.give, b.want) do
+        {:ok,
+         %{
+           type: :three_cycle,
+           actors: [a.owner, b.owner, c.owner],
+           transfer:
+             [
+               for({asset, qty} <- a.want, do: %{from: b.owner, to: a.owner, asset: asset, qty: qty}),
+               for({asset, qty} <- b.want, do: %{from: c.owner, to: b.owner, asset: asset, qty: qty}),
+               for({asset, qty} <- c.want, do: %{from: a.owner, to: c.owner, asset: asset, qty: qty})
+             ]
+             |> List.flatten()
+         }}
+      else
+        false
+      end
+    end)
+  end
+
+  defp covers?(have, need) do
+    Enum.all?(need, fn {asset, qty} -> Map.get(have, asset, 0) >= qty end)
+  end
+
+  defp same_domain?(a, b) do
+    da = Intent.domain(a)
+    db = Intent.domain(b)
+    is_nil(da) or is_nil(db) or da == db
+  end
+
+  # basit kombinasyon üretici
+  defp combinations(list, 0), do: [[ ] |> Enum.reverse()]
+  defp combinations([], _k), do: []
+  defp combinations([h | t], k) when k > 0 do
+    with_h = Enum.map(combinations(t, k - 1), &[h | &1])
+    without_h = combinations(t, k)
+    with_h ++ without_h
+  end
+end

--- a/apps/anoma_intent_lab/lib/mix/tasks/intent.lab.demo.ex
+++ b/apps/anoma_intent_lab/lib/mix/tasks/intent.lab.demo.ex
@@ -1,0 +1,20 @@
+defmodule Mix.Tasks.Intent.Lab.Demo do
+  use Mix.Task
+  @shortdoc "Runs a small intent-matching demo (two-party & three-cycle)"
+  @moduledoc false
+
+  alias AnomaIntentLab.{Intent, Matcher}
+
+  @impl true
+  def run(_args) do
+    IO.puts("== Two-party demo ==")
+    a = %Intent{owner: :alice, give: %{USDT: 10}, want: %{ATOM: 10}, constraints: %{domain: "local:demo"}}
+    b = %Intent{owner: :bob,   give: %{ATOM: 10}, want: %{USDT: 10}, constraints: %{domain: "local:demo"}}
+    IO.inspect(Matcher.two_party(a, b))
+
+    IO.puts("\n== Three-cycle demo ==")
+    c = %Intent{owner: :carol, give: %{OSMO: 10}, want: %{USDT: 10}, constraints: %{domain: "local:demo"}}
+    d = %Intent{owner: :dave,  give: %{USDT: 10}, want: %{OSMO: 10}, constraints: %{domain: "local:demo"}}
+    IO.inspect(Matcher.three_cycle([b, d, c]))
+  end
+end

--- a/apps/anoma_intent_lab/mix.exs
+++ b/apps/anoma_intent_lab/mix.exs
@@ -1,0 +1,23 @@
+defmodule AnomaIntentLab.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :anoma_intent_lab,
+      version: "0.1.0",
+      elixir: "~> 1.17",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [extra_applications: [:logger]]
+  end
+
+  defp deps do
+    [
+      {:stream_data, "~> 0.6", only: :test}
+    ]
+  end
+end

--- a/apps/anoma_intent_lab/test/anoma_intent_lab_test.exs
+++ b/apps/anoma_intent_lab/test/anoma_intent_lab_test.exs
@@ -1,0 +1,8 @@
+defmodule AnomaIntentLabTest do
+  use ExUnit.Case
+  doctest AnomaIntentLab
+
+  test "greets the world" do
+    assert AnomaIntentLab.hello() == :world
+  end
+end

--- a/apps/anoma_intent_lab/test/matcher_test.exs
+++ b/apps/anoma_intent_lab/test/matcher_test.exs
@@ -1,0 +1,23 @@
+defmodule AnomaIntentLab.MatcherTest do
+  use ExUnit.Case, async: true
+  alias AnomaIntentLab.{Intent, Matcher}
+
+  test "two-party match works" do
+    a = %Intent{owner: :a, give: %{USD: 10}, want: %{EUR: 10}, constraints: %{domain: "x"}}
+    b = %Intent{owner: :b, give: %{EUR: 10}, want: %{USD: 10}, constraints: %{domain: "x"}}
+    assert {:ok, %{type: :two_party}} = Matcher.two_party(a, b)
+  end
+
+  test "domain mismatch blocks match" do
+    a = %Intent{owner: :a, give: %{USD: 10}, want: %{EUR: 10}, constraints: %{domain: "x"}}
+    b = %Intent{owner: :b, give: %{EUR: 10}, want: %{USD: 10}, constraints: %{domain: "y"}}
+    assert :nomatch = Matcher.two_party(a, b)
+  end
+
+  test "three-cycle match works" do
+    a = %Intent{owner: :a, give: %{USD: 10}, want: %{EUR: 10}, constraints: %{domain: "x"}}
+    b = %Intent{owner: :b, give: %{EUR: 10}, want: %{JPY: 10}, constraints: %{domain: "x"}}
+    c = %Intent{owner: :c, give: %{JPY: 10}, want: %{USD: 10}, constraints: %{domain: "x"}}
+    assert {:ok, %{type: :three_cycle}} = Matcher.three_cycle([a, b, c])
+  end
+end

--- a/apps/anoma_intent_lab/test/test_helper.exs
+++ b/apps/anoma_intent_lab/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/documentation/windows-wsl-quickstart.md
+++ b/documentation/windows-wsl-quickstart.md
@@ -1,13 +1,17 @@
 # Windows/WSL Quickstart (Elixir Umbrella)
 
-## Prereqs
+## Gerekler
 - Windows 10/11 + WSL2 (Ubuntu 22.04+)
 - Git, build-essential, Erlang, Elixir
 
-## Install on WSL Ubuntu
+## WSL Ubuntu Kurulum
 ```bash
 sudo apt update && sudo apt upgrade -y
 sudo apt install -y git curl build-essential erlang elixir
 elixir -v
 mix --version
+
+
+
+
 

--- a/documentation/windows-wsl-quickstart.md
+++ b/documentation/windows-wsl-quickstart.md
@@ -1,0 +1,13 @@
+# Windows/WSL Quickstart (Elixir Umbrella)
+
+## Prereqs
+- Windows 10/11 + WSL2 (Ubuntu 22.04+)
+- Git, build-essential, Erlang, Elixir
+
+## Install on WSL Ubuntu
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install -y git curl build-essential erlang elixir
+elixir -v
+mix --version
+

--- a/scripts/proto-gen.sh
+++ b/scripts/proto-gen.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PATH="$HOME/.mix/escripts:$PATH"
+: "${PROTOC_GEN_ELIXIR:=$HOME/.mix/escripts/protoc-gen-elixir}"
+
+command -v protoc >/dev/null || { echo "Missing protoc. Install: sudo apt install -y protobuf-compiler"; exit 1; }
+[ -x "$PROTOC_GEN_ELIXIR" ] || { echo "Missing protoc-gen-elixir. Install: mix escript.install hex protobuf --force"; exit 1; }
+
+echo "Using protoc: $(command -v protoc)"
+echo "Using protoc-gen-elixir: $PROTOC_GEN_ELIXIR"
+
+# örnek yollar; repo yapısına göre genişletilebilir
+SRC_DIRS="apps/anoma_protobuf/priv/protos"
+OUT_DIR="apps/anoma_protobuf/lib/anoma/protobuf"
+
+mkdir -p "$OUT_DIR"
+for d in $SRC_DIRS; do
+  [ -d "$d" ] || continue
+  find "$d" -name '*.proto' -print0 | xargs -0 -I{} \
+    protoc --elixir_out=plugins=grpc:"$OUT_DIR" -I"$d" {}
+done
+
+echo "OK: protobuf code generated into $OUT_DIR"


### PR DESCRIPTION
Adds a minimal "Intent Lab" app to the umbrella:

- Simple `Intent` model (owner/want/give + optional `domain` constraint)
- Matching engine:
  - `two_party/2` for bilateral matches
  - `three_cycle/1` for 3-way cycles
- CLI demo: `mix intent.lab.demo`
- Tests for 2-party, domain guard, and 3-cycle

Goal: provide a small, reproducible playground aligned with Upward's intent-centric design (domain-local matching) that new contributors can understand and extend.
