### PR TITLE
Cairo Transaction does not have nullifiers!, use the computed method

### DIFF
--- a/apps/anoma_node/lib/node/transaction/backends/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends/backends.ex
@@ -426,7 +426,7 @@ defmodule Anoma.Node.Transaction.Backends do
 
       cairo_rm_event(
         MapSet.new(commitments),
-        tx.nullifiers,
+        nullifiers,
         node_id
       )
 


### PR DESCRIPTION
I'm not sure how the ZK tests passed on this when looking at cutting a release, I assume this is a major oversight