### PR TITLE
Fix invalid_errors/1 to Return String Instead of List

### DIFF
--- a/apps/anoma_protobuf/lib/error_handler.ex
+++ b/apps/anoma_protobuf/lib/error_handler.ex
@@ -12,7 +12,7 @@ defmodule Anoma.Protobuf.ErrorHandler do
 
   If it is not, I raise a GRPC error. If it is, I do nothing.
   """
-  @spec validate_request!(any()) :: :noop
+  @spec validate_request!(any()) :: :noop | no_return()
   def validate_request!(req) do
     case Validate.valid?(req) do
       {:ok, :valid} ->
@@ -109,5 +109,7 @@ defmodule Anoma.Protobuf.ErrorHandler do
     |> Enum.map(fn {field, errors} ->
       "#{inspect(field)} #{error_message(errors)}"
     end)
+    |> Enum.intersperse(", ")
+    |> Enum.join("")
   end
 end


### PR DESCRIPTION
This fixes a bug where `invalid_errors/1` was returning a list instead of a string.
Now it joins the errors into a single readable string, matching the spec and improving GRPC error messages.