### PR TITLE
Properly turn a list into a string

### DIFF
--- a/apps/anoma_protobuf/lib/error_handler.ex
+++ b/apps/anoma_protobuf/lib/error_handler.ex
@@ -109,5 +109,7 @@ defmodule Anoma.Protobuf.ErrorHandler do
     |> Enum.map(fn {field, errors} ->
       "#{inspect(field)} #{error_message(errors)}"
     end)
+    |> Enum.intersperse("\n")
+    |> Enum.join()
   end
 end


### PR DESCRIPTION
Fixedup version of #2168