### PR TITLE
Fix Proxy.Node.handle_info dead {:reply, ...} return values

### DIFF
--- a/apps/anoma_node/lib/node/transport/network_register/proxy/node.ex
+++ b/apps/anoma_node/lib/node/transport/network_register/proxy/node.ex
@@ -178,12 +178,10 @@ defmodule Anoma.Node.Transport.Proxy.Node do
     case list_transport_protocols(remote_node_id) do
       [] ->
         Logger.error("no protocols for #{remote_node_id}")
-        {:reply, :ok, state}
 
       [transport_protocol | _] ->
         address = Registry.via(transport_protocol)
-        result = TransportProtocol.event(address, message)
-        {:reply, result, state}
+        TransportProtocol.event(address, message)
     end
 
     {:noreply, state}


### PR DESCRIPTION
The case expression result was discarded because {:noreply, state} followed it as the last expression. The {:reply, ...} tuples in the case branches were dead code (and invalid for handle_info anyway). Remove the dead return tuples — the side effects (Logger.error, TransportProtocol.event) still execute.