### PR TITLE
fix: header content grab in Markdown

### DIFF
--- a/apps/anoma_lib/lib/livebook.ex
+++ b/apps/anoma_lib/lib/livebook.ex
@@ -262,7 +262,7 @@ defmodule Livebook do
           String.t()
   def change_header(markdown, header_level, start_header, new_text) do
     header_regex =
-      ~r/^#{header_level}\s+#{start_header}\s*$(.*?)(?=\n#{header_level}\s+|##|\z)/ms
+      ~r/^#{header_level}\s+#{start_header}\s*\n(.*?)(?=^#{header_level}\s+|\z)/ms
 
     updated_markdown =
       String.replace(


### PR DESCRIPTION
The old regex was missing lines between headers.
Switched `$` to `\n` and it now grabs everything up to the next header.
Works with blank lines too.
