### PR TITLE
Fix double-reply in Ordering.handle_commit

### DIFF
--- a/apps/anoma_node/lib/node/transaction/ordering/ordering.ex
+++ b/apps/anoma_node/lib/node/transaction/ordering/ordering.ex
@@ -288,7 +288,7 @@ defmodule Anoma.Node.Transaction.Ordering do
 
   def handle_call({:commit, round, writes, ids}, from, state) do
     handle_commit(round, writes, ids, from, state)
-    {:reply, :ok, state}
+    {:noreply, state}
   end
 
   def handle_call(_msg, _from, state) do
@@ -381,9 +381,9 @@ defmodule Anoma.Node.Transaction.Ordering do
            noun_writes}
         )
       end)
-    end
 
-    :ok
+      GenServer.reply(from, :ok)
+    end
   end
 
   @spec handle_order(list(binary()), t()) :: t()


### PR DESCRIPTION
handle_call returned {:reply, :ok, state} but handle_commit also replied via GenServer.reply inside Task.start, causing a double-reply when reservations existed. Changed to {:noreply, state} and added explicit GenServer.reply in the else branch.