### PR TITLE
Handle TaskCrash events in executor to prevent receive block

### DIFF
--- a/lib/node/transaction/executor/events.ex
+++ b/lib/node/transaction/executor/events.ex
@@ -4,6 +4,7 @@ defmodule Anoma.Node.Transaction.Executor.Events do
 
   I also define the filters that can be used to subscribe to these events.
   """
+  alias Anoma.Node.Event
   alias Anoma.Node.Transaction.Mempool
 
   use EventBroker.DefFilter
@@ -32,8 +33,23 @@ defmodule Anoma.Node.Transaction.Executor.Events do
     @derive Jason.Encoder
     @typedoc """
     I am a crash event for a task that failed.
+
+    ### Fields
+    - `:task` - The transaction id of the crashed task.
     """
-    field(:task, pid())
+    field(:task, binary())
+  end
+
+  ############################################################
+  #                           Filters                        #
+  ############################################################
+
+  deffilter TaskCrashFilter do
+    %EventBroker.Event{body: %Event{body: %TaskCrash{}}} ->
+      true
+
+    _ ->
+      false
   end
 
   ############################################################

--- a/lib/node/transaction/executor/executor.ex
+++ b/lib/node/transaction/executor/executor.ex
@@ -88,6 +88,11 @@ defmodule Anoma.Node.Transaction.Executor do
     ])
 
     EventBroker.subscribe_me([
+      Node.Event.node_filter(args[:node_id]),
+      %Events.TaskCrashFilter{}
+    ])
+
+    EventBroker.subscribe_me([
       %Mempool.Events.BlockFilter{}
     ])
 
@@ -210,6 +215,15 @@ defmodule Anoma.Node.Transaction.Executor do
         }
       } ->
         {res, id}
+
+      %EventBroker.Event{
+        body: %Node.Event{
+          body: %Events.TaskCrash{
+            task: ^id
+          }
+        }
+      } ->
+        {:error, id}
     end
   end
 


### PR DESCRIPTION
## Summary

- `listen_for_worker_finish!/1` only matched `CompleteEvent`, so a worker crash (which emits `TaskCrash`) left the `receive` blocking forever, stalling block finalization
- Subscribe executor to `TaskCrashFilter` events and match them in the receive, returning `{:error, id}`
- Fix `TaskCrash.task` typespec from `pid()` to `binary()` to match actual usage (it receives the tx id, not a pid)

## Test plan

- [x] All 134 existing tests pass
- [ ] Verify crash recovery by killing a worker process mid-execution and confirming the executor unblocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)