### PR TITLE
Fix Proxy.Engine.init ignoring registration failure

### DIFF
--- a/apps/anoma_node/lib/node/transport/network_register/proxy/engine.ex
+++ b/apps/anoma_node/lib/node/transport/network_register/proxy/engine.ex
@@ -85,19 +85,17 @@ defmodule Anoma.Node.Transport.Proxy.Engine do
           "already registered #{args[:engine]} engine for #{args[:remote_node_id]}"
         )
 
-        {:stop, :already_registered}
+        :ignore
 
       {:ok, _} ->
         Logger.debug("registered engine for #{args[:remote_node_id]}")
-        {:ok, args}
+        Logger.debug("#{inspect(self())} proxy engine for #{inspect(args)}")
+        Process.set_label(__MODULE__)
+
+        args = Keyword.validate!(args, @args)
+        state = struct(__MODULE__, Enum.into(args, %{}))
+        {:ok, state}
     end
-
-    Logger.debug("#{inspect(self())} proxy engine for #{inspect(args)}")
-    Process.set_label(__MODULE__)
-
-    args = Keyword.validate!(args, @args)
-    state = struct(__MODULE__, Enum.into(args, %{}))
-    {:ok, state}
   end
 
   @impl true


### PR DESCRIPTION
The case expression result was discarded because it was not the last expression in the function. Lines after the case always executed, so the process started with {:ok, state} even when registration failed. Move success-path code into the {:ok, _} branch and return :ignore for the already-registered case so the supervisor can start gracefully.