### PR TITLE
Fix nested Mnesia transaction and unchecked commit in handle_commit

### DIFF
--- a/apps/anoma_node/lib/node/transaction/storage.ex
+++ b/apps/anoma_node/lib/node/transaction/storage.ex
@@ -46,9 +46,7 @@ defmodule Anoma.Node.Transaction.Storage do
       end
 
       for {key, value} <- state.uncommitted_updates do
-        {:atomic, res} =
-          fn -> :mnesia.read(__MODULE__.Updates, key) end
-          |> :mnesia.transaction()
+        res = :mnesia.read(__MODULE__.Updates, key)
 
         new_updates =
           case res do
@@ -61,7 +59,7 @@ defmodule Anoma.Node.Transaction.Storage do
       end
     end
 
-    :mnesia.transaction(mnesia_tx)
+    {:atomic, _} = :mnesia.transaction(mnesia_tx)
     {:reply, :ok, %__MODULE__{uncommitted_height: state.uncommitted_height}}
   end
 


### PR DESCRIPTION
handle_commit had two issues:

1. Called :mnesia.transaction() inside the outer mnesia_tx function that was already wrapped in :mnesia.transaction(). The inner transaction was unnecessary overhead; a direct :mnesia.read() suffices inside a transaction context.

2. The outer :mnesia.transaction() result was silently discarded. If the commit failed, uncommitted state was cleared anyway, causing silent data loss. Now we assert {:atomic, _} so the GenServer crashes on commit failure.