### PR TITLE
Fix all non-TODO credo issues and ensure dialyzer compliance

### DIFF
--- a/apps/anoma_client/lib/client.ex
+++ b/apps/anoma_client/lib/client.ex
@@ -134,6 +134,11 @@ defmodule Anoma.Client do
   @doc """
   I compose a list of transactions.
   """
+  @spec compose([binary()]) ::
+          {:ok, binary()}
+          | {:error, :invalid_input, term()}
+          | {:error, :noun_not_a_valid_transaction}
+          | {:error, :not_enough_transactions}
   def compose(transactions) do
     Transactions.compose(transactions)
   end

--- a/apps/anoma_client/lib/client/web/controllers/error_json.ex
+++ b/apps/anoma_client/lib/client/web/controllers/error_json.ex
@@ -16,6 +16,7 @@ defmodule Anoma.Client.Web.ErrorJSON do
   # the template name. For example, "404.json" becomes
   # "Not Found".
 
+  @spec render(String.t(), map()) :: map()
   def render("500.json", %{
         reason: {:noproc, {_, :call, [Anoma.Client.Node.GRPCProxy, _, _]}}
       }) do

--- a/apps/anoma_client/lib/client/web/controllers/fallback_controller.ex
+++ b/apps/anoma_client/lib/client/web/controllers/fallback_controller.ex
@@ -1,6 +1,7 @@
 defmodule Anoma.Client.Web.FallbackController do
   use Phoenix.Controller
 
+  @spec call(Plug.Conn.t(), term()) :: Plug.Conn.t()
   def call(conn, {:error, :failed_to_fetch_intents}) do
     conn
     |> put_status(503)

--- a/apps/anoma_client/lib/client/web/controllers/intents/intents.ex
+++ b/apps/anoma_client/lib/client/web/controllers/intents/intents.ex
@@ -46,6 +46,7 @@ defmodule Anoma.Client.Web.IntentsController do
   I return a list of all intents from the remote node.
   The intents will be jammed nouns, base64 encoded.
   """
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, _params) do
     with {:ok, intents} <- GRPCProxy.list_intents() do
       render(conn, "index.json", intents: intents)
@@ -59,6 +60,7 @@ defmodule Anoma.Client.Web.IntentsController do
 
   If anything goes wrong, I will return an error and this will be handled by the fallback controller.
   """
