### PR TITLE
Fix blocking_read catch-all not replying to caller

### DIFF
--- a/apps/anoma_node/lib/node/transaction/storage.ex
+++ b/apps/anoma_node/lib/node/transaction/storage.ex
@@ -206,8 +206,8 @@ defmodule Anoma.Node.Transaction.Storage do
             GenServer.reply(from, {:ok, value})
         end
 
-      _ ->
-        IO.puts("this should be unreachable")
+      unexpected ->
+        GenServer.reply(from, {:error, {:unexpected_event, unexpected}})
     end
 
     EventBroker.unsubscribe_me([


### PR DESCRIPTION
The catch-all branch in blocking_read's receive only called IO.puts("this should be unreachable") without calling GenServer.reply(from, ...). If an unexpected event matched the catch-all, the original caller would hang indefinitely waiting for a reply that never came.

Now the catch-all replies with an error tuple so the caller can handle it instead of hanging.