### PR TITLE
Fix CaseClauseError in do_append when read_in_past returns :error

### DIFF
--- a/apps/anoma_node/lib/node/transaction/storage.ex
+++ b/apps/anoma_node/lib/node/transaction/storage.ex
@@ -321,6 +321,7 @@ defmodule Anoma.Node.Transaction.Storage do
           case read_in_past(height, key, state) do
             :absent -> MapSet.new()
             {:ok, res} -> res
+            :error -> MapSet.new()
           end
 
         res ->


### PR DESCRIPTION
read_in_past/3 can return :error (per its spec and implementation), but do_append's case expression only handled :absent and {:ok, res}. If :error was returned, the GenServer crashed with CaseClauseError.

Treat :error the same as :absent (empty MapSet) since it indicates the key has no prior value that can be read.