### PR TITLE
Fix unchecked :mnesia.transaction() in Ordering.handle_commit

### DIFF
--- a/apps/anoma_node/lib/node/transaction/ordering/ordering.ex
+++ b/apps/anoma_node/lib/node/transaction/ordering/ordering.ex
@@ -375,12 +375,13 @@ defmodule Anoma.Node.Transaction.Ordering do
 
       noun_writes = Enum.map(writes, &Noun.Nounable.to_noun/1)
 
-      :mnesia.transaction(fn ->
-        :mnesia.write(
-          {Tables.table_blocks(state.node_id), ["anoma", "block", round],
-           noun_writes}
-        )
-      end)
+      {:atomic, _} =
+        :mnesia.transaction(fn ->
+          :mnesia.write(
+            {Tables.table_blocks(state.node_id), ["anoma", "block", round],
+             noun_writes}
+          )
+        end)
     end
 
     :ok


### PR DESCRIPTION
The Mnesia block write result was silently discarded. If the transaction failed (e.g. table missing, disk full), the commit would appear to succeed. Assert {:atomic, _} to surface failures.