### PR TITLE
Fix handle_advance_watermark unreachable read-only branch

### DIFF
--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -1,10 +1,12 @@
 defmodule Anoma.Node.Examples.ETransaction do
   alias Anoma.Node
   alias Anoma.Node.Examples.ENode
+  alias Anoma.Node.Registry
   alias Anoma.Node.Transaction.Backends
   alias Anoma.Node.Transaction.Backends.Events.ROEvent
   alias Anoma.Node.Transaction.Mempool
   alias Anoma.Node.Transaction.Ordering
+  alias Anoma.Node.Transaction.Shard
   alias Anoma.Node.Transaction.Storage
   alias Anoma.Tables
   alias Anoma.RM.Transparent.Transaction
@@ -799,5 +801,50 @@ defmodule Anoma.Node.Examples.ETransaction do
     })
 
     Ordering.write(node_id, {tx_id, [{opts[:key], opts[:value]}]})
+  end
+
+  @doc """
+  I verify that shard watermarks advance for keys that are only
+  read (not written) within a block.
+
+  Two transactions each read key ["a"] but write to different keys.
+  After ordering, the shard for ["a"] should have its write
+  watermark advanced so that reads at the block height proceed.
+  """
+  @spec watermark_advances_for_read_only_keys(String.t()) :: String.t()
+  def watermark_advances_for_read_only_keys(
+        node_id \\ Node.example_random_id()
+      ) do
+    ENode.start_node(node_id: node_id)
+
+    tx1 = random_transaction_id()
+    tx2 = random_transaction_id()
+
+    Ordering.reserve(node_id, tx1, %{
+      read: MapSet.new([["a"]]),
+      write: MapSet.new([["b"]])
+    })
+
+    Ordering.reserve(node_id, tx2, %{
+      read: MapSet.new([["a"]]),
+      write: MapSet.new([["c"]])
+    })
+
+    Ordering.order(node_id, [tx1, tx2])
+
+    # Synchronise: ensure Ordering has processed all casts so the
+    # shard for ["a"] exists before we try to read from it.
+    Registry.via(node_id, Ordering) |> :sys.get_state()
+
+    shard_a = Registry.via(node_id, Shard, :a)
+
+    # Cell.read blocks when height > watermark.write + 1.
+    # The watermark should be at 1 (order-1 of the last read),
+    # so reading at height 2 resolves immediately.
+    read_task = Task.async(fn -> Shard.read(shard_a, ["a"], 2) end)
+
+    assert Task.await(read_task, 2000) == :absent
+
+    node_id
   end
 end

--- a/apps/anoma_node/lib/node/transaction/ordering/ordering.ex
+++ b/apps/anoma_node/lib/node/transaction/ordering/ordering.ex
@@ -581,10 +581,12 @@ defmodule Anoma.Node.Transaction.Ordering do
   end
 
   @spec handle_advance_watermark([{flag(), any()}], any(), pid()) :: any()
+  defp handle_advance_watermark([], _key, _pid), do: []
+
   defp handle_advance_watermark(block_list, key, pid) do
     Enum.reduce_while(
       block_list,
-      block_list,
+      tl(block_list),
       fn
         {:read, order}, [] ->
           # if no further keys, advance to the last read of the block
@@ -598,7 +600,7 @@ defmodule Anoma.Node.Transaction.Ordering do
         {:write, order}, acc ->
           # if we hit a write, advance watermark to it directly
           Shard.advance_watermark(pid, key, order - 1)
-          {:halt, acc}
+          {:halt, [{:write, order} | acc]}
       end
     )
   end


### PR DESCRIPTION
The accumulator started as block_list (same list being iterated), so when processing the last element, the accumulator was always [last_element] not []. This made the {:read, order}, [] -> clause dead code, meaning watermarks for read-only key sequences were never advanced mid-block.

Fix by starting the accumulator as tl(block_list), so the last element correctly sees an empty accumulator. The :write clause now reconstructs the remaining list to preserve the write entry.


This one took me a while to see, but it makes sense, Ijust don't think we have good coverage here