### PR TITLE
chore: fix issues in doc scripts

### DIFF
--- a/scripts/docs-files.sh
+++ b/scripts/docs-files.sh
@@ -3,8 +3,8 @@
 # Destination folder where all files will be copied
 destination_folder="./doc/files/"
 
-mkdir -p $destination_folder
+mkdir -p "$destination_folder"
 # Find all folders named "files" and copy their contents to the destination folder
-find ./documentation -type d -name "files" -exec sh -c 'cp -r "$0"/* "$1"' {} "$destination_folder" \;
+find ./documentation -type d -name "files" -exec sh -c 'cp -r "$1"/* "$2"' _ {} "$destination_folder" \;
 
 echo "All files copied and merged into $destination_folder"

--- a/scripts/docs-version.sh
+++ b/scripts/docs-version.sh
@@ -1,5 +1,10 @@
-version=`mix run -e 'IO.puts(Mix.Project.config()[:version])'`; \
+#!/bin/bash
+
+version=$(mix run -e 'IO.puts(to_string(Mix.Project.config()[:version]))')
 mix docs -o "doc/v$version"
 
 # hack to get around github pages being a bit stupid
-for v in $(git tag | tac); do mkdir -p "./doc/$v" &&  cp ./doc/.doc-versions.js "./doc/$v/.doc-versions.js"; done
+for v in $(git tag | tac 2>/dev/null || git tag | tail -r); do
+    mkdir -p "./doc/$v"
+    [ -f ./doc/.doc-versions.js ] && cp ./doc/.doc-versions.js "./doc/$v/.doc-versions.js"
+done


### PR DESCRIPTION
made a couple of fixes across doc scripts:

* **docs-files.sh:** fixed file copy - switched `$0/$1` to `$1/$2` and added `_` for `sh -c`.
* now it correctly grabs files from each `files` folder.
* **docs-version.sh:** tweaks to prevent breaks: use `$(...)` for command substitution, force version to string in Elixir, fallback from `tac` to `tail -r` on macOS, and only copy `.doc-versions.js` if it exists.

**scripts should run more reliably now.**
