### PR TITLE
Fix emit_value returning :ok instead of {:ok, result}

### DIFF
--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -783,4 +783,15 @@ defmodule Anoma.Node.Examples.ETransaction do
       1000 -> assert(false, "Failed to find failure message: #{exp_message}")
     end
   end
+
+  @doc """
+  I verify that `Backends.emit_value/3` returns the wrapped result
+  rather than the bare `:ok` from `EventBroker.event/1`.
+  """
+  @spec emit_value_returns_result() :: :ok
+  def emit_value_returns_result() do
+    assert {:ok, [1 | 2]} == Backends.emit_value("any", "id1", [1 | 2])
+    assert :error == Backends.emit_value("any", "id2", :error)
+    :ok
+  end
 end

--- a/apps/anoma_node/lib/node/transaction/backends/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends/backends.ex
@@ -333,6 +333,8 @@ defmodule Anoma.Node.Transaction.Backends do
     end)
   end
 
+  @spec emit_value(String.t(), binary(), :error | Noun.t()) ::
+          {:ok, Noun.t()} | :error
   def emit_value(node_id, id, result) do
     wrapped_result =
       case result do
@@ -347,6 +349,7 @@ defmodule Anoma.Node.Transaction.Backends do
       })
 
     EventBroker.event(event)
+    wrapped_result
   end
 
   @spec store_value(String.t(), binary(), Noun.t()) :: {:ok, any} | :error


### PR DESCRIPTION
emit_value returned the result of EventBroker.event() (:ok) instead of the wrapped_result ({:ok, res} or :error). This caused the with chain in execute/3 to fail pattern matching {:ok, backend_res} <- :ok, making every successful read-only transaction be reported as :error.

Now emit_value returns wrapped_result so the with chain matches correctly and read-only transactions are reported as successful.