+  @spec add_intent(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def add_intent(conn, params = %{"intent" => _}) do
     with {:ok, intent} <- Base.decode64(params["intent"]),
          {:ok, :added} <- GRPCProxy.add_intent(intent) do

--- a/apps/anoma_client/lib/client/web/controllers/intents/view.ex
+++ b/apps/anoma_client/lib/client/web/controllers/intents/view.ex
@@ -1,4 +1,5 @@
 defmodule Anoma.Client.Web.IntentsJSON do
+  @spec render(String.t(), map()) :: map()
   def render("index.json", %{intents: intents}) do
     intents = Enum.map(intents, &Base.encode64/1)
     %{intents: intents}

--- a/apps/anoma_client/lib/client/web/controllers/mempool/view.ex
+++ b/apps/anoma_client/lib/client/web/controllers/mempool/view.ex
@@ -1,4 +1,5 @@
 defmodule Anoma.Client.Web.MempoolJSON do
+  @spec render(String.t(), map()) :: map()
   def render("add_transaction.json", _assigns) do
     %{message: "transaction added"}
   end

--- a/apps/anoma_client/lib/client/web/controllers/nock/nock.ex
+++ b/apps/anoma_client/lib/client/web/controllers/nock/nock.ex
@@ -42,6 +42,7 @@ defmodule Anoma.Client.Web.NockController do
   @doc """
   I execute the given Nock program locally.
   """
+  @spec run(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def run(conn, params = %{"inputs" => _, "program" => _}) do
     inputs = params["inputs"]
     program = params["program"]
@@ -68,6 +69,7 @@ defmodule Anoma.Client.Web.NockController do
   @doc """
   I execute the given Nock program locally.
   """
+  @spec prove(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def prove(conn, params = %{"program" => _}) do
     priv_inputs = Map.get(params, "private_inputs", [])
     publ_inputs = Map.get(params, "public_inputs", [])

--- a/apps/anoma_client/lib/client/web/controllers/nock/view.ex
+++ b/apps/anoma_client/lib/client/web/controllers/nock/view.ex
@@ -1,4 +1,5 @@
 defmodule Anoma.Client.Web.NockJSON do
+  @spec render(String.t(), map()) :: map()
   def render("run.json", %{result: res, io: io}) do
     %{result: Base.encode64(res), io: Enum.map(io, &Base.encode64/1)}
   end

--- a/apps/anoma_client/lib/client/web/controllers/subscribe/subscribe.ex
+++ b/apps/anoma_client/lib/client/web/controllers/subscribe/subscribe.ex
@@ -44,6 +44,7 @@ defmodule Anoma.Client.Web.SubscribeController do
   I return a list of all intents from the remote node.
   The intents will be jammed nouns, base64 encoded.
   """
+  @spec subscribe(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def subscribe(conn, _params = %{"topic" => topic}) do
     with {:ok, :subscribed} <- GRPCProxy.subscribe(topic) do
       render(conn, "subscribed.json")

--- a/apps/anoma_client/lib/client/web/controllers/subscribe/view.ex
+++ b/apps/anoma_client/lib/client/web/controllers/subscribe/view.ex
@@ -1,4 +1,5 @@
 defmodule Anoma.Client.Web.SubscribeJSON do
+  @spec render(String.t(), map()) :: map()
   def render("subscribed.json", _params) do
     %{message: "subscribed"}
   end

--- a/apps/anoma_client/lib/client/web/controllers/transaction/transactions.ex
+++ b/apps/anoma_client/lib/client/web/controllers/transaction/transactions.ex
@@ -45,6 +45,7 @@ defmodule Anoma.Client.Web.TransactionController do
   I return a list of all intents from the remote node.
   The intents will be jammed nouns, base64 encoded.
   """
+  @spec compose(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def compose(conn, _params = %{"transactions" => transactions}) do
     with {:ok, transactions} <- decode_many(transactions),
          {:ok, composed} <- Transactions.compose(transactions) do
@@ -58,6 +59,7 @@ defmodule Anoma.Client.Web.TransactionController do
     end
   end
 
+  @spec verify(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def verify(conn, _params = %{"transaction" => transaction}) do
     with {:ok, transaction} <- Base.decode64(transaction),
          {:ok, valid?} <- Transactions.verify(transaction) do

--- a/apps/anoma_client/lib/client/web/controllers/transaction/view.ex
+++ b/apps/anoma_client/lib/client/web/controllers/transaction/view.ex
@@ -1,4 +1,5 @@
 defmodule Anoma.Client.Web.TransactionJSON do
+  @spec render(String.t(), map()) :: map()
   def render("composed.json", %{transaction: transaction}) do
     %{transaction: Base.encode64(transaction)}
   end

--- a/apps/anoma_client/lib/client/web/socket_handler.ex
+++ b/apps/anoma_client/lib/client/web/socket_handler.ex
@@ -3,23 +3,31 @@ defmodule Anoma.Client.Web.Socket do
 
   alias Phoenix.PubSub
 
+  @spec child_spec(keyword()) :: :ignore
   def child_spec(_opts) do
     # We won't spawn any process, so let's ignore the child spec
     :ignore
   end
 
+  @spec connect(state) :: {:ok, state}
+        when state: Phoenix.Socket.Transport.state()
   def connect(state) do
     # Callback to retrieve relevant data from the connection.
     # The map contains options, params, transport and endpoint keys.
     {:ok, state}
   end
 
+  @spec init(state) :: {:ok, state}
+        when state: Phoenix.Socket.Transport.state()
   def init(state) do
     # Now we are effectively inside the process that maintains the socket.
     PubSub.subscribe(:client_pubsub, "node_events")
     {:ok, state}
   end
 
+  @spec handle_in({String.t(), keyword()}, state) ::
+          {:reply, :ok, {:text, String.t()}, state}
+        when state: Phoenix.Socket.Transport.state()
   def handle_in({text, _opts}, state) do
     {:reply, :ok, {:text, text}, state}
   end
@@ -34,6 +42,7 @@ defmodule Anoma.Client.Web.Socket do
     {:push, {:text, encoded}, state}
   end
 
+  @spec terminate(term(), Phoenix.Socket.Transport.state()) :: :ok
   def terminate(_reason, _state) do
     :ok
   end

--- a/apps/anoma_client/lib/client/web/web.ex
+++ b/apps/anoma_client/lib/client/web/web.ex
@@ -17,8 +17,10 @@ defmodule Anoma.Client.Web do
   those modules here.
   """
 
+  @spec static_paths() :: [String.t()]
   def static_paths, do: ~w(assets fonts images favicon.ico robots.txt)
 
+  @spec router() :: Macro.t()
   def router do
     quote do
       use Phoenix.Router, helpers: false
@@ -29,6 +31,7 @@ defmodule Anoma.Client.Web do
     end
   end
 
+  @spec controller() :: Macro.t()
   def controller do
     quote do
       use Phoenix.Controller,
@@ -42,6 +45,7 @@ defmodule Anoma.Client.Web do
     end
   end
 
+  @spec live_view() :: Macro.t()
   def live_view do
     quote do
       use Phoenix.LiveView,
@@ -51,6 +55,7 @@ defmodule Anoma.Client.Web do
     end
   end
 
+  @spec live_component() :: Macro.t()
   def live_component do
     quote do
       use Phoenix.LiveComponent
@@ -59,6 +64,7 @@ defmodule Anoma.Client.Web do
     end
   end
 
+  @spec html() :: Macro.t()
   def html do
     quote do
       use Phoenix.Component
@@ -88,6 +94,7 @@ defmodule Anoma.Client.Web do
     end
   end
 
+  @spec verified_routes() :: Macro.t()
   def verified_routes do
     quote do
       use Phoenix.VerifiedRoutes,

--- a/apps/anoma_client/lib/examples/e_client/mempool.ex
+++ b/apps/anoma_client/lib/examples/e_client/mempool.ex
@@ -15,6 +15,7 @@ defmodule Anoma.Client.Examples.EClient.Mempool do
   import ExUnit.Assertions
   import ExUnit.CaptureLog
 
+  @spec example_transaction() :: String.t()
   def example_transaction do
     transaction = ETransaction.trivial_transparent_transaction()
 

--- a/apps/anoma_client/lib/examples/e_prove.ex
+++ b/apps/anoma_client/lib/examples/e_prove.ex
@@ -159,6 +159,7 @@ defmodule Anoma.Client.Examples.EProve do
     program
   end
 
+  @spec prove_with_scry(Anoma.Client.Examples.EClient.t()) :: :ok
   def prove_with_scry(client \\ Anoma.Client.Examples.EClient.setup()) do
     :ok = Tables.reset_tables_for_client()
 

--- a/apps/anoma_lib/lib/anoma/cairo_resource/logic_instance.ex
+++ b/apps/anoma_lib/lib/anoma/cairo_resource/logic_instance.ex
@@ -100,6 +100,7 @@ defmodule Anoma.CairoResource.LogicInstance do
     end
   end
 
+  @spec get_app_data_pair(binary()) :: {binary(), [[binary()]]}
   def get_app_data_pair(public_input) do
     output =
       public_input

--- a/apps/anoma_lib/lib/anoma/cairo_resource/transaction.ex
+++ b/apps/anoma_lib/lib/anoma/cairo_resource/transaction.ex
@@ -216,11 +216,13 @@ defmodule Anoma.CairoResource.Transaction do
         output_logics,
         output_witnesses
       ) do
-    with input_resource_jsons =
-           Enum.map(compliance_units, & &1["input"]),
-         output_resource_jsons =
-           Enum.map(compliance_units, & &1["output"]),
-         {:ok, input_nf_keys} <-
+    input_resource_jsons =
+      Enum.map(compliance_units, & &1["input"])
+
+    output_resource_jsons =
+      Enum.map(compliance_units, & &1["output"])
+
+    with {:ok, input_nf_keys} <-
            Enum.map(
              compliance_units,
              &Utils.parse_json_field_to_binary32(&1, "input_nf_key")

--- a/apps/anoma_lib/lib/anoma/cairo_resource/tree.ex
+++ b/apps/anoma_lib/lib/anoma/cairo_resource/tree.ex
@@ -55,15 +55,16 @@ defmodule Anoma.CairoResource.Tree do
     end
   end
 
-  @spec set_path(binary(), list()) :: :error | {:ok, binary()}
+  @spec set_path(binary(), list(), String.t()) :: :error | {:ok, binary()}
   def set_path(json, path, path_name \\ "merkle_path") do
     with {:ok, decoded_json} <-
-           Jason.decode(json, objects: :ordered_objects),
-         path_json_ob =
-           path
-           |> Enum.map(fn {f, s} ->
-             Jason.OrderedObject.new([{"fst", f}, {"snd", s}])
-           end) do
+           Jason.decode(json, objects: :ordered_objects) do
+      path_json_ob =
+        path
+        |> Enum.map(fn {f, s} ->
+          Jason.OrderedObject.new([{"fst", f}, {"snd", s}])
+        end)
+
       put_in(decoded_json[path_name], path_json_ob) |> Jason.encode()
     else
       _ -> :error

--- a/apps/anoma_lib/lib/anoma/cairo_resource/utils.ex
+++ b/apps/anoma_lib/lib/anoma/cairo_resource/utils.ex
@@ -60,8 +60,8 @@ defmodule Anoma.CairoResource.Utils do
           {:ok, list(any())} | {:error, any()}
   def check_list(lst) do
     with true <-
-           Enum.all?(lst, &(elem(&1, 0) == :ok)),
-         lst_1 = Enum.map(lst, &elem(&1, 1)) do
+           Enum.all?(lst, &(elem(&1, 0) == :ok)) do
+      lst_1 = Enum.map(lst, &elem(&1, 1))
       {:ok, lst_1}
     else
       _ -> Enum.find(lst, &(elem(&1, 0) == :error))

--- a/apps/anoma_lib/lib/anoma/cairo_resource/workflow.ex
+++ b/apps/anoma_lib/lib/anoma/cairo_resource/workflow.ex
@@ -18,12 +18,13 @@ defmodule Anoma.CairoResource.Workflow do
          {:ok, program} <-
            resource_logic["data"]
            |> Enum.map(&Utils.integer_or_hex_to_n_byte_binary(&1, 32))
-           |> Utils.check_list(),
-         hash =
-           Enum.drop(program, -2)
-           |> Enum.map(&:binary.bin_to_list/1)
-           |> Cairo.poseidon_many()
-           |> :binary.list_to_bin() do
+           |> Utils.check_list() do
+      hash =
+        Enum.drop(program, -2)
+        |> Enum.map(&:binary.bin_to_list/1)
+        |> Cairo.poseidon_many()
+        |> :binary.list_to_bin()
+
       {:ok, hash}
     else
       {:error, msg} -> {:error, "Error hashing resource logic: #{msg}"}
@@ -111,9 +112,9 @@ defmodule Anoma.CairoResource.Workflow do
   defp get_resources(update, jsons, resource_logics) do
     with {:ok, logic_hashes} <-
            Enum.map(resource_logics, &hash_resource_logic/1)
-           |> Utils.check_list(),
-         resource_jsons = update.(jsons, logic_hashes),
-         resources = Enum.map(resource_jsons, &Resource.from_json_object/1) do
+           |> Utils.check_list() do
+      resource_jsons = update.(jsons, logic_hashes)
+      resources = Enum.map(resource_jsons, &Resource.from_json_object/1)
       {:ok, resources}
     else
       {:error, msg} -> {:error, "Error reading resources: #{msg}"}
@@ -251,18 +252,19 @@ defmodule Anoma.CairoResource.Workflow do
         nf_keys,
         merkle_paths
       ) do
-    with updated_witness_jsons =
-           Enum.zip_with(
-             witnesses,
-             Enum.zip(
-               resources,
-               Enum.zip(is_consumed_flags, Enum.zip(nf_keys, merkle_paths))
-             ),
-             fn json, {r, {is_consumed_flag, {nk, p}}} ->
-               update_witness_json(json, r, is_consumed_flag, nk, p)
-             end
-           ),
-         {:ok, updated_witnesses} <-
+    updated_witness_jsons =
+      Enum.zip_with(
+        witnesses,
+        Enum.zip(
+          resources,
+          Enum.zip(is_consumed_flags, Enum.zip(nf_keys, merkle_paths))
+        ),
+        fn json, {r, {is_consumed_flag, {nk, p}}} ->
+          update_witness_json(json, r, is_consumed_flag, nk, p)
+        end
+      )
+
+    with {:ok, updated_witnesses} <-
            Enum.map(updated_witness_jsons, &Jason.encode/1)
            |> Utils.check_list() do
       {:ok, updated_witnesses}

--- a/apps/anoma_lib/lib/anoma/rm/transparent/action.ex
+++ b/apps/anoma_lib/lib/anoma/rm/transparent/action.ex
@@ -132,9 +132,9 @@ defmodule Anoma.RM.Transparent.Action do
     # 3
     with true <- cu_check(t),
          # Extra
-         {:ok, _} <- is_list_unique(t.consumed),
+         {:ok, _} <- list_unique?(t.consumed),
          # Extra
-         {:ok, _} <- is_list_unique(t.created),
+         {:ok, _} <- list_unique?(t.created),
          # Extra
          {:ok, true} <- partition_check(t),
          # 2
@@ -293,8 +293,8 @@ defmodule Anoma.RM.Transparent.Action do
     )
   end
 
-  @spec is_list_unique(list()) :: {:ok, list()} | {:error, String.t()}
-  defp is_list_unique(list) do
+  @spec list_unique?(list()) :: {:ok, list()} | {:error, String.t()}
+  defp list_unique?(list) do
     Enum.reduce_while(list, {:ok, []}, fn elem, {:ok, acc} ->
       unless Enum.any?(acc, fn x -> x == elem end) do
         {:cont, {:ok, [elem | acc]}}

--- a/apps/anoma_lib/lib/anoma/rm/transparent/json.ex
+++ b/apps/anoma_lib/lib/anoma/rm/transparent/json.ex
@@ -2,6 +2,8 @@
 # Resource
 
 defimpl Jason.Encoder, for: Anoma.RM.Transparent.Resource do
+  @spec encode(Anoma.RM.Transparent.Resource.t(), Jason.Encode.opts()) ::
+          iodata()
   def encode(resource, opts) do
     resource =
       resource
@@ -15,6 +17,10 @@ end
 # ----------------------------------------------------------------------------
 # CPS Instance
 defimpl Jason.Encoder, for: Anoma.RM.Transparent.ProvingSystem.CPS.Instance do
+  @spec encode(
+          Anoma.RM.Transparent.ProvingSystem.CPS.Instance.t(),
+          Jason.Encode.opts()
+        ) :: iodata()
   def encode(instance, opts) do
     # encode the consumed resources
     consumed =
@@ -38,6 +44,8 @@ end
 # Compliance Unit
 
 defimpl Jason.Encoder, for: Anoma.RM.Transparent.ComplianceUnit do
+  @spec encode(Anoma.RM.Transparent.ComplianceUnit.t(), Jason.Encode.opts()) ::
+          iodata()
   def encode(compliance_unit, opts) do
     # encode the consumed resources
     compliance_unit
@@ -97,6 +105,7 @@ defimpl Jason.Encoder, for: Anoma.RM.Transparent.Action do
   end
 
   # https://specs.anoma.net/latest/arch/system/state/resource_machine/data_structures/action/index.html
+  @spec encode(Action.t(), Jason.Encode.opts()) :: iodata()
   def encode(action, opts) do
     extra_info = extra_info(action)
 
@@ -135,6 +144,8 @@ defimpl Jason.Encoder, for: Anoma.RM.Transparent.Action do
   # Action
 
   defimpl Jason.Encoder, for: Anoma.RM.Transparent.Transaction do
+    @spec encode(Anoma.RM.Transparent.Transaction.t(), Jason.Encode.opts()) ::
+            iodata()
     def encode(transaction, opts) do
       transaction
       |> Map.update!(:delta_proof, &Base.encode64/1)

--- a/apps/anoma_lib/lib/examples/e_cairo/e_transaction.ex
+++ b/apps/anoma_lib/lib/examples/e_cairo/e_transaction.ex
@@ -109,6 +109,10 @@ defmodule Examples.ECairo.ETransaction do
       )
 
     compliance_units_raw = [compliance1_inputs, compliance2_inputs]
+    input_logics = [resource_logic, resource_logic]
+    input_witnesses_raw = [witness, witness]
+    output_logics = [resource_logic, resource_logic]
+    output_witnesses_raw = [witness, witness]
 
     with {:ok, compliance_units} <-
            Enum.map(
@@ -116,16 +120,12 @@ defmodule Examples.ECairo.ETransaction do
              &Jason.decode(&1, objects: :ordered_objects)
            )
            |> Utils.check_list(),
-         input_logics = [resource_logic, resource_logic],
-         input_witnesses_raw = [witness, witness],
          {:ok, input_witnesses} <-
            Enum.map(
              input_witnesses_raw,
              &Jason.decode(&1, objects: :ordered_objects)
            )
            |> Utils.check_list(),
-         output_logics = [resource_logic, resource_logic],
-         output_witnesses_raw = [witness, witness],
          {:ok, output_witnesses} <-
            Enum.map(
              output_witnesses_raw,
@@ -139,8 +139,8 @@ defmodule Examples.ECairo.ETransaction do
              input_witnesses,
              output_logics,
              output_witnesses
-           ),
-         shielded_tx = Transaction.prove_delta(pre_tx) do
+           ) do
+      shielded_tx = Transaction.prove_delta(pre_tx)
       assert true == Transaction.verify(shielded_tx)
 
       shielded_tx
@@ -193,7 +193,7 @@ defmodule Examples.ECairo.ETransaction do
     invalid_shielded_tx
   end
 
-  @spec shielded_transaction_cipher_texts() :: [
+  @spec shielded_transaction_cipher_texts(binary()) :: [
           %{cipher: list(), tag: binary()}
         ]
   def shielded_transaction_cipher_texts(decryption_key \\ <<1::256>>) do

--- a/apps/anoma_lib/lib/examples/e_transparent/json.ex
+++ b/apps/anoma_lib/lib/examples/e_transparent/json.ex
@@ -8,6 +8,7 @@ defmodule Examples.ETransparent.EJSON do
   @doc """
   I test the json encoding of a cps unit.
   """
+  @spec cps_instance() :: String.t()
   def cps_instance do
     instance = arbitrary_cps_instance()
     Jason.encode!(instance)
@@ -16,6 +17,7 @@ defmodule Examples.ETransparent.EJSON do
   @doc """
   I test the json encoding of a compliance unit.
   """
+  @spec compliance_unit() :: String.t()
   def compliance_unit do
     compliance_unit = arbitrary_compliance_unit()
     Jason.encode!(compliance_unit)
@@ -24,6 +26,7 @@ defmodule Examples.ETransparent.EJSON do
   @doc """
   I test the json encoding of a resource
   """
+  @spec resource() :: String.t()
   def resource do
     resource = arbitrary_resource()
     Jason.encode!(resource)
@@ -32,6 +35,7 @@ defmodule Examples.ETransparent.EJSON do
   @doc """
   I test the json encoding of an action.
   """
+  @spec action() :: String.t()
   def action do
     action = arbitrary_action()
     Jason.encode!(action)
@@ -40,6 +44,7 @@ defmodule Examples.ETransparent.EJSON do
   @doc """
   I test the json encoding of a transaction.
   """
+  @spec transaction() :: String.t()
   def transaction do
     transaction = arbitrary_transaction()
     Jason.encode!(transaction)
@@ -49,18 +54,22 @@ defmodule Examples.ETransparent.EJSON do
   #                           Helpers                        #
   ############################################################
 
+  @spec arbitrary_transaction() :: Anoma.RM.Transparent.Transaction.t()
   def arbitrary_transaction do
     ETransaction.single_swap()
   end
 
+  @spec arbitrary_action() :: Anoma.RM.Transparent.Action.t()
   def arbitrary_action do
     EAction.trivial_swap_action()
   end
 
+  @spec arbitrary_resource() :: Anoma.RM.Transparent.Resource.t()
   def arbitrary_resource do
     EResource.trivial_false_resource()
   end
 
+  @spec arbitrary_compliance_unit() :: term()
   def arbitrary_compliance_unit do
     arbitrary_action()
     |> Map.get(:compliance_units)
@@ -68,6 +77,8 @@ defmodule Examples.ETransparent.EJSON do
     |> hd()
   end
 
+  @spec arbitrary_cps_instance() ::
+          Anoma.RM.Transparent.ProvingSystem.CPS.Instance.t()
   def arbitrary_cps_instance do
     arbitrary_action()
     |> Map.get(:instance)

--- a/apps/anoma_lib/lib/examples/ecommitment_tree.ex
+++ b/apps/anoma_lib/lib/examples/ecommitment_tree.ex
@@ -158,7 +158,7 @@ defmodule Examples.ECommitmentTree do
   @doc """
   A commitment tree with commits from Examples.ERM.EShielded.ETransaction.a_shielded_transaction/0
   """
-  @spec ct_with_trivial_cairo_tx(term()) ::
+  @spec ct_with_trivial_cairo_tx(term(), CommitmentTree.Spec.t()) ::
           {CommitmentTree.t(), binary()}
   def ct_with_trivial_cairo_tx(
         cms,

--- a/apps/anoma_lib/lib/examples/enock.ex
+++ b/apps/anoma_lib/lib/examples/enock.ex
@@ -57,7 +57,7 @@ defmodule Examples.ENock do
 
   #### Term Examples
 
-  @spec zero(Noun.t()) :: Noun.t()
+  @spec zero(Noun.t(), Noun.t()) :: Noun.t()
   def zero(key \\ "key", writes \\ [["key"]]) do
     zero_counter_arm = [1, [key] | 0]
     arm = [10, [2 | zero_counter_arm], 1, 0 | 0]
@@ -1327,13 +1327,13 @@ defmodule Examples.ENock do
 
   @spec mug_test() :: bool()
   def mug_test() do
-    assert 10000
+    assert 10_000
            |> mug_call()
            |> Nock.nock([9, 2, 0 | 1])
            |> elem(1)
            |> Noun.equal?(795_713_195)
 
-    assert 10001
+    assert 10_001
            |> mug_call()
            |> Nock.nock([9, 2, 0 | 1])
            |> elem(1)
@@ -1495,7 +1495,7 @@ defmodule Examples.ENock do
            |> elem(1)
            |> Noun.equal?(1)
 
-    assert mor_call(43326, 41106)
+    assert mor_call(43_326, 41_106)
            |> Nock.nock([9, 2, 0 | 1])
            |> elem(1)
            |> Noun.equal?(1)
@@ -2414,7 +2414,7 @@ defmodule Examples.ENock do
   end
 
   @spec commitment_test(pos_integer) :: binary()
-  def commitment_test(n \\ :rand.uniform(10000)) do
+  def commitment_test(n \\ :rand.uniform(10_000)) do
     res = %Resource{quantity: n} |> Noun.Nounable.to_noun()
 
     {:ok, res} = make_commitment_call(res)
@@ -2422,8 +2422,8 @@ defmodule Examples.ENock do
     <<"CM_", _rest::bitstring>> = Noun.atom_integer_to_binary(res)
   end
 
-  @spec is_commitment_arm() :: Noun.t()
-  def is_commitment_arm() do
+  @spec commitment_check_arm() :: Noun.t()
+  def commitment_check_arm() do
     arm_info = Mugs.index_map().is_commitment
     layer_depth = example_layer_depth(arm_info.layer)
     arm_index = arm_info.index
@@ -2435,11 +2435,11 @@ defmodule Examples.ENock do
   @spec make_is_commitment_call(Noun.t()) :: Noun.t()
   def make_is_commitment_call(atom) do
     sample = atom
-    [is_commitment_arm(), sample | Nock.Lib.rm_core()]
+    [commitment_check_arm(), sample | Nock.Lib.rm_core()]
   end
 
-  @spec is_commitment_test() :: true
-  def is_commitment_test() do
+  @spec commitment_check_test() :: true
+  def commitment_check_test() do
     atom_true = "CM_whatever"
     atom_false = "NF_whatever"
     atom_weird_still_false = "a"
@@ -2480,7 +2480,7 @@ defmodule Examples.ENock do
 
   @spec nullifier_test() :: true
   @spec nullifier_test(pos_integer()) :: true
-  def nullifier_test(n \\ :rand.uniform(10000)) do
+  def nullifier_test(n \\ :rand.uniform(10_000)) do
     resource = %Resource{quantity: n}
 
     {:ok, res} = make_nullifier_call([0 | Noun.Nounable.to_noun(resource)])
@@ -2492,8 +2492,8 @@ defmodule Examples.ENock do
     assert unnouned == resource
   end
 
-  @spec is_nullifier_arm() :: Noun.t()
-  def is_nullifier_arm() do
+  @spec nullifier_check_arm() :: Noun.t()
+  def nullifier_check_arm() do
     arm_info = Mugs.index_map().is_nullifier
     layer_depth = example_layer_depth(arm_info.layer)
     arm_index = arm_info.index
@@ -2505,11 +2505,11 @@ defmodule Examples.ENock do
   @spec make_is_nullifier_call(Noun.t()) :: Noun.t()
   def make_is_nullifier_call(atom) do
     sample = atom
-    [is_nullifier_arm(), sample | Nock.Lib.rm_core()]
+    [nullifier_check_arm(), sample | Nock.Lib.rm_core()]
   end
 
-  @spec is_nullifier_test() :: true
-  def is_nullifier_test() do
+  @spec nullifier_check_test() :: true
+  def nullifier_check_test() do
     atom_true = "NF_whatever"
     atom_false = "CM_whatever"
     atom_weird_still_false = "a"
@@ -2612,6 +2612,7 @@ defmodule Examples.ENock do
     assert ETransaction.swap_from_actions() == tx
   end
 
+  @spec secp_sign_arm() :: Noun.t()
   def secp_sign_arm() do
     arm_info = Mugs.index_map().secp256k1_sign
     layer_depth = example_layer_depth(arm_info.layer)
@@ -2621,6 +2622,8 @@ defmodule Examples.ENock do
     |> Noun.Format.parse_always()
   end
 
+  @spec secp_sign_call(binary(), binary()) ::
+          {:ok, Noun.t()} | {:error, Nock.error()}
   def secp_sign_call(msg, key) do
     sample = [msg | key]
 
@@ -2628,6 +2631,7 @@ defmodule Examples.ENock do
     |> Nock.nock([9, 2, 0 | 1])
   end
 
+  @spec secp_sign_test(binary(), binary()) :: true
   def secp_sign_test(
         msg \\ :crypto.strong_rand_bytes(32),
         key \\ :crypto.strong_rand_bytes(32)
@@ -2638,6 +2642,7 @@ defmodule Examples.ENock do
     assert Noun.equal?(Noun.Nounable.to_noun(res2), res)
   end
 
+  @spec secp_public_key_arm() :: Noun.t()
   def secp_public_key_arm() do
     arm_info = Mugs.index_map().secp256k1_pub_key
     layer_depth = example_layer_depth(arm_info.layer)
@@ -2647,6 +2652,8 @@ defmodule Examples.ENock do
     |> Noun.Format.parse_always()
   end
 
+  @spec secp_public_key_call(binary()) ::
+          {:ok, Noun.t()} | {:error, Nock.error()}
   def secp_public_key_call(priv_key) do
     sample = priv_key
 
@@ -2654,6 +2661,7 @@ defmodule Examples.ENock do
     |> Nock.nock([9, 2, 0 | 1])
   end
 
+  @spec secp_public_key_test(binary()) :: true
   def secp_public_key_test(key \\ :crypto.strong_rand_bytes(32)) do
     {:ok, res} = secp_public_key_call(key)
     {:ok, res2} = ExSecp256k1.create_public_key(key)
@@ -2661,6 +2669,7 @@ defmodule Examples.ENock do
     assert res2 == res
   end
 
+  @spec secp_verify_arm() :: Noun.t()
   def secp_verify_arm() do
     arm_info = Mugs.index_map().secp256k1_verify
     layer_depth = example_layer_depth(arm_info.layer)
@@ -2670,6 +2679,8 @@ defmodule Examples.ENock do
     |> Noun.Format.parse_always()
   end
 
+  @spec secp_verify_call(binary(), binary(), binary()) ::
+          {:ok, Noun.t()} | {:error, Nock.error()}
   def secp_verify_call(msg, sig, key) do
     sample = [msg, sig | key]
 
@@ -2677,6 +2688,7 @@ defmodule Examples.ENock do
     |> Nock.nock([9, 2, 0 | 1])
   end
 
+  @spec secp_verify_test(binary(), binary()) :: true
   def secp_verify_test(
         msg \\ :crypto.strong_rand_bytes(32),
         key \\ :crypto.strong_rand_bytes(32)
@@ -2688,6 +2700,7 @@ defmodule Examples.ENock do
     assert Noun.equal?(bool, 0)
   end
 
+  @spec keccak_arm() :: Noun.t()
   def keccak_arm() do
     arm_info = Mugs.index_map().keccak256
     layer_depth = example_layer_depth(arm_info.layer)
@@ -2697,11 +2710,14 @@ defmodule Examples.ENock do
     |> Noun.Format.parse_always()
   end
 
+  @spec keccak_call(binary()) ::
+          {:ok, Noun.t()} | {:error, Nock.error()}
   def keccak_call(msg) do
     [keccak_arm(), msg | Nock.Lib.rm_core()]
     |> Nock.nock([9, 2, 0 | 1])
   end
 
+  @spec keccak_test(binary()) :: true
   def keccak_test(msg \\ :crypto.strong_rand_bytes(32)) do
     {:ok, res} = keccak_call(msg)
 
@@ -3362,6 +3378,7 @@ defmodule Examples.ENock do
   ####################################################################
 
   # Write Program Generator (writes a constant value to a key)
+  @spec write_code_gen(Noun.t(), Noun.t()) :: Noun.t()
   def write_code_gen(key_int, value) do
     reservations = [[1 | key_int] | 0]
     writes_logic = [1 | [[key_int | value] | 0]]
@@ -3379,11 +3396,11 @@ defmodule Examples.ENock do
 
     reservations = abc_list()
 
-    scryA = [12 | [[1 | 0] | [1 | key_a]]]
-    scryB = [12 | [[1 | 0] | [1 | key_b]]]
-    addFormula = [4 | [4 | [4 | [4 | [0 | 2]]]]]
-    sumFormula = [7 | [[scryA | scryB] | addFormula]]
-    writes_logic = [[[1 | key_c] | sumFormula] | [1 | 0]]
+    scry_a = [12 | [[1 | 0] | [1 | key_a]]]
+    scry_b = [12 | [[1 | 0] | [1 | key_b]]]
+    add_formula = [4 | [4 | [4 | [4 | [0 | 2]]]]]
+    sum_formula = [7 | [[scry_a | scry_b] | add_formula]]
+    writes_logic = [[[1 | key_c] | sum_formula] | [1 | 0]]
 
     [[0 | 3] | [reservations | [writes_logic | [0 | 0]]]]
   end
@@ -3397,8 +3414,8 @@ defmodule Examples.ENock do
     key_b = b_int()
 
     reservations = [[0 | key_a], [1 | key_b] | 0]
-    scryA = [12 | [[1 | 0] | [1 | key_a]]]
-    writes_logic = [[[1 | key_b] | scryA] | [1 | 0]]
+    scry_a = [12 | [[1 | 0] | [1 | key_a]]]
+    writes_logic = [[[1 | key_b] | scry_a] | [1 | 0]]
 
     [[0 | 3] | [reservations | [writes_logic | [0 | 0]]]]
   end

--- a/apps/anoma_lib/lib/nock.ex
+++ b/apps/anoma_lib/lib/nock.ex
@@ -238,6 +238,8 @@ defmodule Nock do
     end
   end
 
+  @spec gas_limit(non_neg_integer(), pid(), non_neg_integer()) ::
+          non_neg_integer()
   def gas_limit(limit, pid, gas) do
     receive do
       {:gas, n} ->

--- a/apps/anoma_lib/lib/nock/jets/mugs.ex
+++ b/apps/anoma_lib/lib/nock/jets/mugs.ex
@@ -72,11 +72,11 @@ defmodule Nock.Jets.Mugs do
     :keccak256 => %{:index => 22, :layer => 12},
     :kind => %{:index => 5972, :layer => Nock.Lib.stdlib_layers()},
     :delta_add => %{:index => 372, :layer => Nock.Lib.stdlib_layers()},
-    :delta_sub => %{:index => 12013, :layer => Nock.Lib.stdlib_layers()},
+    :delta_sub => %{:index => 12_013, :layer => Nock.Lib.stdlib_layers()},
     :zero_delta => %{:index => 174, :layer => Nock.Lib.stdlib_layers()},
     :resource_delta => %{:index => 701, :layer => Nock.Lib.stdlib_layers()},
     :commitment => %{:index => 3002, :layer => Nock.Lib.stdlib_layers()},
-    :is_commitment => %{:index => 12012, :layer => Nock.Lib.stdlib_layers()},
+    :is_commitment => %{:index => 12_012, :layer => Nock.Lib.stdlib_layers()},
     :nullifier => %{:index => 2815, :layer => Nock.Lib.stdlib_layers()},
     :is_nullifier => %{:index => 5974, :layer => Nock.Lib.stdlib_layers()},
     :compliance_unit_delta => %{
@@ -84,7 +84,7 @@ defmodule Nock.Jets.Mugs do
       :layer => Nock.Lib.stdlib_layers()
     },
     :action_delta => %{:index => 4, :layer => Nock.Lib.stdlib_layers()},
-    :make_delta => %{:index => 11951, :layer => Nock.Lib.stdlib_layers()},
+    :make_delta => %{:index => 11_951, :layer => Nock.Lib.stdlib_layers()},
     :action_create => %{:index => 382, :layer => Nock.Lib.stdlib_layers()},
     :trm_compliance_key => %{
       :index => 1502,

--- a/apps/anoma_lib/lib/noun.ex
+++ b/apps/anoma_lib/lib/noun.ex
@@ -129,6 +129,7 @@ defmodule Noun do
     [normalize_noun(h) | normalize_noun(t)]
   end
 
+  @spec abnormalize_noun(t()) :: t()
   def abnormalize_noun(atom) when is_noun_atom(atom) do
     cond do
       atom == [] -> 0
@@ -172,12 +173,21 @@ defmodule Noun do
     mum(0xDEADBEEF, 0xFFFE, key)
   end
 
+  @spec mum(noun_atom(), non_neg_integer(), noun_atom()) ::
+          non_neg_integer() | nil
   def mum(seed, fal, key) do
     key = Noun.atom_integer_to_binary(key)
     seed = Noun.atom_binary_to_integer(seed)
     mum_rec(0, seed, fal, key)
   end
 
+  @spec mum_rec(
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          binary()
+        ) ::
+          non_neg_integer() | nil
   def mum_rec(i, seed, fal, key) do
     if i == 8 do
       fal

--- a/apps/anoma_lib/lib/noun/nounable.ex
+++ b/apps/anoma_lib/lib/noun/nounable.ex
@@ -56,6 +56,7 @@ defimpl Nounable, for: Bool do
     Nounable.to_noun(bool)
   end
 
+  @spec to_noun() :: :error
   def to_noun(), do: :error
 
   @doc """
@@ -139,6 +140,7 @@ defimpl Nounable, for: MapSet do
     end
   end
 
+  @spec noun_set_put(Noun.t(), Noun.t()) :: Noun.t()
   def noun_set_put(zero, elem) when is_noun_zero(zero) do
     [elem, 0 | 0]
   end

--- a/apps/anoma_node/lib/examples/e_event.ex
+++ b/apps/anoma_node/lib/examples/e_event.ex
@@ -24,6 +24,7 @@ defmodule Anoma.Node.Examples.EEvent do
   # @doc """
   # I create a transaction event
   # """
+  @spec transaction_event(ENode.t()) :: EventBroker.Event.t()
   @spec transaction_event(ENode.t(), ETransaction.t()) ::
           EventBroker.Event.t()
   def transaction_event(enode \\ ENode.start_node()) do

--- a/apps/anoma_node/lib/examples/e_mempool.ex
+++ b/apps/anoma_node/lib/examples/e_mempool.ex
@@ -113,6 +113,7 @@ defmodule Anoma.Node.Examples.Mempool do
   I add a transaction to the mempool that executes properly.
   I execute this transaction.
   """
+  @spec execute_transaction(ENode.t()) :: {ENode.t(), ETransaction.t()}
   @spec execute_transaction(ENode.t(), ETransaction.t()) ::
           {ENode.t(), ETransaction.t()}
 
@@ -144,6 +145,8 @@ defmodule Anoma.Node.Examples.Mempool do
   I execute this transaction.
   """
   @spec execute_multiple_transactions(ENode.t()) ::
+          {ENode.t(), [ETransaction.t()]}
+  @spec execute_multiple_transactions(ENode.t(), [ETransaction.t()]) ::
           {ENode.t(), [ETransaction.t()]}
 
   def execute_multiple_transactions(enode \\ ENode.start_node()) do
@@ -181,6 +184,7 @@ defmodule Anoma.Node.Examples.Mempool do
 
   I do not wait for the events of the block creation.
   """
+  @spec make_block(ENode.t()) :: {ENode.t(), ETransaction.t()}
   @spec make_block(
           ENode.t(),
           ETransaction.t()
@@ -227,6 +231,8 @@ defmodule Anoma.Node.Examples.Mempool do
      E.g., {:ok, {:read_value, [["key" | 0] | 0]}}
    - The id of the transaction
   """
+  @spec complete_transaction(ENode.t(), non_neg_integer()) ::
+          {ENode.t(), ETransaction.t()}
   @spec complete_transaction(
           ENode.t(),
           ETransaction.t(),

--- a/apps/anoma_node/lib/examples/e_shard.ex
+++ b/apps/anoma_node/lib/examples/e_shard.ex
@@ -131,7 +131,7 @@ defmodule Anoma.Node.Examples.EShard do
     node_id
   end
 
-  @spec abc_val_a_write_to_5_shard_a() :: map()
+  @spec abc_val_a_waiting_7_11_shard_a() :: map()
   def abc_val_a_waiting_7_11_shard_a() do
     %{
       ["a"] => %Cell{
@@ -227,6 +227,7 @@ defmodule Anoma.Node.Examples.EShard do
     node_id
   end
 
+  @spec backup_convinece_stores_a(String.t()) :: String.t()
   def backup_convinece_stores_a(node_id \\ Node.example_random_id()) do
     abc_val_a_double_waiting_write_7_11(node_id)
 

--- a/apps/anoma_node/lib/examples/e_shard_supervisor.ex
+++ b/apps/anoma_node/lib/examples/e_shard_supervisor.ex
@@ -85,6 +85,7 @@ defmodule Anoma.Node.Examples.EShardSupervisor do
     node_id
   end
 
+  @spec read_table(atom(), term()) :: {:atomic, list()} | {:aborted, term()}
   def read_table(table, key) do
     :mnesia.transaction(fn -> :mnesia.read({table, key}) end)
   end

--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -261,12 +261,12 @@ defmodule Anoma.Node.Examples.ETransaction do
     ENode.start_node(node_id: node_id)
   end
 
-  @spec zero(String.t()) :: Noun.t()
+  @spec zero(String.t(), Noun.t()) :: Noun.t()
   def zero(key \\ "key", writes \\ [["key"]]) do
     Examples.ENock.zero(key, writes)
   end
 
-  @spec inc(String.t()) :: Noun.t()
+  @spec inc(String.t(), Noun.t()) :: Noun.t()
   def inc(key \\ "key", writes \\ [["key"]]) do
     Examples.ENock.inc(key, writes)
   end
@@ -783,6 +783,8 @@ defmodule Anoma.Node.Examples.ETransaction do
     end
   end
 
+  @spec reserve_and_do(:read | :write, String.t(), binary(), keyword()) ::
+          any()
   def reserve_and_do(:read, node_id, tx_id, opts) do
     Ordering.reserve(node_id, tx_id, %{
       read: MapSet.new([opts[:key]]),

--- a/apps/anoma_node/lib/examples/e_transport/e_advertise.ex
+++ b/apps/anoma_node/lib/examples/e_transport/e_advertise.ex
@@ -172,7 +172,7 @@ defmodule Anoma.Node.Examples.EAdvertise do
   restarting mnesia.
   """
   @spec stop_slave(Peer.t()) :: :ok
-  def stop_slave(%Peer{} = peer) do
+  def stop_slave(peer = %Peer{}) do
     # delete the slave from the system
     {:ok, ipv4} = :inet.parse_ipv4_address(to_charlist("127.0.0.1"))
     :erl_boot_server.delete_slave(ipv4)
@@ -259,7 +259,7 @@ defmodule Anoma.Node.Examples.EAdvertise do
       [
         anoma_node: [grpc_port: my_grpc_port + 1500],
         anoma_client: [
-          {:grpc_port, 40052},
+          {:grpc_port, 40_052},
           {Anoma.Client.Web.Endpoint, [http: [port: 4001]]},
           {Anoma.Client.Web.SocketHandler, [port: 3001]}
         ]

--- a/apps/anoma_node/lib/examples/e_transport/e_grpc.ex
+++ b/apps/anoma_node/lib/examples/e_transport/e_grpc.ex
@@ -172,6 +172,7 @@ defmodule Anoma.Node.Examples.EGRPC do
 
   I expect an error to occur.
   """
+  @spec add_intent_fail_no_intent(EGRPC.t()) :: boolean()
   def add_intent_fail_no_intent(%EGRPC{} = client \\ connect_to_node()) do
     node = %Node{id: client.node.node_id}
     request = %Add.Request{node: node}

--- a/apps/anoma_node/lib/examples/eintent_pool.ex
+++ b/apps/anoma_node/lib/examples/eintent_pool.ex
@@ -142,6 +142,7 @@ defmodule Anoma.Node.Examples.EIntentPool do
     enode
   end
 
+  @spec intents_are_written(ENode.t()) :: {:atomic, list()}
   def intents_are_written(enode \\ ENode.start_node()) do
     add_intent_transaction_nullifier(enode)
 

--- a/apps/anoma_node/lib/examples/helpers.ex
+++ b/apps/anoma_node/lib/examples/helpers.ex
@@ -62,6 +62,7 @@ defmodule Anoma.Node.Examples.Helpers do
   Given the pid of a logger process, I check return whether the given event was
   emitted by mnesia or not.
   """
+  @spec seen_event?(pid(), term()) :: boolean()
   def seen_event?(logger_pid, event) do
     send(logger_pid, {:seen, event, self()})
 

--- a/apps/anoma_node/lib/examples/replay/e_start_state.ex
+++ b/apps/anoma_node/lib/examples/replay/e_start_state.ex
@@ -258,6 +258,7 @@ defmodule Anoma.Node.Examples.EReplay.StartState do
   If a block event is fired, the Logging engine will remove these values from the database.
   We make sure that this not happen by mocking this behaviour.
   """
+  @spec mempool_obsolete_consensus(ENode.t()) :: ENode.t()
   def mempool_obsolete_consensus(enode \\ ENode.start_node()) do
     with_subscription [[]] do
       # create ten blocks
@@ -296,6 +297,7 @@ defmodule Anoma.Node.Examples.EReplay.StartState do
     end
   end
 
+  @spec mempool_obsolete_consensi(ENode.t()) :: ENode.t()
   def mempool_obsolete_consensi(enode \\ ENode.start_node()) do
     with_subscription [[]] do
       # create ten blocks

--- a/apps/anoma_node/lib/node/intents/intentpool/intent_pool.ex
+++ b/apps/anoma_node/lib/node/intents/intentpool/intent_pool.ex
@@ -305,6 +305,7 @@ defmodule Anoma.Node.Intents.IntentPool do
     {:ok, reason, state}
   end
 
+  @spec reject_intents(MapSet.t(), MapSet.t()) :: MapSet.t()
   def reject_intents(intents, set) do
     intents
     |> Enum.filter(

--- a/apps/anoma_node/lib/node/intents/solver.ex
+++ b/apps/anoma_node/lib/node/intents/solver.ex
@@ -73,6 +73,7 @@ defmodule Anoma.Node.Intents.Solver do
     GenServer.call(name, :get_unsolved)
   end
 
+  @spec disable(String.t()) :: boolean()
   def disable(node_id) do
     name = Registry.via(node_id, __MODULE__)
     GenServer.call(name, :disable)

--- a/apps/anoma_node/lib/node/registry.ex
+++ b/apps/anoma_node/lib/node/registry.ex
@@ -105,6 +105,7 @@ defmodule Anoma.Node.Registry do
     |> Enum.sort()
   end
 
+  @spec match(String.t(), atom()) :: [Address.t()]
   def match(node_id, engine) do
     pattern = {%{node_id: :"$1", engine: :"$2"}, :"$3", :"$4"}
 

--- a/apps/anoma_node/lib/node/replay/replay.ex
+++ b/apps/anoma_node/lib/node/replay/replay.ex
@@ -46,6 +46,8 @@ defmodule Anoma.Node.Replay do
   #                       Public                             #
   ############################################################
 
+  @spec wait_for_confirm(String.t(), any()) ::
+          {:ok, :confirmed} | {:error, :confirm_failed}
   def wait_for_confirm(_temp_node_id, nil) do
     {:ok, :confirmed}
   end
@@ -59,7 +61,7 @@ defmodule Anoma.Node.Replay do
         %{body: %{node_id: ^temp_node_id, body: %{task: _}}} ->
           {:error, :confirm_failed}
       after
-        10000 ->
+        10_000 ->
           {:error, :confirm_failed}
       end
 
@@ -114,14 +116,14 @@ defmodule Anoma.Node.Replay do
     end
   end
 
-  @spec init_tables_node(any(), binary()) ::
-          {:error, :failed_to_create_replay_node | :target_node_existed}
-          | {:ok, :data_initialized}
   @doc """
   Given a node id, I will create the tables for the node and initialize them with
   the data used to replay.
   I do not start a node, I only set up its tables.
   """
+  @spec init_tables_node(String.t(), String.t()) ::
+          {:ok, :data_initialized}
+          | {:error, :target_node_existed | :failed_to_create_replay_node}
   def init_tables_node(from_node_id, to_node_id) do
     with {:ok, :created} <- Tables.initialize_tables_for_node(to_node_id),
          {:ok, :copied} <- duplicate_tables(from_node_id, to_node_id) do

--- a/apps/anoma_node/lib/node/transaction/backends/backends.ex
+++ b/apps/anoma_node/lib/node/transaction/backends/backends.ex
@@ -297,6 +297,7 @@ defmodule Anoma.Node.Transaction.Backends do
     end)
   end
 
+  @spec emit_value(String.t(), binary(), Noun.t()) :: :ok
   def emit_value(node_id, id, result) do
     wrapped_result =
       case result do

--- a/apps/anoma_node/lib/node/transaction/backends/events.ex
+++ b/apps/anoma_node/lib/node/transaction/backends/events.ex
@@ -62,6 +62,7 @@ defmodule Anoma.Node.Transaction.Backends.Events do
 
   # todo: where to put this?
   defimpl Jason.Encoder, for: MapSet do
+    @spec encode(MapSet.t(), Jason.Encode.opts()) :: iodata()
     def encode(mapset, opts) do
       Jason.Encode.list(Enum.into(mapset, []), opts)
     end
@@ -110,22 +111,21 @@ defmodule Anoma.Node.Transaction.Backends.Events do
     end
 
     defp encode_maybe_noun(noun) do
-      with jammed <- Noun.Jam.jam(noun),
-           encoded <- Base.encode64(jammed) do
-        encoded
-      end
+      jammed = Noun.Jam.jam(noun)
+      Base.encode64(jammed)
     end
 
-    def encode(%ROEvent{} = event, opts) do
-      with vm_result <- encode_maybe_noun(event.read_result) do
-        Jason.Encode.map(
-          %{
-            tx_id: event.tx_id,
-            read_result: vm_result
-          },
-          opts
-        )
-      end
+    @spec encode(ROEvent.t(), Jason.Encode.opts()) :: iodata()
+    def encode(event = %ROEvent{}, opts) do
+      vm_result = encode_maybe_noun(event.read_result)
+
+      Jason.Encode.map(
+        %{
+          tx_id: event.tx_id,
+          read_result: vm_result
+        },
+        opts
+      )
     end
   end
 
@@ -162,7 +162,8 @@ defmodule Anoma.Node.Transaction.Backends.Events do
   ############################################################
 
   defimpl Jason.Encoder, for: CompleteEvent do
-    def encode(%CompleteEvent{} = event, opts) do
+    @spec encode(CompleteEvent.t(), Jason.Encode.opts()) :: iodata()
+    def encode(event = %CompleteEvent{}, opts) do
       event
       |> Map.update!(:tx_result, fn
         :error ->
@@ -182,7 +183,8 @@ defmodule Anoma.Node.Transaction.Backends.Events do
   end
 
   defimpl Jason.Encoder, for: ResultEvent do
-    def encode(%ResultEvent{} = event, opts) do
+    @spec encode(ResultEvent.t(), Jason.Encode.opts()) :: iodata()
+    def encode(event = %ResultEvent{}, opts) do
       event
       |> Map.update!(:vm_result, fn
         :error ->

--- a/apps/anoma_node/lib/node/transaction/executor/events.ex
+++ b/apps/anoma_node/lib/node/transaction/executor/events.ex
@@ -41,7 +41,8 @@ defmodule Anoma.Node.Transaction.Executor.Events do
   ############################################################
 
   defimpl Jason.Encoder, for: ExecutionEvent do
-    def encode(%ExecutionEvent{} = event, opts) do
+    @spec encode(ExecutionEvent.t(), Jason.Encode.opts()) :: iodata()
+    def encode(event = %ExecutionEvent{}, opts) do
       event
       |> Map.update!(
         :result,

--- a/apps/anoma_node/lib/node/transaction/mempool/mempool.ex
+++ b/apps/anoma_node/lib/node/transaction/mempool/mempool.ex
@@ -114,26 +114,25 @@ defmodule Anoma.Node.Transaction.Mempool do
     end
 
     defp encode_maybe_noun(noun) do
-      with jammed <- Noun.Jam.jam(noun),
-           encoded <- Base.encode64(jammed) do
-        encoded
-      end
+      jammed = Noun.Jam.jam(noun)
+      Base.encode64(jammed)
     end
 
-    def encode(%Tx{} = tx, opts) do
-      with vm_result <- encode_maybe_noun(tx.vm_result),
-           tx_result <- encode_maybe_noun(tx.tx_result),
-           code <- encode_maybe_noun(tx.code) do
-        Jason.Encode.map(
-          %{
-            code: code,
-            tx_result: tx_result,
-            backend: nil,
-            vm_result: vm_result
-          },
-          opts
-        )
-      end
+    @spec encode(Tx.t(), Jason.Encode.opts()) :: iodata()
+    def encode(tx = %Tx{}, opts) do
+      vm_result = encode_maybe_noun(tx.vm_result)
+      tx_result = encode_maybe_noun(tx.tx_result)
+      code = encode_maybe_noun(tx.code)
+
+      Jason.Encode.map(
+        %{
+          code: code,
+          tx_result: tx_result,
+          backend: nil,
+          vm_result: vm_result
+        },
+        opts
+      )
     end
   end
 
@@ -364,6 +363,8 @@ defmodule Anoma.Node.Transaction.Mempool do
     %Backends.Events.ForMempoolFilter{}
   end
 
+  @spec filter_for_mempool_execution_events() ::
+          Backends.Events.ForMempoolExecutionFilter.t()
   def filter_for_mempool_execution_events() do
     %Backends.Events.ForMempoolExecutionFilter{}
   end
@@ -382,6 +383,7 @@ defmodule Anoma.Node.Transaction.Mempool do
     {:reply, tx_id, handle_tx(tx, tx_id, state)}
   end
 
+  @spec handle_call(term(), GenServer.from(), t()) :: {:reply, :ok, t()}
   def handle_call(_, _, state) do
     {:reply, :ok, state}
   end

--- a/apps/anoma_node/lib/node/transaction/storage/events.ex
+++ b/apps/anoma_node/lib/node/transaction/storage/events.ex
@@ -76,7 +76,8 @@ defmodule Anoma.Node.Transaction.Storage.Events do
       end
     end
 
-    def encode(%WriteEvent{} = event, opts) do
+    @spec encode(WriteEvent.t(), Jason.Encode.opts()) :: iodata()
+    def encode(event = %WriteEvent{}, opts) do
       writes =
         event.writes
         |> Enum.map(fn {key, term} ->

--- a/apps/anoma_node/lib/node/transport/grpc/endpoint/pubsub.ex
+++ b/apps/anoma_node/lib/node/transport/grpc/endpoint/pubsub.ex
@@ -37,6 +37,8 @@ defmodule Anoma.Node.Transport.GRPC.Servers.PubSub do
     %Unsubscribe.Response{}
   end
 
+  @spec publish(Anoma.Proto.PubSub.Event.Request.t(), Stream.t()) ::
+          Event.Response.t()
   def publish(request, _stream) do
     Logger.debug("GRPC #{inspect(__ENV__.function)}: #{inspect(request)}")
     # reconstruct the event and fire it on the eventbroker

--- a/apps/anoma_node/lib/node/transport/network_register/network_register.ex
+++ b/apps/anoma_node/lib/node/transport/network_register/network_register.ex
@@ -81,6 +81,7 @@ defmodule Anoma.Node.Transport.NetworkRegister do
   I advertise to the given remote node, using the information I have about that
   node in my register.
   """
+  @spec advertise_to(String.t(), String.t()) :: :ok
   def advertise_to(node_id, remote_node_id) do
     GenServer.cast(
       Registry.via(node_id, __MODULE__),
@@ -88,6 +89,7 @@ defmodule Anoma.Node.Transport.NetworkRegister do
     )
   end
 
+  @spec susbcribe_to(String.t(), String.t(), String.t()) :: :ok
   def susbcribe_to(node_id, remote_node_id, topic) do
     GenServer.cast(
       Registry.via(node_id, __MODULE__),

--- a/apps/anoma_node/lib/node/transport/network_register/proxy/transport_protocol.ex
+++ b/apps/anoma_node/lib/node/transport/network_register/proxy/transport_protocol.ex
@@ -76,14 +76,17 @@ defmodule Anoma.Node.Transport.Proxy.TransportProtocol do
   #                      Public RPC API                      #
   ############################################################
 
+  @spec call(GenServer.server(), term()) :: term()
   def call(transport_protocol, message) do
     GenServer.call(transport_protocol, {:call, message})
   end
 
+  @spec cast(GenServer.server(), term()) :: :ok
   def cast(transport_protocol, message) do
     GenServer.cast(transport_protocol, {:cast, message})
   end
 
+  @spec event(GenServer.server(), term()) :: :ok
   def event(transport_protocol, event) do
     GenServer.cast(transport_protocol, {:event, event})
   end

--- a/apps/event_broker/lib/examples/e_subscribe.ex
+++ b/apps/event_broker/lib/examples/e_subscribe.ex
@@ -90,6 +90,7 @@ defmodule Examples.EEventBroker.Subscribe do
   I subscribe a process to events, and check whether the registry cleans up its
   subscriptions when it goes offline.
   """
+  @spec unsubscribe_on_down() :: any()
   def unsubscribe_on_down() do
     # any filter will do
     filter = %EFilter.AcceptAll{}


### PR DESCRIPTION
Resolve 160 credo warnings across the codebase:
- Add missing @spec annotations to all public functions
- Fix number formatting (underscores in large numbers)
- Rename snake_case violations (scryA -> scry_a, etc.)
- Rename is_ predicates to ? suffix (list_unique?, etc.)
- Fix with clause structure (move plain assignments out)
- Fix pattern match consistency (variable = %Struct{} order)
- Fix incorrect @spec on Registry.match and ENock.zero