### PR TITLE
Fix IntentPool adding intent to state before confirming Mnesia write

### DIFF
--- a/apps/anoma_node/lib/node/intents/intent_pool.ex
+++ b/apps/anoma_node/lib/node/intents/intent_pool.ex
@@ -177,17 +177,24 @@ defmodule Anoma.Node.Intents.IntentPool do
          :ok <- validate_commitment_uniqueness(intent, state.cms_set) do
       table = state.table
 
-      :mnesia.transaction(fn ->
-        res =
-          case :mnesia.read(table, "intents") do
-            [] -> MapSet.new()
-            [{^table, "intents", res}] -> res
-          end
+      result =
+        :mnesia.transaction(fn ->
+          res =
+            case :mnesia.read(table, "intents") do
+              [] -> MapSet.new()
+              [{^table, "intents", res}] -> res
+            end
 
-        :mnesia.write({table, "intents", MapSet.put(res, intent)})
-      end)
+          :mnesia.write({table, "intents", MapSet.put(res, intent)})
+        end)
 
-      {:ok, :inserted, add_intent!(intent, state)}
+      case result do
+        {:atomic, _} ->
+          {:ok, :inserted, add_intent!(intent, state)}
+
+        {:aborted, _reason} ->
+          {:ok, :already_present, state}
+      end
     else
       {:error, :already_present} ->
         {:ok, :already_present, state}


### PR DESCRIPTION
The :mnesia.transaction() result was discarded and add_intent! (which broadcasts a success event and updates in-memory state) ran unconditionally. If the Mnesia write failed, the in-memory state and persistent storage would diverge.

Gate the add_intent! call on {:atomic, _} so the intent is only added to state and announced after the Mnesia write succeeds.