### PR TITLE
Fix @spec name mismatch for listen_for_block_finish!

### DIFF
--- a/apps/anoma_node/lib/node/transaction/executor/executor.ex
+++ b/apps/anoma_node/lib/node/transaction/executor/executor.ex
@@ -208,7 +208,7 @@ defmodule Anoma.Node.Transaction.Executor do
     end
   end
 
-  @spec listen_for_worker_finish!(integer()) :: :ok
+  @spec listen_for_block_finish!([binary()]) :: :ok
   defp listen_for_block_finish!(list) do
     receive do
       %EventBroker.Event{


### PR DESCRIPTION
The spec was named listen_for_worker_finish! (copy-paste from the function above) but the function is listen_for_block_finish!. Also fixes the parameter type from integer() to [binary()].